### PR TITLE
feat:  experimental ensure-stack-id command

### DIFF
--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -205,7 +205,7 @@ type cliSpec struct {
 		} `cmd:"" help:"Terramate Cloud commands"`
 
 		EnsureStackID struct {
-		} `cmd:"" help:"generate stack.id for all stacks which does not define it"`
+		} `cmd:"" help:"generate an UUID for the stack.id of all stacks which does not define it"`
 	} `cmd:"" help:"Experimental features (may change or be removed in the future)"`
 }
 

--- a/cmd/terramate/e2etests/exp_ensure_stack_id_test.go
+++ b/cmd/terramate/e2etests/exp_ensure_stack_id_test.go
@@ -1,0 +1,83 @@
+// Copyright 2023 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+package e2etest
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/terramate-io/terramate/test/sandbox"
+)
+
+func TestEnsureStackID(t *testing.T) {
+	type testcase struct {
+		name   string
+		layout []string
+		wd     string
+	}
+
+	for _, tc := range []testcase{
+		{
+			name: "single stack at root with id",
+			layout: []string{
+				`s:.:id=test`,
+			},
+		},
+		{
+			name: "single stack at root without id",
+			layout: []string{
+				`s:.`,
+			},
+		},
+		{
+			name: "single stack at root without id but wd not at root",
+			layout: []string{
+				`d:some/deep/dir/for/test`,
+				`s:.`,
+			},
+			wd: `/some/deep/dir/for/test`,
+		},
+		{
+			name: "mix of multiple stacks with and without id",
+			layout: []string{
+				`s:s1`,
+				`s:s1/a1:id=test`,
+				`s:s2`,
+				`s:s3/a3:id=test2`,
+				`s:s3/a1`,
+				`s:a/b/c/d/e/f/g/h/stack`,
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			testEnsureStackID(t, tc.wd, tc.layout)
+		})
+	}
+}
+
+func testEnsureStackID(t *testing.T, wd string, layout []string) {
+	s := sandbox.New(t)
+	s.BuildTree(layout)
+	if wd == "" {
+		wd = s.RootDir()
+	} else {
+		wd = filepath.Join(s.RootDir(), filepath.FromSlash(wd))
+	}
+	tm := newCLI(t, wd)
+	assertRunResult(
+		t,
+		tm.run("experimental", "ensure-stack-id"),
+		runExpected{
+			Status:       0,
+			IgnoreStdout: true,
+		},
+	)
+
+	s.ReloadConfig()
+	for _, stackElem := range s.LoadStacks() {
+		if stackElem.ID == "" {
+			t.Fatalf("stack.id not generated for stack %s", stackElem.Dir())
+		}
+	}
+}

--- a/stack/clone.go
+++ b/stack/clone.go
@@ -85,6 +85,9 @@ func filterDotFiles(_ string, entry os.DirEntry) bool {
 	return !strings.HasPrefix(entry.Name(), ".")
 }
 
