### PR TITLE
fix: Isolate git global config

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -463,6 +463,8 @@ func (git *Git) exec(command string, args ...string) (string, error) {
 	if git.config.Isolated {
 		cmd.Env = append(cmd.Env, "GIT_CONFIG_SYSTEM=/dev/null")
 		cmd.Env = append(cmd.Env, "GIT_CONFIG_GLOBAL=/dev/null")
+		cmd.Env = append(cmd.Env, "GIT_CONFIG_NOGLOBAL=1") // back-compat
+		cmd.Env = append(cmd.Env, "GIT_CONFIG_NOSYSTEM=1") // back-compat
 		cmd.Env = append(cmd.Env, "GIT_ATTR_NOSYSTEM=1")
 	}
 


### PR DESCRIPTION
The PR #18 exposed an issue that git wasn't properly isolated in tests from global/system configurations when the wrapper was instantiated with the `Isolated` configuration.