### PR TITLE
Fix config to always use darkmode as default mode instead of detecting the browsers default

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -85,6 +85,8 @@ export default defineConfig({
 
     return head
   },
+  // https://vitepress.dev/reference/site-config#appearance
+  appearance: 'dark',
   themeConfig: {
     // https://vitepress.dev/reference/default-theme-config#sitetitle
     siteTitle: '🦄 Terramate',
@@ -94,9 +96,6 @@ export default defineConfig({
     //   dark: '/logo-dark.svg',
     //   alt: 'Terramate',
     // },
-
-    // https://vitepress.dev/reference/site-config#appearance
-    appearance: 'dark',
 
     // https://vitepress.dev/reference/default-theme-search#local-search
     search: {


### PR DESCRIPTION
# Reason for This Change

Previously the configuration of Vitepress was faulty the theme was always set to the users browser standard instead of setting it to dark mode per default.

## Description of Changes

This change moves `appearance: 'dark',` to the correct level in the configuration so that dark mode is always used as the default mode.

