### PR TITLE
feat: add support for selecting the organization using env var

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,11 +56,6 @@ jobs:
       - name: check cloud info
         run: ./bin/terramate experimental cloud info
 
-      - name: check cloud sync
-        run: ./bin/terramate run --log-level=debug --disable-check-git-remote --cloud-sync-deployment -- echo "Hello from Terramate CI"
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-
   gh_integration_test:
     name: GHA Integration Test
 

--- a/cloud/testserver/handlers.go
+++ b/cloud/testserver/handlers.go
@@ -26,7 +26,8 @@ func (orgHandler *organizationHandler) ServeHTTP(w http.ResponseWriter, _ *http.
 		{
 			"org_name": "terramate-io",
 			"org_display_name": "Terramate",
-			"org_uuid": "%s"
+			"org_uuid": "%s",
+			"status": "active"
 		}
 	]`, DefaultOrgUUID),
 	))

--- a/cloud/types.go
+++ b/cloud/types.go
@@ -129,7 +129,7 @@ func (orgs MemberOrganizations) String() string {
 		write("none")
 	} else {
 		for i, org := range orgs {
-			write(org.DisplayName)
+			write(org.Name)
 			if i+1 < len(orgs) {
 				write(", ")
 			}

--- a/cmd/terramate/cli/cloud.go
+++ b/cmd/terramate/cli/cloud.go
@@ -112,7 +112,7 @@ func (c *cli) checkSyncDeployment() {
 	} else {
 		org := orgs[0]
 		if org.Status != "active" {
-			fatal(errors.E("selected organization %s is not active", org.Name))
+			fatal(errors.E("You are not yet an active member of organization %s. Please accept the invitation first.", org.Name))
 		}
 		c.cloud.run.orgUUID = org.UUID
 	}

--- a/cmd/terramate/cli/cloud.go
+++ b/cmd/terramate/cli/cloud.go
@@ -101,9 +101,9 @@ func (c *cli) checkSyncDeployment() {
 		c.cloud.run.orgUUID = useOrgUUID
 	} else if len(orgs) != 1 {
 		fatal(
-			errors.E("requires 1 organization associated with the credential but %d found: %s",
-				len(orgs),
-				orgs),
+			errors.E("if the organization is not explicitly set with TM_CLOUD_ORGANIZATION "+
+				"environment variable then the user must be associated with only 1 organization "+
+				"but %d found: %s", len(orgs), orgs),
 		)
 	} else {
 		c.cloud.run.orgUUID = orgs[0].UUID

--- a/cmd/terramate/cli/cloud.go
+++ b/cmd/terramate/cli/cloud.go
@@ -96,7 +96,7 @@ func (c *cli) checkSyncDeployment() {
 		}
 
 		if useOrgUUID == "" {
-			fatal(errors.E("organization %q is not in the set of user's organizations: %s",
+			fatal(errors.E("You are not a member of organization %q or the organization does not exist. Available organizations: %s",
 				useOrgName,
 				orgs,
 			))

--- a/cmd/terramate/cli/cloud.go
+++ b/cmd/terramate/cli/cloud.go
@@ -105,9 +105,7 @@ func (c *cli) checkSyncDeployment() {
 		c.cloud.run.orgUUID = useOrgUUID
 	} else if len(orgs) != 1 {
 		fatal(
-			errors.E("if the organization is not explicitly set with TM_CLOUD_ORGANIZATION "+
-				"environment variable then the user must be associated with only 1 organization "+
-				"but %d found: %s", len(orgs), orgs),
+			errors.E("Please set TM_CLOUD_ORGANIZATION environment variable to a specific available organization %s", orgs),
 		)
 	} else {
 		org := orgs[0]

--- a/cmd/terramate/cli/cloud.go
+++ b/cmd/terramate/cli/cloud.go
@@ -105,7 +105,7 @@ func (c *cli) checkSyncDeployment() {
 		c.cloud.run.orgUUID = useOrgUUID
 	} else if len(orgs) != 1 {
 		fatal(
-			errors.E("Please set TM_CLOUD_ORGANIZATION environment variable to a specific available organization %s", orgs),
+			errors.E("Please set TM_CLOUD_ORGANIZATION environment variable to a specific available organization: %s", orgs),
 		)
 	} else {
 		org := orgs[0]

--- a/cmd/terramate/cli/cloud.go
+++ b/cmd/terramate/cli/cloud.go
@@ -86,6 +86,10 @@ func (c *cli) checkSyncDeployment() {
 		var useOrgUUID string
 		for _, org := range orgs {
 			if org.Name == useOrgName {
+				if org.Status != "active" {
+					fatal(errors.E("selected organization %s is not active", useOrgName))
+				}
+
 				useOrgUUID = org.UUID
 				break
 			}
@@ -106,7 +110,11 @@ func (c *cli) checkSyncDeployment() {
 				"but %d found: %s", len(orgs), orgs),
 		)
 	} else {
-		c.cloud.run.orgUUID = orgs[0].UUID
+		org := orgs[0]
+		if org.Status != "active" {
+			fatal(errors.E("selected organization %s is not active", org.Name))
+		}
+		c.cloud.run.orgUUID = org.UUID
 	}
 
 	c.cloud.run.meta2id = make(map[string]int)

--- a/cmd/terramate/cli/cloud.go
+++ b/cmd/terramate/cli/cloud.go
@@ -87,7 +87,7 @@ func (c *cli) checkSyncDeployment() {
 		for _, org := range orgs {
 			if org.Name == useOrgName {
 				if org.Status != "active" {
-					fatal(errors.E("selected organization %s is not active", useOrgName))
+					fatal(errors.E("You are not yet an active member of organization %s. Please accept the invitation first.", useOrgName))
 				}
 
 				useOrgUUID = org.UUID


### PR DESCRIPTION
The environment variable `TM_CLOUD_ORGANIZATION` can be used to select the organization where data will be sent to.