### PR TITLE
chore: improve module parsing error message

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -342,7 +342,7 @@ func (m *Manager) filesApply(dir string, apply func(file fs.DirEntry) error) err
 			Msg("Apply function to file.")
 		err := apply(file)
 		if err != nil {
-			return errors.E(err, "applying operation to file %q", file)
+			return errors.E(err, "applying operation to file %q", file.Name())
 		}
 	}
 


### PR DESCRIPTION
before:

```
$ terramate list -c
2022-07-07T14:26:44+01:00 FTL listing stacks error="/home/i4k/src/mineiros/tm-example/stack-
b/test.tf:1,1-2: listing changed stacks error: checking module changes: applying operation to
 file &{\"/home/i4k/src/mineiros/tm-example/stack-b\" \"test.tf\" '\\x00' <nil>}: parsing 
modules: HCL syntax error: An argument or block definition is required here." action=printStacks()
```

after:

```
$ terramate list -c
2022-07-07T14:32:23+01:00 FTL listing stacks error="/home/i4k/src/mineiros/tm-example/stack-
b/test.tf:1,1-2: listing changed stacks error: checking module changes: applying operation to
 file \"test.tf\": parsing modules: HCL syntax error: An argument or block definition is
 required here." action=printStacks()
```