### PR TITLE
chore: optimize listing of Terramate files and directories.

### DIFF
--- a/hcl/fmt/fmt.go
+++ b/hcl/fmt/fmt.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
@@ -65,6 +66,7 @@ func FormatTree(dir string) ([]FormatResult, error) {
 	if err != nil {
 		return nil, errors.E(errFormatTree, err)
 	}
+	sort.Strings(files)
 
 	results := []FormatResult{}
 	errs := errors.L()
@@ -99,6 +101,7 @@ func FormatTree(dir string) ([]FormatResult, error) {
 		errs.Append(err)
 		return nil, errors.E(errFormatTree, errs)
 	}
+	sort.Strings(dirs)
 
 	for _, d := range dirs {
 		subres, err := FormatTree(filepath.Join(dir, d))

--- a/makefiles/common.mk
+++ b/makefiles/common.mk
@@ -115,7 +115,7 @@ bench/all:
 bench/check: allocdelta="+20%"
 bench/check: timedelta="+20%"
 bench/check: name=github.com/terramate-io/terramate
-bench/check: pkg=./...
+bench/check: pkg?=./...
 bench/check: old=main
 bench/check: new?=$(shell git rev-parse HEAD)
 bench/check:

--- a/stack/manager.go
+++ b/stack/manager.go
@@ -415,15 +415,24 @@ func (m *Manager) AddWantedOf(scopeStacks config.List[*config.SortableStack]) (c
 	return selectedStacks, nil
 }
 
-func (m *Manager) filesApply(dir string, apply func(file fs.DirEntry) error) error {
+func (m *Manager) filesApply(dir string, apply func(file fs.DirEntry) error) (err error) {
 	logger := log.With().
 		Str("action", "filesApply()").
 		Str("path", dir).
 		Logger()
 
-	logger.Debug().
-		Msg("Read dir.")
-	files, err := os.ReadDir(dir)
+	logger.Debug().Msg("Read dir.")
+
+	f, err := os.Open(dir)
+	if err != nil {
+		return errors.E(err, "opening directory %q", dir)
+	}
+
+	defer func() {
+		err = errors.L(err, f.Close()).AsError()
+	}()
+
+	files, err := f.ReadDir(-1)
 	if err != nil {
 		return errors.E(err, "listing files of directory %q", dir)
 	}
@@ -433,8 +442,8 @@ func (m *Manager) filesApply(dir string, apply func(file fs.DirEntry) error) err
 			continue
 		}
 
-		logger.Debug().
-			Msg("Apply function to file.")
+		logger.Debug().Msg("Apply function to file.")
+
 		err := apply(file)
 		if err != nil {
 			return errors.E(err, "applying operation to file %q", file.Name())


### PR DESCRIPTION
# Reason for This Change

- Use `f.ReadDir(-1)` for listing all the files with `e.IsDir()` populated in a single syscall.
- do not sort the files
