### PR TITLE
chore: make error message in case no terramate project has been detected more explicit

### DIFF
--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -445,7 +445,7 @@ func newCLI(version string, args []string, stdin io.Reader, stdout, stderr io.Wr
 	}
 
 	if !foundRoot {
-		log.Fatal().Msg("Project root not found. Please run Terramate in a git repository or specify the project root by creating terramate.tm.hcl. For details please see https://terramate.io/docs/cli/configuration/project-config#project-configuration.")
+		log.Fatal().Msg("Project root not found. If you invoke Terramate inside a Git repository, Terramate will automatically assume the top level of your repository as the project root. If you use Terramate in a directory that isn't a Git repository, you must configure the project root by creating a terramate.tm.hcl configuration in the directory you wish to be the top-level of your Terramate project. For details please see https://terramate.io/docs/cli/configuration/project-config#project-configuration.")
 	}
 
 	logger.Trace().Msg("Set defaults from parsed command line arguments.")


### PR DESCRIPTION
Makes the exception returned by Terramate CLI if no project is detected even more explicit.
