### PR TITLE
fix: crash when having generate_hcl with no content block

### DIFF
--- a/hcl/hcl.go
+++ b/hcl/hcl.go
@@ -832,6 +832,11 @@ func parseGenerateHCLBlock(block *ast.Block) (GenHCLBlock, error) {
 		}
 	}
 
+	if content == nil {
+		errs.Append(
+			errors.E(ErrTerramateSchema, `"generate_hcl" block requires a content block`, block.Range))
+	}
+
 	mergedLets := ast.MergedLabelBlocks{}
 	for labelType, mergedBlock := range letsConfig.MergedLabelBlocks {
 		if labelType.Type == "lets" {

--- a/hcl/hcl_test.go
+++ b/hcl/hcl_test.go
@@ -642,6 +642,26 @@ func TestHCLParserMultipleErrors(t *testing.T) {
 			},
 		},
 		{
+			name: "generate_hcl with no content block",
+			input: []cfgfile{
+				{
+					filename: "gen.tm",
+					body: `
+					generate_hcl "test.tf" {
+						lets {
+							a = 1
+						}
+					}
+					`,
+				},
+			},
+			want: want{
+				errs: []error{
+					errors.E(hcl.ErrTerramateSchema),
+				},
+			},
+		},
+		{
 			name: "generate_hcl with lets with unexpected child blocks - fails",
 			input: []cfgfile{
 				{


### PR DESCRIPTION
I spent some time digging if we lost this test somehow when moving testcases around between packages, but we actually never had tests for a missing `content` block inside the `generate_hcl` block.
The `content` block was introduced here: https://github.com/terramate-io/terramate/pull/220/files

Then this fixes a bug that has existed since [v0.0.11](https://github.com/terramate-io/terramate/releases/tag/v0.0.11).