### PR TITLE
feat: add matrix build for multiple OS's

### DIFF
--- a/.github/workflows/terrastack.yml
+++ b/.github/workflows/terrastack.yml
@@ -30,7 +30,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-10.15, ubuntu-20.04, windows-2019]
+        os: [macos-10.15, ubuntu-20.04] # maybe in the future: windows-2019
         go: ["1.17"]
 
     steps:


### PR DESCRIPTION
The idea is:

- linting on different go versions (I remember seeing different behavior sometimes accross different go versions + linter combinations, but debatable).
- build/tests on go versions VS OS (and in the future, git version installed on host would be desireable).

For OS's, windows is more debatable right now, but I think we for sure need linux + macos, at least initially. On the long run, there is people using windows and powershell, @soerenmartius knows these people well :rofl: (just in case fixing for windows is a lot of work)