### PR TITLE
Add a descriptive page title to the documentation page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,10 @@
 ---
 layout: home
 
-description: Terramate adds powerful capabilities such as code generation, stacks, orchestration, change detection, data sharing and more to Terraform.
+title: 'Terramate: Supercharge Terraform with Stacks and Code Generation'
+titleTemplate: false
+description: Terramate adds powerful capabilities such as stacks, code generation, orchestration, change detection, data sharing and more to Terraform.
+
 hero:
   name: Terramate
   text: Code Generator and Orchestrator for Terraform


### PR DESCRIPTION
# Reason for This Change

Prior to this PR the documentation landing page had the title 'Terramate | Terramate'

## Description of Changes

This PR changes the title to 'Terramate: Supercharge Terraform with Stacks and Code Generation' which is SEO and human friendly.
