### PR TITLE
Add codeowners for automatically assigning PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @terramate-io/cli-tooling


### PR DESCRIPTION
# Reason for This Change

Previously we didn't manage CODEOWNERS.

## Description of Changes

This PR introduces CODEOWNERS to automatically assign all PRs to @terramate-io/cli-tooling 
