### PR TITLE
chore: disable OIDC integration in tests

### DIFF
--- a/cmd/terramate/e2etests/run_cloud_test.go
+++ b/cmd/terramate/e2etests/run_cloud_test.go
@@ -243,9 +243,7 @@ func TestCLIRunWithCloudSync(t *testing.T) {
 			uuid, err := uuid.NewRandom()
 			assert.NoError(t, err)
 			runid := uuid.String()
-			cli.appendEnv = []string{
-				"TM_TEST_RUN_ID=" + runid,
-			}
+			cli.appendEnv = []string{"TM_TEST_RUN_ID=" + runid}
 
 			var exec *testCmd
 			cmd := []string{"run", "--cloud-sync-deployment"}

--- a/cmd/terramate/e2etests/run_cloud_test.go
+++ b/cmd/terramate/e2etests/run_cloud_test.go
@@ -243,7 +243,9 @@ func TestCLIRunWithCloudSync(t *testing.T) {
 			uuid, err := uuid.NewRandom()
 			assert.NoError(t, err)
 			runid := uuid.String()
-			cli.appendEnv = []string{"TM_TEST_RUN_ID=" + runid}
+			cli.appendEnv = []string{
+				"TM_TEST_RUN_ID=" + runid,
+			}
 
 			var exec *testCmd
 			cmd := []string{"run", "--cloud-sync-deployment"}

--- a/cmd/terramate/e2etests/run_test.go
+++ b/cmd/terramate/e2etests/run_test.go
@@ -2298,6 +2298,8 @@ func TestRunWitCustomizedEnv(t *testing.T) {
 	}
 
 	wantenv := append(hostenv,
+		"ACTIONS_ID_TOKEN_REQUEST_URL=",
+		"ACTIONS_ID_TOKEN_REQUEST_TOKEN=",
 		"CHECKPOINT_DISABLE=1", // e2e tests have telemetry disabled
 		fmt.Sprintf("FROM_META=%s", stackName),
 		fmt.Sprintf("FROM_GLOBAL=%s", stackGlobal),

--- a/cmd/terramate/e2etests/runner_test.go
+++ b/cmd/terramate/e2etests/runner_test.go
@@ -156,7 +156,11 @@ func (tm tmcli) newCmd(args ...string) *testCmd {
 	// custom cliconfig file
 	userTmpDir := t.TempDir()
 	cliConfigPath := test.WriteFile(t, userTmpDir, "terramate.rc", fmt.Sprintf(testCliConfigFormat, strings.Replace(userTmpDir, "\\", "\\\\", -1)))
-	env = append(env, "TM_CLI_CONFIG_FILE="+cliConfigPath)
+	env = append(env,
+		"TM_CLI_CONFIG_FILE="+cliConfigPath,
+		"ACTIONS_ID_TOKEN_REQUEST_URL=",
+		"ACTIONS_ID_TOKEN_REQUEST_TOKEN=",
+	)
 
 	env = append(env, tm.appendEnv...)
 


### PR DESCRIPTION
# Reason for This Change

The tests are generating OIDC JWT tokens because they are detected in the e2e tests.

## Description of Changes

Disabled them in the e2e runner.
