### PR TITLE
refactor: initial extract of logic from main

### DIFF
--- a/cmd/terrastack/cli/cli.go
+++ b/cmd/terrastack/cli/cli.go
@@ -35,7 +35,9 @@ type cliSpec struct {
 	} `cmd:"" help:"Run command in the stacks."`
 }
 
-// Run will run the command + flags defined on args.
+// Run will run terrastack with the provided flags defined on args.
+// Only flags should be on the args slice.
+
 // Results will be written on stdout, according to the
 // command flags. Any partial/non-critical errors will be
 // written on stderr.
@@ -78,7 +80,7 @@ func newCLI(args []string, workingdir string, stdin io.Reader, stdout io.Writer,
 		return nil, fmt.Errorf("failed to create cli parser: %v", err)
 	}
 
-	ctx, err := parser.Parse(args[1:])
+	ctx, err := parser.Parse(args)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse cli args %v: %v", args, err)
 	}

--- a/cmd/terrastack/main.go
+++ b/cmd/terrastack/main.go
@@ -12,7 +12,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("error: failed to get current directory: %v", err)
 	}
-	if err := cli.Run(os.Args, basedir, os.Stdin, os.Stdout, os.Stderr); err != nil {
+	if err := cli.Run(os.Args[1:], basedir, os.Stdin, os.Stdout, os.Stderr); err != nil {
 		log.Fatal(err)
 	}
 }


### PR DESCRIPTION
I tried to do the minimum amount of work necessary to ensure isolation on each cli.Run call, so the design is not final/awesome or anything, just bare minimum for a extract so we can start testing.

Tested manually using this script:

```sh
#!/bin/bash

set -o errexit
set -o nounset

stack_absolute_path=$(mktemp -d)

cd "${stack_absolute_path}"

mkdir stack1
touch stack1/terrastack

mkdir stack2
touch stack2/terrastack

echo "=== inside base dir ==="
echo "=== terrastack run ==="
echo
terrastack run -b "${stack_absolute_path}" ls

echo
echo "=== terrastack list ==="
echo
terrastack list "${stack_absolute_path}"

echo
echo "=== outside base dir ==="
cd ..

echo "=== terrastack run ==="
echo
terrastack run -b "${stack_absolute_path}" ls

echo
echo "=== terrastack list ==="
echo
terrastack list "${stack_absolute_path}"
```

It is not automated or comprehensive, but at least it doesn't seem like I broke the cli completely =P.

Closes #21