### PR TITLE
fix: ineffectual assigment on basedir variable

### DIFF
--- a/cmd/terrastack/main.go
+++ b/cmd/terrastack/main.go
@@ -154,8 +154,6 @@ func run(basedir string) {
 	cmdName := cliSpec.Run.Command[0]
 	args := cliSpec.Run.Command[1:]
 
-	basedir = basedir + string(os.PathSeparator)
-
 	for _, stack := range stacks {
 
 		cmd := exec.Command(cmdName, args...)


### PR DESCRIPTION
The previous linter being used on the CI was not catching this innefective assigment ([PR's were green](https://github.com/mineiros-io/terrastack/pulls?q=is%3Apr+is%3Aclosed)), but now that we merged a change using golang-ci-lint it caught that as an [linting error](https://github.com/mineiros-io/terrastack/runs/4157085790?check_suite_focus=true).

The error is also captured by staticcheck (but not by previous CI linting automation).

This would have been caught on the PR that changed the linting to be more strict if we forced the branch to be updated with main before merging, since a previous merge on main (which was OK) introduced the issue, and then it only failed when we merged the linting changes on main.