### PR TITLE
fix: normalize git repository url

### DIFF
--- a/cloud/git.go
+++ b/cloud/git.go
@@ -1,3 +1,6 @@
+// Copyright 2023 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
 package cloud
 
 import (
@@ -6,6 +9,8 @@ import (
 	"strings"
 )
 
+// NormalizeGitURI normalizes the raw uri in a Terramate Cloud
+// compatible form.
 func NormalizeGitURI(raw string) string {
 	// in the case the remote is a local bare repo, it can be an absolute or
 	// a relative path, but relative paths can be ambiguous with remote URLs,

--- a/cloud/git.go
+++ b/cloud/git.go
@@ -1,0 +1,39 @@
+package cloud
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+func NormalizeGitURI(raw string) string {
+	// in the case the remote is a local bare repo, it can be an absolute or
+	// a relative path, but relative paths can be ambiguous with remote URLs,
+	// then an fs stat is needed here.
+	_, err := os.Lstat(raw)
+	if err == nil {
+		// path exists, then likely a local path.
+		return "local"
+	}
+
+	switch {
+	case strings.HasPrefix(raw, "git@"):
+		uri := raw[4:]
+		parts := strings.Split(uri, ":")
+		if len(parts) == 2 {
+			host := parts[0]
+			path := strings.TrimSuffix(parts[1], ".git")
+			return fmt.Sprintf("%s/%s", host, path)
+		}
+		// unrecognized, then return it raw
+	case strings.HasPrefix(raw, "https://"):
+		uri := raw[8:]
+		parts := strings.Split(uri, "/")
+		if len(parts) > 1 {
+			host := parts[0]
+			path := strings.TrimSuffix(strings.Join(parts[1:], "/"), ".git")
+			return fmt.Sprintf("%s/%s", host, path)
+		}
+	}
+	return raw
+}

--- a/cloud/git_test.go
+++ b/cloud/git_test.go
@@ -1,0 +1,85 @@
+package cloud_test
+
+import (
+	"testing"
+
+	"github.com/madlambda/spells/assert"
+	"github.com/terramate-io/terramate/cloud"
+)
+
+func TestNormalizeGitURL(t *testing.T) {
+	type testcase struct {
+		name       string
+		raw        string
+		normalized string
+	}
+
+	tempDir := t.TempDir()
+
+	for _, tc := range []testcase{
+		{
+			name:       "basic github https url",
+			raw:        "https://github.com/terramate-io/terramate.git",
+			normalized: "github.com/terramate-io/terramate",
+		},
+		{
+			name:       "github https url without .git suffix",
+			raw:        "https://github.com/terramate-io/terramate",
+			normalized: "github.com/terramate-io/terramate",
+		},
+		{
+			name:       "basic github ssh url",
+			raw:        "git@github.com:terramate-io/terramate.git",
+			normalized: "github.com/terramate-io/terramate",
+		},
+		{
+			name:       "github ssh url without .git suffix",
+			raw:        "git@github.com:terramate-io/terramate.git",
+			normalized: "github.com/terramate-io/terramate",
+		},
+		{
+			name:       "https url from any domain",
+			raw:        "https://domain/path",
+			normalized: "domain/path",
+		},
+		{
+			name:       "https url from ipv4 ip address",
+			raw:        "https://192.168.1.169/path",
+			normalized: "192.168.1.169/path",
+		},
+		{
+			name:       "ssh url from any domain",
+			raw:        "git@example.com:path.git",
+			normalized: "example.com/path",
+		},
+		{
+			name:       "filesystem path returns as local",
+			raw:        tempDir,
+			normalized: "local",
+		},
+		{
+			name:       "unrecognized url return as is",
+			raw:        "something else",
+			normalized: "something else",
+		},
+		{
+			name:       "unrecognized ssh url",
+			raw:        "git@github.com:8888:terramate-io/terramate.git",
+			normalized: "git@github.com:8888:terramate-io/terramate.git",
+		},
+		{
+			name:       "unrecognized git url with ssh:// prefix",
+			raw:        "ssh://git@github.com/terramate-io/terramate.git",
+			normalized: "ssh://git@github.com/terramate-io/terramate.git",
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			assert.EqualStrings(t,
+				tc.normalized,
+				cloud.NormalizeGitURI(tc.raw),
+				"git url normalization mismatch",
+			)
+		})
+	}
+}

--- a/cloud/git_test.go
+++ b/cloud/git_test.go
@@ -1,3 +1,6 @@
+// Copyright 2023 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
 package cloud_test
 
 import (

--- a/cmd/terramate/cli/cloud.go
+++ b/cmd/terramate/cli/cloud.go
@@ -149,17 +149,10 @@ func (c *cli) createCloudDeployment(stacks config.List[*config.SortableStack], c
 
 	if c.prj.isRepo {
 		repoURL, err = c.prj.git.wrapper.URL(c.prj.gitcfg().DefaultRemote)
-		if err != nil {
-			logger.Warn().Err(err).Msg("failed to retrieve repository URL")
-		}
-
-		// in the case the remote is a local bare repo, it can be an absolute or
-		// a relative path, but relative paths can be ambiguous with remote URLs,
-		// then an fs stat is needed here.
-		_, err := os.Lstat(repoURL)
 		if err == nil {
-			// path exists, then likely a local path.
-			repoURL = "local"
+			repoURL = cloud.NormalizeGitURI(repoURL)
+		} else {
+			logger.Warn().Err(err).Msg("failed to retrieve repository URL")
 		}
 
 		commitSHA = c.prj.headCommit()


### PR DESCRIPTION
Normalize the repository name for Terramate Cloud.