+// UpdateStackID updates the stack.id of the given stack directory.
+// The functions updates just the file which defines the stack block.
+// The updated file will lose all comments.
 func UpdateStackID(stackdir string) (string, error) {
 	logger := log.With().
 		Str("action", "stack.updateStackID()").

--- a/stack/clone.go
+++ b/stack/clone.go
@@ -116,6 +116,13 @@ func UpdateStackID(stackdir string) (string, error) {
 		return "", errors.E("stack does not have a stack block")
 	}
 
+	st, err := os.Lstat(stackFilePath)
+	if err != nil {
+		return "", errors.E(err, "stating the stack file")
+	}
+
+	originalFileMode := st.Mode()
+
 	// Parsing HCL always delivers an AST that
 	// has no comments on it, so building a new HCL file from the parsed
 	// AST will lose all comments from the original code.
@@ -155,10 +162,7 @@ func UpdateStackID(stackdir string) (string, error) {
 
 		logger.Trace().Msg("saving updated file")
 
-		// TODO(i4k): improve this.
-		// Since we just created the stack files they have the default
-		// permissions given by Go on os.Create, 0666.
-		err = os.WriteFile(stackFilePath, parsed.Bytes(), 0666)
+		err = os.WriteFile(stackFilePath, parsed.Bytes(), originalFileMode)
 		if err != nil {
 			return "", err
 		}

--- a/stack/clone.go
+++ b/stack/clone.go
@@ -73,7 +73,7 @@ func Clone(root *config.Root, destdir, srcdir string) error {
 	}
 
 	logger.Trace().Msg("stack has ID, updating ID of the cloned stack")
-	err = updateStackID(destdir)
+	_, err = UpdateStackID(destdir)
 	if err != nil {
 		return err
 	}
@@ -85,7 +85,7 @@ func filterDotFiles(_ string, entry os.DirEntry) bool {
 	return !strings.HasPrefix(entry.Name(), ".")
 }
 
-func updateStackID(stackdir string) error {
+func UpdateStackID(stackdir string) (string, error) {
 	logger := log.With().
 		Str("action", "stack.updateStackID()").
 		Str("stack", stackdir).
@@ -95,78 +95,74 @@ func updateStackID(stackdir string) error {
 
 	parser, err := hcl.NewTerramateParser(stackdir, stackdir)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	if err := parser.AddDir(stackdir); err != nil {
-		return err
+		return "", err
 	}
 
 	if err := parser.Parse(); err != nil {
-		return err
+		return "", err
 	}
 
 	logger.Trace().Msg("finding file containing stack definition")
 
 	stackFilePath := getStackFilepath(parser)
 	if stackFilePath == "" {
-		return errors.E("cloned stack does not have a stack block")
+		return "", errors.E("stack does not have a stack block")
 	}
 
 	// Parsing HCL always delivers an AST that
 	// has no comments on it, so building a new HCL file from the parsed
 	// AST will lose all comments from the original code.
 
-	logger.Trace().Msg("reading cloned stack file")
+	logger.Trace().Msg("reading stack file")
 
 	stackContents, err := os.ReadFile(stackFilePath)
 	if err != nil {
-		return errors.E(err, "reading cloned stack definition file")
+		return "", errors.E(err, "reading stack definition file")
 	}
 
-	logger.Trace().Msg("parsing cloned stack file")
+	logger.Trace().Msg("parsing stack file")
 
 	parsed, diags := hclwrite.ParseConfig([]byte(stackContents), stackFilePath, hhcl.InitialPos)
 	if diags.HasErrors() {
-		return errors.E(diags, "parsing cloned stack configuration")
+		return "", errors.E(diags, "parsing stack configuration")
 	}
 
 	blocks := parsed.Body().Blocks()
 
 	logger.Trace().Msg("searching for stack ID attribute")
 
-updateStackID:
 	for _, block := range blocks {
 		if block.Type() != hcl.StackBlockType {
 			continue
 		}
 
-		body := block.Body()
-		attrs := body.Attributes()
-		for name := range attrs {
-			if name != "id" {
-				continue
-			}
-
-			id, err := uuid.NewRandom()
-			if err != nil {
-				return errors.E(err, "creating new ID for cloned stack")
-			}
-
-			logger.Trace().
-				Str("newID", id.String()).
-				Msg("found stack ID attribute, updating")
-
-			body.SetAttributeValue(name, cty.StringVal(id.String()))
-			break updateStackID
+		uuid, err := uuid.NewRandom()
+		if err != nil {
+			return "", errors.E(err, "creating new ID for stack")
 		}
+
+		id := uuid.String()
+
+		body := block.Body()
+		body.SetAttributeValue("id", cty.StringVal(id))
+
+		logger.Trace().Msg("saving updated file")
+
+		// TODO(i4k): improve this.
+		// Since we just created the stack files they have the default
+		// permissions given by Go on os.Create, 0666.
+		err = os.WriteFile(stackFilePath, parsed.Bytes(), 0666)
+		if err != nil {
+			return "", err
+		}
+		return id, nil
 	}
 
-	logger.Trace().Msg("saving updated file")
-
-	// Since we just created the clones stack files they have the default
-	// permissions given by Go on os.Create, 0666.
-	return os.WriteFile(stackFilePath, parsed.Bytes(), 0666)
+	return "", errors.E("stack block not found")
 }
 
 func getStackFilepath(parser *hcl.TerramateParser) string {


### PR DESCRIPTION
This command generates a random UUID for the `stack.id` of each stack which does not define it.