### PR TITLE
fix: generate: assert loading when proj root is /

### DIFF
--- a/generate/generate.go
+++ b/generate/generate.go
@@ -838,11 +838,11 @@ func loadAsserts(meta project.Metadata, sm stack.Metadata, globals globals.Map) 
 			}
 		}
 
-		parent := filepath.Dir(curdir)
-		if parent == curdir {
+		if curdir == meta.Rootdir() {
 			break
 		}
-		curdir = parent
+
+		curdir = filepath.Dir(curdir)
 	}
 
 	if err := errs.AsError(); err != nil {


### PR DESCRIPTION
# Reason for This Change

If a project root is on / we would loop forever on the HasPrefix logic (you never leave root).

## Description of Changes

When we reach root break explicitely.
