### PR TITLE
Move cookie integration to google tag manager

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -24,16 +24,12 @@ export default defineConfig({
           )}`,
         },
       ],
+      // Google Tag Manager
       [
         'script',
-        {
-          'type': 'text/javascript',
-          'data-cmp-ab': '1',
-          'src': 'https://cdn.consentmanager.net/delivery/autoblocking/549c07dafc3a.js',
-          'data-cmp-host': 'd.delivery.consentmanager.net',
-          'data-cmp-cdn': 'cdn.consentmanager.net',
-          'data-cmp-codesrc': '1',
-        },
+        { id: 'register-gtm' },
+        // eslint-disable-next-line @typescript-eslint/quotes
+        `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0], j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src= 'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f); })(window,document,'script','dataLayer','GTM-5KZT64L');`,
       ],
       [
         'link',

--- a/docs/.vitepress/theme/Layout.vue
+++ b/docs/.vitepress/theme/Layout.vue
@@ -1,0 +1,18 @@
+<script setup>
+import DefaultTheme from 'vitepress/theme'
+
+const { Layout } = DefaultTheme
+</script>
+
+<template>
+  <Layout>
+    <template #layout-top>
+      <!-- Google Tag Manager (noscript) -->
+      <noscript>
+        <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5KZT64L" height="0" width="0" style="display:none;visibility:hidden">
+        </iframe>
+      </noscript>
+      <!-- End Google Tag Manager (noscript) -->
+    </template>
+  </Layout>
+</template>


### PR DESCRIPTION
# Reason for This Change

Previously we used ConsentManager - however the solution doesn't scale for multiple tags.

## Description of Changes

Moving to Google Tag Manager to programmatically manage tags.
