### PR TITLE
chore: rename tsk suffix to tm

### DIFF
--- a/docs/backend-config.md
+++ b/docs/backend-config.md
@@ -57,7 +57,7 @@ has this layout:
 ```
 
 You can define a prod backend configuration by creating the file
-**envs/prod/terramate.tsk.hcl**:
+**envs/prod/terramate.tm.hcl**:
 
 ```hcl
 terramate {
@@ -68,7 +68,7 @@ terramate {
 ```
 
 Then you can define a staging backend configuration by creating the file
-**envs/staging/terramate.tsk.hcl**:
+**envs/staging/terramate.tm.hcl**:
 
 ```hcl
 terramate {
@@ -85,7 +85,7 @@ your project, by running from the project top level directory:
 terramate generate
 ```
 
-Now you will see a **_gen_terramate.tsk.tf** file on each stack.
+Now you will see a **_gen_terramate.tm.tf** file on each stack.
 The files generated on the stacks inside **envs/prod** will be:
 
 ```hcl

--- a/docs/execution-order.md
+++ b/docs/execution-order.md
@@ -40,12 +40,12 @@ For example, let's assume we have a project organized like this:
 ```
 .
 ├── stack-a
-│   └── terramate.tsk.hcl
+│   └── terramate.tm.hcl
 └── stack-b
-    └── terramate.tsk.hcl
+    └── terramate.tm.hcl
 ```
 
-And **stack-a/terramate.tsk.hcl** looks like:
+And **stack-a/terramate.tm.hcl** looks like:
 
 ```
 terramate {
@@ -53,7 +53,7 @@ terramate {
 }
 ```
 
-And then we have **stack-b/terramate.tsk.hcl**:
+And then we have **stack-b/terramate.tm.hcl**:
 
 ```
 terramate {
@@ -74,7 +74,7 @@ The order of execution will be:
 
 The same order of execution can be defined as:
 
-**stack-a/terramate.tsk.hcl**:
+**stack-a/terramate.tm.hcl**:
 
 ```
 terramate {
@@ -88,7 +88,7 @@ stack {
 }
 ```
 
-**stack-b/terramate.tsk.hcl**:
+**stack-b/terramate.tm.hcl**:
 
 ```
 terramate {
@@ -98,7 +98,7 @@ terramate {
 
 This would also be a valid way to express the same order (although redundant):
 
-**stack-a/terramate.tsk.hcl**:
+**stack-a/terramate.tm.hcl**:
 
 ```
 terramate {
@@ -112,7 +112,7 @@ stack {
 }
 ```
 
-**stack-b/terramate.tsk.hcl**:
+**stack-b/terramate.tm.hcl**:
 
 ```
 terramate {
@@ -130,7 +130,7 @@ You can also use **before** and **after** simultaneously on the same
 stack for more complex scenarios. Lets add a third **stack-c** to our example.
 The three stacks are defined as follows:
 
-**stack-a/terramate.tsk.hcl**:
+**stack-a/terramate.tm.hcl**:
 
 ```
 terramate {
@@ -138,7 +138,7 @@ terramate {
 }
 ```
 
-**stack-b/terramate.tsk.hcl**:
+**stack-b/terramate.tm.hcl**:
 
 ```
 terramate {
@@ -146,7 +146,7 @@ terramate {
 }
 ```
 
-**stack-c/terramate.tsk.hcl**:
+**stack-c/terramate.tm.hcl**:
 
 ```
 terramate {
@@ -252,7 +252,7 @@ error message pointing out the detected cycle.
 
 Also in the case of a conflict, like a stack defined like this:
 
-**stack-a/terramate.tsk.hcl**:
+**stack-a/terramate.tm.hcl**:
 
 ```
 terramate {

--- a/init.go
+++ b/init.go
@@ -12,7 +12,7 @@ import (
 )
 
 // ConfigFilename is the name of the terramate configuration file.
-const ConfigFilename = "terramate.tsk.hcl"
+const ConfigFilename = "terramate.tm.hcl"
 
 // DefaultInitConstraint is the default constraint used in stack initialization.
 const DefaultInitConstraint = "~>"
@@ -98,7 +98,7 @@ func Init(dir string, force bool) error {
 }
 
 // DefaultVersionConstraint is the default version constraint used by terramate
-// when generating tsk files.
+// when generating tm files.
 func DefaultVersionConstraint() string {
 	return DefaultInitConstraint + " " + Version()
 }

--- a/test/sandbox/sandbox.go
+++ b/test/sandbox/sandbox.go
@@ -100,7 +100,7 @@ func (s S) BuildTree(layout []string) {
 		return path, data
 	}
 
-	gentskfile := func(spec string) {
+	gentmfile := func(spec string) {
 		relpath, data := parsePathData(spec)
 		attrs := strings.Split(data, ",")
 
@@ -126,7 +126,7 @@ func (s S) BuildTree(layout []string) {
 
 		var p hcl.Printer
 		err = p.PrintTerramate(f, ts)
-		assert.NoError(t, err, "BuildTree() failed to generate tsk file")
+		assert.NoError(t, err, "BuildTree() failed to generate tm file")
 	}
 
 	for _, spec := range layout {
@@ -136,7 +136,7 @@ func (s S) BuildTree(layout []string) {
 		case 's':
 			s.CreateStack(spec[2:])
 		case 't':
-			gentskfile(spec)
+			gentmfile(spec)
 		case 'f':
 			path, data := parsePathData(spec)
 			test.WriteFile(t, s.basedir, path, data)


### PR DESCRIPTION
Not sure "tm" is the suffix to go, just being pro-active =P. tm is used by https://www.texmacs.org/tmweb/home/welcome.en.html