### PR TITLE
Update Ubuntu LTS and add Git to the Dockerfile

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -3,12 +3,12 @@ title: Installation | Terramate
 description: Terramate adds powerful capabilities such as code generation, stacks, orchestration, change detection, data sharing and more to Terraform.
 
 prev:
-  text: 'About Stacks'
-  link: '/about-stacks'
+  text: "About Stacks"
+  link: "/about-stacks"
 
 next:
-  text: 'Getting Started'
-  link: '/getting-started'
+  text: "Getting Started"
+  link: "/getting-started"
 ---
 
 # Installation
@@ -66,7 +66,7 @@ To install Terramate using a release binary, follow these steps:
 ## Using Docker
 
 If you prefer not to install Terramate directly on your host system,
-you can use either [Docker](<https://www.docker.com/>) or [Podman](https://podman.io/) to run Terramate within a container.
+you can use either [Docker](https://www.docker.com/) or [Podman](https://podman.io/) to run Terramate within a container.
 
 To do so, execute the following command:
 
@@ -76,6 +76,18 @@ docker run ghcr.io/terramate-io/terramate
 
 We also provide container images tagged with specific release versions.
 To view a list of available container image tags, visit this [link](https://github.com/terramate-io/terramate/pkgs/container/terramate/versions).
+
+**Note:** Our image doesn't come with additional dependencies such as Terraform. We recommend building
+your own image by using our image as the base image to install additional dependencies required.
+
+We recommend mounting your Terramate project as a Docker mount volume to use it inside the container.
+Depending on your setup, you should set the correct permissions when running the container.
+
+```sh
+docker run -it -u $(id -u ${USER}):$(id -g ${USER}) \
+  -v /some/repo:/some/repo \
+  ghcr.io/terramate-io/terramate:latest -C /some/repo --changed run -- cmd
+```
 
 ## Auto Completion
 

--- a/hack/release/Dockerfile
+++ b/hack/release/Dockerfile
@@ -5,4 +5,6 @@ FROM ubuntu:22.04
 
 COPY terramate /usr/local/bin/terramate
 
+RUN apt-get -y update && apt-get install -y git
+
 ENTRYPOINT ["terramate"]

--- a/hack/release/Dockerfile
+++ b/hack/release/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright 2023 Terramate GmbH
 # SPDX-License-Identifier: MPL-2.0
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 COPY terramate /usr/local/bin/terramate
 


### PR DESCRIPTION
# Reason for This Change

Our Dockerfile is based on an outdated version of Ubuntu and missed Git as a dependency.

## Description of Changes

Updates ubuntu to current LTS `22.04` and adds Git as a dependency.
