### PR TITLE
feat!: make stack.id case insensitive

### DIFF
--- a/cloud/types.go
+++ b/cloud/types.go
@@ -5,6 +5,7 @@ package cloud
 
 import (
 	"bytes"
+	"strings"
 
 	"github.com/terramate-io/terramate/errors"
 )
@@ -189,6 +190,9 @@ func (d DeploymentStackRequest) Validate() error {
 	}
 	if d.MetaID == "" {
 		return errors.E(`missing "meta_id" field`)
+	}
+	if strings.ToLower(d.MetaID) != d.MetaID {
+		return errors.E(`"meta_id" requires a lowercase string but %s provided`, d.MetaID)
 	}
 	if d.DeploymentCommand == "" {
 		return errors.E(`missing "deployment_cmd" field`)

--- a/cmd/terramate/cli/cloud.go
+++ b/cmd/terramate/cli/cloud.go
@@ -295,7 +295,7 @@ func (c *cli) createCloudDeployment(stacks config.List[*config.SortableStack], c
 			tags = []string{}
 		}
 		payload.Stacks = append(payload.Stacks, cloud.DeploymentStackRequest{
-			MetaID:            s.ID,
+			MetaID:            strings.ToLower(s.ID),
 			MetaName:          s.Name,
 			MetaDescription:   s.Description,
 			MetaTags:          tags,

--- a/cmd/terramate/e2etests/run_cloud_test.go
+++ b/cmd/terramate/e2etests/run_cloud_test.go
@@ -226,7 +226,7 @@ func TestCLIRunWithCloudSync(t *testing.T) {
 						if strings.Contains(layout, "id=") {
 							t.Fatalf("testcases should not contain stack IDs but found %s", layout)
 						}
-						id := strings.Replace(layout[2:]+"-id-"+t.Name(), "/", "-", -1)
+						id := strings.ToLower(strings.Replace(layout[2:]+"-id-"+t.Name(), "/", "-", -1))
 						if len(id) > 64 {
 							id = id[:64]
 						}
@@ -438,7 +438,7 @@ func assertRunEvents(t *testing.T, runid string, ids []string, events map[string
 	for stackpath, ev := range events {
 		found := false
 		for _, id := range ids {
-			if strings.HasPrefix(id, strings.ReplaceAll(stackpath+"-id-", "/", "-")) {
+			if strings.HasPrefix(id, strings.ToLower(strings.ReplaceAll(stackpath+"-id-", "/", "-"))) {
 				expectedEvents[id] = ev
 				found = true
 				break

--- a/config/stack.go
+++ b/config/stack.go
@@ -326,7 +326,7 @@ func LoadAllStacks(cfg *Tree) (List[*SortableStack], error) {
 
 		if stack.ID != "" {
 			logger.Trace().Msg("stack has ID, checking for duplicate")
-			if otherStack, ok := stacksIDs[stack.ID]; ok {
+			if otherStack, ok := stacksIDs[strings.ToLower(stack.ID)]; ok {
 				return List[*SortableStack]{}, errors.E(ErrStackDuplicatedID,
 					"stack %q and %q have same ID %q",
 					stack.Dir,
@@ -334,7 +334,7 @@ func LoadAllStacks(cfg *Tree) (List[*SortableStack], error) {
 					stack.ID,
 				)
 			}
-			stacksIDs[stack.ID] = stack
+			stacksIDs[strings.ToLower(stack.ID)] = stack
 		}
 	}
 

--- a/docs/stacks/index.md
+++ b/docs/stacks/index.md
@@ -72,8 +72,8 @@ Some of these properties include:
 ## stack.id (string)(optional)
 
 The stack ID **must** be a string composed of alphanumeric chars + `-` + `_`.
-The ID can't be bigger than 64 bytes and **must** be unique on the
-whole project.
+The ID can't be bigger than 64 bytes, **it's case insensitive** and
+**must** be unique on the whole project.
 
 There is no default value determined for the stack ID.
 

--- a/stack/stack_test.go
+++ b/stack/stack_test.go
@@ -16,8 +16,8 @@ import (
 func TestLoadAllFailsIfStacksIDIsNotUnique(t *testing.T) {
 	s := sandbox.New(t)
 	s.BuildTree([]string{
-		"s:stacks/stack-1:id=id",
-		"s:stacks/stack-2:id=id",
+		"s:stacks/stack-1:id=terramate",
+		"s:stacks/stack-2:id=TerraMate",
 	})
 	cfg, err := config.LoadTree(s.RootDir(), s.RootDir())
 	assert.NoError(t, err)


### PR DESCRIPTION
**breaking change**: The handling of `stack.id` is now case-insensitive, which means that the ids `my-id`, `My-id`, `MY-id`, `MY-Id`, etc, all represent the same id.
The Terramate CLI is going to treat them as lowercase internally and in the cloud.