### PR TITLE
chore: align user type with oas

### DIFF
--- a/cloud/api.go
+++ b/cloud/api.go
@@ -19,6 +19,7 @@ type (
 		DisplayName string `json:"display_name"`
 		JobTitle    string `json:"job_title"`
 		IDPUserID   string `json:"idp_user_id"`
+		UserUUID    string `json:"user_uuid,omitempty"`
 	}
 
 	// MemberOrganization represents the organization associated with the member.


### PR DESCRIPTION
Add the `user_uuid` to the User type to align it with the OpenAPI Specification for Terramate Cloud backend.

Should not be merged until #958 has been merged. 