### PR TITLE
fix: only send the commitSHA if the repository is clean

### DIFF
--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -859,15 +859,15 @@ func debugFiles(files []string, msg string) {
 	}
 }
 
-func (c *cli) gitFileSafeguards(checks stack.RepoChecks, shouldAbort bool) {
+func (c *cli) gitFileSafeguards(shouldAbort bool) {
 	if c.parsedArgs.Run.DryRun {
 		return
 	}
 
-	debugFiles(checks.UntrackedFiles, "untracked file")
-	debugFiles(checks.UncommittedFiles, "uncommitted file")
+	debugFiles(c.prj.git.repoChecks.UntrackedFiles, "untracked file")
+	debugFiles(c.prj.git.repoChecks.UncommittedFiles, "uncommitted file")
 
-	if c.checkGitUntracked() && len(checks.UntrackedFiles) > 0 {
+	if c.checkGitUntracked() && len(c.prj.git.repoChecks.UntrackedFiles) > 0 {
 		const msg = "repository has untracked files"
 		if shouldAbort {
 			log.Fatal().Msg(msg)
@@ -876,7 +876,7 @@ func (c *cli) gitFileSafeguards(checks stack.RepoChecks, shouldAbort bool) {
 		}
 	}
 
-	if c.checkGitUncommited() && len(checks.UncommittedFiles) > 0 {
+	if c.checkGitUncommited() && len(c.prj.git.repoChecks.UncommittedFiles) > 0 {
 		const msg = "repository has uncommitted files"
 		if shouldAbort {
 			log.Fatal().Msg(msg)
@@ -1066,7 +1066,8 @@ func (c *cli) printStacks() {
 		fatal(err, "listing stacks")
 	}
 
-	c.gitFileSafeguards(report.Checks, false)
+	c.prj.git.repoChecks = report.Checks
+	c.gitFileSafeguards(false)
 
 	for _, entry := range c.filterStacks(report.Stacks) {
 		stack := entry.Stack
@@ -1751,7 +1752,8 @@ func (c *cli) computeSelectedStacks(ensureCleanRepo bool) (config.List[*config.S
 		return nil, err
 	}
 
-	c.gitFileSafeguards(report.Checks, ensureCleanRepo)
+	c.prj.git.repoChecks = report.Checks
+	c.gitFileSafeguards(ensureCleanRepo)
 
 	logger.Trace().Msg("Filter stacks by working directory.")
 

--- a/cmd/terramate/cli/cloud.go
+++ b/cmd/terramate/cli/cloud.go
@@ -142,6 +142,14 @@ func (c *cli) createCloudDeployment(stacks config.List[*config.SortableStack], c
 
 	// TODO(i4k): convert repoURL to Go-style module name (eg.: github.com/org/reponame)
 
+	commitSHA := c.prj.git.headCommit
+	if len(c.prj.git.repoChecks.UntrackedFiles) > 0 ||
+		len(c.prj.git.repoChecks.UncommittedFiles) > 0 {
+		commitSHA = ""
+
+		logger.Debug().Msg("commit SHA is not being synced because the repository is dirty")
+	}
+
 	var payload cloud.DeploymentStacksPayloadRequest
 	for _, s := range stacks {
 		tags := s.Tags
@@ -155,7 +163,7 @@ func (c *cli) createCloudDeployment(stacks config.List[*config.SortableStack], c
 			MetaTags:        tags,
 			Repository:      repoURL,
 			Path:            prj.PrjAbsPath(c.rootdir(), c.wd()).String(),
-			CommitSHA:       c.prj.git.headCommit,
+			CommitSHA:       commitSHA,
 			Command:         strings.Join(command, " "),
 		})
 	}

--- a/cmd/terramate/cli/project.go
+++ b/cmd/terramate/cli/project.go
@@ -11,6 +11,7 @@ import (
 	"github.com/terramate-io/terramate/errors"
 	"github.com/terramate-io/terramate/git"
 	"github.com/terramate-io/terramate/hcl"
+	"github.com/terramate-io/terramate/stack"
 )
 
 type project struct {
@@ -25,6 +26,8 @@ type project struct {
 		headCommit                string
 		localDefaultBranchCommit  string
 		remoteDefaultBranchCommit string
+
+		repoChecks stack.RepoChecks
 	}
 }
 


### PR DESCRIPTION
# Reason for This Change

If the repository is not in a clean state, we shall not send the CommitSHA field of the stack object.

