### PR TITLE
fix: handle OIDC trusted status

### DIFF
--- a/cmd/terramate/cli/cloud.go
+++ b/cmd/terramate/cli/cloud.go
@@ -86,7 +86,7 @@ func (c *cli) checkSyncDeployment() {
 		var useOrgUUID string
 		for _, org := range orgs {
 			if org.Name == useOrgName {
-				if org.Status != "active" {
+				if org.Status != "active" && org.Status != "trusted" {
 					fatal(errors.E("You are not yet an active member of organization %s. Please accept the invitation first.", useOrgName))
 				}
 
@@ -109,7 +109,7 @@ func (c *cli) checkSyncDeployment() {
 		)
 	} else {
 		org := orgs[0]
-		if org.Status != "active" {
+		if org.Status != "active" && org.Status != "trusted" {
 			fatal(errors.E("You are not yet an active member of organization %s. Please accept the invitation first.", org.Name))
 		}
 		c.cloud.run.orgUUID = org.UUID

--- a/cmd/terramate/cli/cloud_credential_github.go
+++ b/cmd/terramate/cli/cloud_credential_github.go
@@ -181,7 +181,7 @@ func (g *githubOIDC) Info() {
 		panic(errors.E(errors.ErrInternal, "cred.Info() called for unvalidated credential"))
 	}
 
-	if len(g.orgs) > 0 {
+	if len(g.orgs) > 0 && g.orgs[0].Status == "trusted" {
 		g.output.MsgStdOut("status: signed in")
 	} else {
 		g.output.MsgStdOut("status: untrusted")


### PR DESCRIPTION
In the case of `Github OIDC` the organization status is `trusted` and it was not handled.
