### PR TITLE
CPU profiling branch

### DIFF
--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"runtime/pprof"
 	"strings"
 	"time"
 
@@ -95,6 +96,7 @@ type cliSpec struct {
 	LogDestination string   `optional:"true" default:"stderr" enum:"stderr,stdout" help:"Destination of log messages"`
 	Quiet          bool     `optional:"false" help:"Disable output"`
 	Verbose        int      `short:"v" optional:"true" default:"0" type:"counter" help:"Increase verboseness of output"`
+	CPUProfiling   bool     `optional:"true" default:"false" help:"Create a CPU profile file when running"`
 
 	DisableCheckGitUntracked   bool `optional:"true" default:"false" help:"Disable git check for untracked files"`
 	DisableCheckGitUncommitted bool `optional:"true" default:"false" help:"Disable git check for uncommitted files"`
@@ -300,6 +302,19 @@ func newCLI(version string, args []string, stdin io.Reader, stdout, stderr io.Wr
 		fatal(err, "parsing cli args %v", args)
 	}
 
+	if parsedArgs.CPUProfiling {
+		stdfmt.Println("Creating CPU profile...")
+		f, err := os.Create("terramate.prof")
+		if err != nil {
+			fatal(err, "can't create profile output file")
+		}
+		err = pprof.StartCPUProfile(f)
+		if err != nil {
+			fatal(err, "error when starting CPU profiling")
+		}
+
+	}
+
 	configureLogging(parsedArgs.LogLevel, parsedArgs.LogFmt,
 		parsedArgs.LogDestination, stdout, stderr)
 	// If we don't re-create the logger after configuring we get some
@@ -484,6 +499,13 @@ func (c *cli) run() {
 	c.setupFilterTags()
 
 	logger.Debug().Msg("Handle command.")
+
+	// We start the CPU Profiling during the flags parsing, but can't defer
+	// the stop there, as the CLI parsing returns far before the program is
+	// done running. Therefore we schedule it here.
+	if c.parsedArgs.CPUProfiling {
+		defer pprof.StopCPUProfile()
+	}
 
 	switch c.ctx.Command() {
 	case "fmt":

--- a/scripts/cpu_profile.sh
+++ b/scripts/cpu_profile.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+WORKSPACE_ROOT="$HOME/src"
+TM="$WORKSPACE_ROOT/terramate"
+IAC="$WORKSPACE_ROOT/iac-gcloud"
+
+delete_terraform_files() {
+    pushd "$IAC"
+    fd '_terramate.*tf' --exec rm
+    printf "Deleted generated terraform files...\n"
+    popd
+}
+
+build_terramate() {
+    pushd "${WORKSPACE_ROOT}/terramate"
+    printf "Building Terramate from source...\n"
+    make test/build
+    printf "Built Terramate\n"
+    popd
+}
+
+main() {
+    build_terramate
+    mv "${TM}/bin/test-terramate" "$IAC/terramate"
+    delete_terraform_files
+
+    pushd "$IAC"
+    printf "Starting profiling run...\n\n"
+    ./terramate --cpu-profiling generate
+    printf "Profiling run done, moving to '$WORKSPACE_ROOT/terramate.prof'\n"
+    mv "./terramate.prof" "$WORKSPACE_ROOT"
+    popd
+}
+
+main


### PR DESCRIPTION
Terramate is slow in many circumstances, let's get some evidence as to how and why that is! 

Since performance is often counter-intuitive and doesn't behave as one would expect, let's get out `pprof` for gathering some evidence. This PR body is going to be a very abridged version of [this article][pprof-article] that you can read for further information, I'm just going to talk about a short version of generating performance reports. 

Long story short: 
1. Switch Terramate to the branch `cpu-profiling`. 
2. Run the script after adapting your local repositories for appropriate values of `$TM`, `$IAC` and `$WORKSPACE_ROOT`.
3. You will receive a `terramate.pprof` file.
4. You can now run `go tool pprof ./terramate.prof`. This will drop you into a `pprof` REPL that works quite a bit like `gdb` or `delve`. 

Inside this REPL you can explore the performance trace. For more information read the article above, but here's the very short version: 
- `web` generates a SVG of the call tree and opens it in your browser. This is an annotated graph that allows you to figure out where the time goes, which ares are expensive, and which ones are under your control. (requires graphviz) 
- `top 10` (where 10 is arbitrary) gives you the 10 highest-time-spent-total symbols. This is going to frequently/always be runtime operations like allocating memory, syscalls, and such.  
- `top 10 -cum` instead gives you the _cumulative_ 10 highest-time-spent symbols. This means that `main.main` is going to be at position 1, with everything else then slowly going down. 
- `list myFunction` gives you an annotated source-code view of myFunction (or anything that has a debugging symbol attached), allowing you to see in which lines time is spent. 
- `help` lists the functions available. 

A note on `pprof`'s concept of time: You will frequently see total times that are higher than the actual execution time, and you will see cases of `main.main` only having 50% or so of total time when it should have 100%, etc. This is because time spent in threads occurs simultaneously and also counts against the total trace time.

As for Terramate specifically, I'm going to need to spend more time creating better examples and such. This example case in specific has no no-ops and _all_ terraform files need to be generated. A more realistic case is that only one stack needs to have files generated, and we spend tons of time checking all stacks, making it slow. (If you have a ton of stacks in a repo and terramate is slow for you, please reach out and I'll be happy to work with you to make this faster. I have some ideas, but profiling data beats intuition almost every day.) 

[pprof-article]: https://go.dev/blog/pprof
sc-8205