### PR TITLE
Add introduction page to documentation

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -10,6 +10,7 @@ function getPath(path: string) {
 // https://vitepress.dev/reference/site-config
 export default defineConfig({
   title: 'Terramate',
+  // titleTemplate: ':title - Terramate',
   description:
     'Terramate adds powerful capabilities such as code generation, stacks, orchestration, change detection, data sharing and more to Terraform.',
   cleanUrls: true,
@@ -112,7 +113,7 @@ export default defineConfig({
 
     // https://vitepress.dev/reference/default-theme-config
     nav: [
-      { text: 'Docs', link: '/about-stacks' },
+      { text: 'Docs', link: '/introduction' },
       { text: 'Blog', link: 'https://blog.terramate.io/' },
       { text: 'We are hiring!', link: 'https://jobs.ashbyhq.com/terramate' },
       {
@@ -124,25 +125,19 @@ export default defineConfig({
 
     sidebar: [
       {
-        text: '👋 What is Terramate',
+        text: '👋 Get Started',
         collapsed: false,
         items: [
-          { text: 'Overview', link: '/' },
-          { text: 'About Stacks', link: 'about-stacks' },
-        ],
-      },
-      {
-        text: '🛠️ Getting Started',
-        collapsed: false,
-        items: [
+          { text: 'Introduction', link: 'introduction' },
           { text: 'Installation', link: 'installation' },
-          { text: 'Quick Start', link: 'getting-started/' },
+          { text: 'Quickstart', link: 'getting-started/' },
         ],
       },
       {
         text: '📚 Stacks',
         collapsed: false,
         items: [
+          { text: 'About Stacks', link: 'about-stacks' },
           { text: 'Stack Configuration', link: 'stacks/' },
           { text: 'Orchestration', link: 'orchestration/' },
           { text: 'Tag Filter', link: 'tag-filter' },

--- a/docs/about-stacks.md
+++ b/docs/about-stacks.md
@@ -3,12 +3,12 @@ title: An introduction to Stacks
 description: Terramate adds powerful capabilities such as code generation, stacks, orchestration, change detection, data sharing and more to Terraform.
 
 prev:
-  text: 'Overview'
-  link: '/'
+  text: 'Quickstart'
+  link: '/getting-started/'
 
 next:
-  text: 'Installation'
-  link: '/installation'
+  text: 'Stacks Configuration'
+  link: '/stacks/'
 ---
 
 # About Stacks

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,19 +1,17 @@
 ---
-title: Getting Started
-description: Terramate adds powerful capabilities such as code generation, stacks, orchestration, change detection, data sharing and more to Terraform.
+title: Quickstart
+description: Learn about the basic concepts such as stacks in Terramate and how a filesystem-oriented code generator can improve the management of your Terraform code efficiently.
 
 prev:
   text: "Installation"
   link: "/installation"
 
 next:
-  text: "Stack Configuration"
-  link: "/stacks/"
+  text: "About Stacks"
+  link: "/about-stacks"
 ---
 
-# Getting Started
-
-[Terramate](https://github.com/mineiros-io/terramate) is a [code generator and orchestrator for Terraform](https://blog.terramate.io/product-introduction-github-as-code-af466550a4a9?source=friends_link&sk=ae60be77dcb484724b3b821898e7813d) that adds powerful capabilities such as code generation, stacks, orchestration, change detection, data sharing and more to Terraform.
+# Quickstart
 
 This tutorial aims to introduce you to the basic concepts of [Terramate](https://github.com/terramate-io/terramate), and demonstrate how a filesystem-oriented code generator can improve the management of your Terraform code efficiently.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,14 +1,14 @@
 ---
-title: Installation
-description: Terramate adds powerful capabilities such as code generation, stacks, orchestration, change detection, data sharing and more to Terraform.
+title: How to Install
+description: You can easily install Terramate with Go or package managers such as brew. You can also run Terramate with Docker by building on top of our pre-configured image.
 
 prev:
-  text: "About Stacks"
-  link: "/about-stacks"
+  text: "Introduction"
+  link: "/introduction"
 
 next:
-  text: "Getting Started"
-  link: "/getting-started"
+  text: "Quickstart"
+  link: "/getting-started/"
 ---
 
 # Installation

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -1,0 +1,47 @@
+---
+title: Overview
+description: Terramate supercharges Terraform with Stacks, Orchestration, Git Integration, Code Generation, Data Sharing and more 🦄
+
+next:
+  text: 'Installation'
+  link: '/installation'
+---
+
+# Introduction
+
+Terramate supercharges Terraform with Stacks, Orchestration, Git Integration, Code Generation, Data Sharing and more.🦄
+It focuses on improving the Developer Experience (DX), providing workflows, and lowering the time spent writing and maintaining infrastructure code for projects at any scale.
+
+Compared to other prominent tooling in the market, **Terramate always generates native Terraform code**
+that integrates with existing tooling such as Terraform Cloud, Env0, Spacelift, Terragrunt, and others.
+
+The main benefits of Terramate CLI are:
+
+1. **Stacks**: are isolated and independent units that contain infrastructure code such as Terraform,
+Kubernetes Manifests and others. Stacks help you to split your monolithic IaC projects into smaller units
+to reduce the blast radius, speed up execution time, provide clear ownership and better collaboration.
+
+2. **Orchestration**: helps define the order of execution of commands such as `terraform plan|apply` in a selected
+range of stacks. You can use orchestration to define the order of execution based on criteria such as tags or stacks
+that contain changes.
+
+3. **Git Integration**: allows you to execute commands (such as `terraform apply`) only against the stacks that have changed.
+workflow and CI/CD pipelines and comes with advanced functionality, such as module change detection for Terraform stacks.
+
+4. **Code Generation**: keep your Terraform DRY and maintainable by programmatically generating Terraform backend and provider
+configurations. You can also provide blueprints for your teams to create stacks with pre-configured infrastructure.
+
+5. **Data Sharing**: define data once and inherit, extend or overwrite it in your hierarchy of stacks. Extremely useful for
+setting values such as tags or environments used in multiple stacks.
+
+## Get started
+
+To install Terramate please see the [Installation](https://terramate.io/docs/cli/installation) page in the documentation.
+
+We recommend following our [Getting Started](https://terramate.io/docs/cli/getting-started/) guide to familiarize yourself
+with the fundamentals by building your first Terramate project.
+
+## Community
+
+Join us on [GitHub](https://github.com/terramate-io/terramate) or [Discord](https://terramate.io/discord) to ask
+questions, share feedback, meet other developers building with Terramate, and dream about the future of IaC.


### PR DESCRIPTION
# Reason for This Change

Currently we don't have an overview/ introduction page in the documentation. Developers don't really feel well guided through the docs.

## Description of Changes

This PR introduces a new documentation page called introduction that explains Terramate, the value prop and a quick overview. In a follow up PR we will add uses case and more references to articles and guides.
