### PR TITLE
feat: implement experimental init command.

### DIFF
--- a/cloud/testserver/handlers.go
+++ b/cloud/testserver/handlers.go
@@ -103,6 +103,13 @@ func (dhandler *deploymentHandler) ServeHTTP(w http.ResponseWriter, r *http.Requ
 			return
 		}
 
+		err = p.Validate()
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(err.Error()))
+			return
+		}
+
 		res := cloud.DeploymentStacksResponse{}
 		for _, s := range p.Stacks {
 			next := atomic.LoadInt64(&dhandler.nextStackID)

--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -1045,6 +1045,9 @@ func (c *cli) initDir(baseDir string) error {
 
 		log.Info().Msgf("created stack %s", stackSpec.Dir)
 		c.output.MsgStdOut("Created stack %s", stackSpec.Dir)
+
+		// so other files in the same directory do not trigger stack creation.
+		isStack = true
 	}
 
 	return errs.AsError()

--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -946,6 +946,11 @@ func (c *cli) initStacks() {
 		return
 	}
 
+	err = c.prj.root.LoadSubTree(prj.NewPath("/"))
+	if err != nil {
+		fatal(err, "failed to reload the configuration tree")
+	}
+
 	report, vendorReport := c.gencodeWithVendor()
 	if report.HasFailures() {
 		c.output.MsgStdOut("Code generation failed")

--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -1021,8 +1021,13 @@ func (c *cli) initDir(baseDir string) error {
 		}
 
 		stackDir := baseDir
+		stackID, err := uuid.NewRandom()
+		if err != nil {
+			fatal(err, "creating stack UUID")
+		}
 		stackSpec := config.Stack{
 			Dir: prj.PrjAbsPath(c.rootdir(), stackDir),
+			ID:  stackID.String(),
 		}
 
 		err = stack.Create(c.cfg(), stackSpec)

--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -1017,7 +1017,7 @@ func (c *cli) initDir(baseDir string) error {
 			continue
 		}
 
-		found, err := tf.FileHasBackend(path)
+		found, err := tf.IsStack(path)
 		if err != nil {
 			fatal(errors.E(err, "parsing terraform"))
 		}

--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -993,10 +993,6 @@ func (c *cli) initDir(baseDir string) error {
 
 	errs := errors.L()
 	for _, f := range dirs {
-		if f.Name() == "." || f.Name() == ".." {
-			continue
-		}
-
 		path := filepath.Join(baseDir, f.Name())
 		if strings.HasPrefix(f.Name(), ".") {
 			logger.Trace().Msgf("ignoring file %s", path)
@@ -1049,7 +1045,6 @@ func (c *cli) initDir(baseDir string) error {
 		// so other files in the same directory do not trigger stack creation.
 		isStack = true
 	}
-
 	return errs.AsError()
 }
 

--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -140,6 +140,10 @@ type cliSpec struct {
 	InstallCompletions kongplete.InstallCompletions `cmd:"" help:"Install shell completions"`
 
 	Experimental struct {
+		Init struct {
+			AllTerraform bool `help:"initialize all Terraform directories containing terraform.backend blocks defined"`
+		} `cmd:"" help:"Init existing directories with stacks"`
+
 		Clone struct {
 			SrcDir  string `arg:"" name:"srcdir" predictor:"file" help:"Path of the stack being cloned"`
 			DestDir string `arg:"" name:"destdir" predictor:"file" help:"Path of the new stack"`
@@ -498,6 +502,8 @@ func (c *cli) run() {
 	switch c.ctx.Command() {
 	case "fmt":
 		c.format()
+	case "init":
+		c.initStacks()
 	case "create <path>":
 		c.createStack()
 	case "list":
@@ -922,6 +928,19 @@ func (c *cli) listStacks(mgr *stack.Manager, isChanged bool) (*stack.Report, err
 		return mgr.ListChanged()
 	}
 	return mgr.List()
+}
+
+func (c *cli) initStacks() {
+	logger := log.With().
+		Str("workingDir", c.wd()).
+		Str("action", "cli.initStacks()").
+		Logger()
+
+	if !c.parsedArgs.Experimental.Init.AllTerraform {
+		fatal(errors.E("The --all-terraform is required"))
+	}
+
+	logger.Debug().Msg("scanning TF files")
 }
 
 func (c *cli) createStack() {

--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -946,6 +946,13 @@ func (c *cli) initStacks() {
 		return
 	}
 
+	root, err := config.LoadRoot(c.rootdir())
+	if err != nil {
+		fatal(err, "reloading the configuration")
+	}
+
+	c.prj.root = *root
+
 	report, vendorReport := c.gencodeWithVendor()
 	if report.HasFailures() {
 		c.output.MsgStdOut("Code generation failed")
@@ -1115,6 +1122,11 @@ func (c *cli) createStack() {
 	if c.parsedArgs.Create.NoGenerate {
 		log.Debug().Msg("code generation on stack creation disabled")
 		return
+	}
+
+	err = c.prj.root.LoadSubTree(stackSpec.Dir)
+	if err != nil {
+		fatal(err, "loading newly created stack")
 	}
 
 	report, vendorReport := c.gencodeWithVendor()

--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -946,11 +946,6 @@ func (c *cli) initStacks() {
 		return
 	}
 
-	err = c.prj.root.LoadSubTree(prj.NewPath("/"))
-	if err != nil {
-		fatal(err, "failed to reload the configuration tree")
-	}
-
 	report, vendorReport := c.gencodeWithVendor()
 	if report.HasFailures() {
 		c.output.MsgStdOut("Code generation failed")

--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -966,9 +966,8 @@ func (c *cli) initStacks() {
 
 func (c *cli) initDir(baseDir string) error {
 	logger := log.With().
-		Str("workingDir", c.wd()).
 		Str("dir", baseDir).
-		Str("action", "cli.initStacks()").
+		Str("action", "cli.initDir()").
 		Logger()
 
 	pdir := prj.PrjAbsPath(c.rootdir(), baseDir)
@@ -978,7 +977,7 @@ func (c *cli) initDir(baseDir string) error {
 		isStack = tree.IsStack()
 	}
 
-	logger.Debug().Msg("scanning TF files")
+	logger.Trace().Msg("scanning TF files")
 
 	dirs, err := os.ReadDir(baseDir)
 	if err != nil {
@@ -993,7 +992,7 @@ func (c *cli) initDir(baseDir string) error {
 
 		path := filepath.Join(baseDir, f.Name())
 		if strings.HasPrefix(f.Name(), ".") {
-			logger.Debug().Msgf("ignoring file %s", path)
+			logger.Trace().Msgf("ignoring file %s", path)
 			continue
 		}
 
@@ -1007,7 +1006,7 @@ func (c *cli) initDir(baseDir string) error {
 		}
 
 		if filepath.Ext(f.Name()) != ".tf" {
-			logger.Debug().Msgf("ignoring file %s", path)
+			logger.Trace().Msgf("ignoring file %s", path)
 			continue
 		}
 
@@ -1017,6 +1016,7 @@ func (c *cli) initDir(baseDir string) error {
 		}
 
 		if !found {
+			logger.Trace().Msgf("ignoring file %s", path)
 			continue
 		}
 

--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -960,7 +960,7 @@ func (c *cli) initStacks() {
 		os.Exit(1)
 	}
 
-	c.output.MsgStdOutV(report.Minimal())
+	c.output.MsgStdOutV(report.Full())
 	c.output.MsgStdOutV(vendorReport.String())
 }
 

--- a/cmd/terramate/e2etests/init_test.go
+++ b/cmd/terramate/e2etests/init_test.go
@@ -1,0 +1,97 @@
+package e2etest
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/madlambda/spells/assert"
+	"github.com/terramate-io/terramate/stack"
+	errtest "github.com/terramate-io/terramate/test/errors"
+	"github.com/terramate-io/terramate/test/sandbox"
+)
+
+func TestExperimentalInitModuleAtRoot(t *testing.T) {
+	s := sandbox.New(t)
+	s.BuildTree([]string{
+		`f:main.tf:terraform {
+			backend "remote" {
+				attr = "value"
+			}
+		}`,
+		`f:README.md:# My module`,
+	})
+	tm := newCLI(t, s.RootDir())
+	assertRunResult(t,
+		tm.run("experimental", "init", "--all-terraform"),
+		runExpected{
+			Stdout: "Created stack /\n",
+		},
+	)
+	_, err := os.Lstat(filepath.Join(s.RootDir(), stack.DefaultFilename))
+	assert.NoError(t, err)
+}
+
+func TestExperimentalInitModuleDeepDownInTheTree(t *testing.T) {
+	testCase := func(t *testing.T, generate bool) {
+		s := sandbox.New(t)
+		backendContent := `terraform {
+		backend "remote" {
+			attr = "value"
+		}
+	}
+	`
+		s.BuildTree([]string{
+			`f:prod/stacks/k8s-stack/deployment.yml:# empty file`,
+			`f:prod/stacks/A/anyfile.tf:` + backendContent,
+			`f:prod/stacks/A/README.md:# empty`,
+			`f:prod/stacks/B/main.tf:` + backendContent,
+			`f:prod/stacks/A/other-stack/main.tf:` + backendContent,
+			`f:README.md:# My module`,
+			`f:generate.tm:generate_hcl "_generated.tf" {
+			content {
+				test = 1
+			}
+		}`,
+		})
+		tm := newCLI(t, s.RootDir())
+		args := []string{"experimental", "init", "--all-terraform"}
+		if !generate {
+			args = append(args, "--no-generate")
+		}
+		assertRunResult(t,
+			tm.run(args...),
+			runExpected{
+				Stdout: `Created stack /prod/stacks/A
+Created stack /prod/stacks/A/other-stack
+Created stack /prod/stacks/B
+`,
+			},
+		)
+
+		for _, path := range []string{
+			"/prod/stacks/A",
+			"/prod/stacks/B",
+			"/prod/stacks/A/other-stack",
+		} {
+			stackPath := filepath.Join(s.RootDir(), path)
+			_, err := os.Lstat(filepath.Join(stackPath, stack.DefaultFilename))
+			assert.NoError(t, err)
+
+			_, err = os.Lstat(filepath.Join(stackPath, "_generated.tf"))
+			if generate {
+				assert.NoError(t, err)
+			} else {
+				errtest.Assert(t, err, os.ErrNotExist)
+			}
+		}
+	}
+
+	t.Run("with generation", func(t *testing.T) {
+		testCase(t, true)
+	})
+
+	t.Run("without generation", func(t *testing.T) {
+		testCase(t, false)
+	})
+}

--- a/cmd/terramate/e2etests/init_test.go
+++ b/cmd/terramate/e2etests/init_test.go
@@ -1,3 +1,6 @@
+// Copyright 2023 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
 package e2etest
 
 import (

--- a/cmd/terramate/e2etests/init_test.go
+++ b/cmd/terramate/e2etests/init_test.go
@@ -43,13 +43,23 @@ func TestExperimentalInitModuleDeepDownInTheTree(t *testing.T) {
 			attr = "value"
 		}
 	}
+
 	`
+
+		const providerContent = `
+		provider "aws" {
+			attr = 1
+		}
+	`
+
+		const mixedBackendProvider = backendContent + providerContent
+
 		s.BuildTree([]string{
 			`f:prod/stacks/k8s-stack/deployment.yml:# empty file`,
 			`f:prod/stacks/A/anyfile.tf:` + backendContent,
 			`f:prod/stacks/A/README.md:# empty`,
-			`f:prod/stacks/B/main.tf:` + backendContent,
-			`f:prod/stacks/A/other-stack/main.tf:` + backendContent,
+			`f:prod/stacks/B/main.tf:` + providerContent,
+			`f:prod/stacks/A/other-stack/main.tf:` + mixedBackendProvider,
 			`f:README.md:# My module`,
 			`f:generate.tm:generate_hcl "_generated.tf" {
 			content {

--- a/cmd/terramate/e2etests/runner_test.go
+++ b/cmd/terramate/e2etests/runner_test.go
@@ -268,7 +268,7 @@ func assertRunResult(t *testing.T, got runResult, want runExpected) {
 			}
 		} else {
 			if diff := cmp.Diff(wantStdout, stdout); diff != "" {
-				t.Errorf("stdout mismatch: %s", diff)
+				t.Errorf("stdout mismatch (-want +got): %s", diff)
 			}
 		}
 	}

--- a/stack/create.go
+++ b/stack/create.go
@@ -117,5 +117,5 @@ func Create(root *config.Root, stack config.Stack, imports ...string) (err error
 		return errors.E(err, "writing stack imports to stack file")
 	}
 
-	return root.LoadSubTree(stack.Dir)
+	return nil
 }

--- a/tf/terraform.go
+++ b/tf/terraform.go
@@ -98,6 +98,8 @@ func ParseModules(path string) ([]Module, error) {
 	return modules, nil
 }
 
+// FileHasBackend tells if the file defined by path has a terraform.backend
+// block definition.
 func FileHasBackend(path string) (bool, error) {
 	logger := log.With().
 		Str("action", "HasBackend").

--- a/tf/terraform.go
+++ b/tf/terraform.go
@@ -98,7 +98,7 @@ func ParseModules(path string) ([]Module, error) {
 	return modules, nil
 }
 
-func HasBackend(path string) (bool, error) {
+func FileHasBackend(path string) (bool, error) {
 	logger := log.With().
 		Str("action", "HasBackend").
 		Logger()

--- a/tf/terraform_test.go
+++ b/tf/terraform_test.go
@@ -249,6 +249,70 @@ func TestTerraformHasBackend(t *testing.T) {
 				hasBackend: false,
 			},
 		},
+		{
+			name: "terraform block with no backend",
+			layout: []string{
+				tfFileLayout(`terraform {}`),
+			},
+			want: want{
+				hasBackend: false,
+			},
+		},
+		{
+			name: "terraform block with unrecognized blocks",
+			layout: []string{
+				tfFileLayout(`terraform {
+					abc {}
+					xyz {
+						a = 1
+					}
+				}`),
+			},
+			want: want{
+				hasBackend: false,
+			},
+		},
+		{
+			name: "terraform block with a single backend",
+			layout: []string{
+				tfFileLayout(`terraform {
+					abc "label" {}
+					xyz {
+						a = 1
+					}
+
+					backend {
+						a = 1
+					}
+
+					xpto {
+						c = 1
+					}
+				}`),
+			},
+			want: want{
+				hasBackend: true,
+			},
+		},
+		{
+			name: "terraform block with multiple backends",
+			layout: []string{
+				tfFileLayout(`terraform {
+					backend "a" {
+						a = 1
+					}
+					backend "b" {
+						a = 1
+					}
+					backend "c" {
+						a = 1
+					}
+				}`),
+			},
+			want: want{
+				hasBackend: true,
+			},
+		},
 	} {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {

--- a/tf/terraform_test.go
+++ b/tf/terraform_test.go
@@ -322,7 +322,7 @@ func TestTerraformHasBackend(t *testing.T) {
 			s.BuildTree(tc.layout)
 
 			path := filepath.Join(s.RootDir(), filename)
-			hasBackend, err := tf.HasBackend(path)
+			hasBackend, err := tf.FileHasBackend(path)
 			errtest.Assert(t, err, tc.want.err)
 
 			if err != nil {


### PR DESCRIPTION
Implements the command `terramate experimental init`.
For now, it requires a `--all-terraform` flag which initialize Terraform stacks.
In the future additional flags would be created to initialize Terragrunt, Kubernetes, etc.
