### PR TITLE
Add cookie manager to documentation website

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -25,6 +25,17 @@ export default defineConfig({
         },
       ],
       [
+        'script',
+        {
+          'type': 'text/javascript',
+          'data-cmp-ab': '1',
+          'src': 'https://cdn.consentmanager.net/delivery/autoblocking/549c07dafc3a.js',
+          'data-cmp-host': 'd.delivery.consentmanager.net',
+          'data-cmp-cdn': 'cdn.consentmanager.net',
+          'data-cmp-codesrc': '1',
+        },
+      ],
+      [
         'link',
         {
           rel: 'apple-touch-icon',


### PR DESCRIPTION
# Reason for This Change

Previously we didn't have any GDPR compliant consent on the website.

## Description of Changes

This adds the Consentmanager integration to the website for users to opt in and out for tracking such as HubSpot.