### PR TITLE
fix: execute commands using correct stack path

### DIFF
--- a/cmd/terrastack/main.go
+++ b/cmd/terrastack/main.go
@@ -157,10 +157,9 @@ func run(basedir string) {
 	basedir = basedir + string(os.PathSeparator)
 
 	for _, stack := range stacks {
-		stackdir := strings.TrimPrefix(stack.Dir, basedir)
 
 		cmd := exec.Command(cmdName, args...)
-		cmd.Dir = stackdir
+		cmd.Dir = stack.Dir
 
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
@@ -168,7 +167,7 @@ func run(basedir string) {
 
 		cmd.Env = os.Environ()
 
-		printf("[%s] running %s\n", stackdir, cmd)
+		printf("[%s] running %s\n", stack.Dir, cmd)
 
 		err = cmd.Run()
 		if err != nil {


### PR DESCRIPTION
Fixes: https://github.com/mineiros-io/terrastack/issues/14

Usually I like to add automated tests, but there isn't anything for the run function, and since we want to already refactor the design, it seems desireable to move **run** to be part of the core logic, not on cmd/main (like it was done with list/list changed).

Usually I would also refactor first + fix the bug on the new improved design, but since there is no tests the refactoring itself may break some features and we want a stable initial v0.0.1 ASAP.

So I did the unusual surgery mode fix. But refactoring around "run" should come ASAP.