### PR TITLE
fix: cloud info panics if cloud features are disabled

### DIFF
--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -36,7 +36,7 @@ const (
 const ErrUnexpectedStatus errors.Kind = "unexpected status code"
 
 // ErrNotFound indicates the requested resource does not exist in the server.
-const ErrNotFound errors.Kind = "resource not found"
+const ErrNotFound errors.Kind = "resource not found (HTTP Status 404)"
 
 // ErrUnexpectedResponseBody indicates the server responded with an unexpected body.
 const ErrUnexpectedResponseBody errors.Kind = "unexpected API response body"

--- a/cmd/terramate/cli/cloud.go
+++ b/cmd/terramate/cli/cloud.go
@@ -372,6 +372,9 @@ func (c *cli) cloudInfo() {
 	if err != nil {
 		fatal(err)
 	}
+	if c.cloud.disabled {
+		fatal(errors.E("unable to provide credential info"))
+	}
 	c.cred().Info()
 	// verbose info
 	c.cloud.output.MsgStdOutV("next token refresh in: %s", time.Until(c.cred().ExpireAt()))


### PR DESCRIPTION
When the cloud features are disabled, the `terramate experimental cloud info` gives the panic below:

```
2023-07-19T12:19:16+01:00 WRN disabling the cloud features error="resource not found: failed to check if credentials work: GET http://localhost:8080/v1/memberships"
panic: terramate internal error: cred.Info() called for unvalidated credential

goroutine 1 [running]:
github.com/terramate-io/terramate/cmd/terramate/cli.(*googleCredential).Info(0xc000004300?)
	/home/i4k/src/terramate-io/terramate/cmd/terramate/cli/cloud_credential_google.go:623 +0x874
github.com/terramate-io/terramate/cmd/terramate/cli.(*cli).cloudInfo(0xc000004300)
	/home/i4k/src/terramate-io/terramate/cmd/terramate/cli/cloud.go:357 +0x82
github.com/terramate-io/terramate/cmd/terramate/cli.(*cli).run(0xc000004300)
	/home/i4k/src/terramate-io/terramate/cmd/terramate/cli/cli.go:560 +0x755
github.com/terramate-io/terramate/cmd/terramate/cli.Exec({0xb3c55c, 0x9}, {0xc0000240b0, 0x4, 0x4}, {0xc72c00, 0xc000014010}, {0xc72c40, 0xc000014018}, {0xc72c40, ...})
	/home/i4k/src/terramate-io/terramate/cmd/terramate/cli/cli.go:239 +0x10a
main.main()
	/home/i4k/src/terramate-io/terramate/cmd/terramate/main.go:20 +0x90
```

With this change it aborts with the logging below:

```
2023-07-19T12:20:28+01:00 WRN disabling the cloud features error="resource not found: failed to check if credentials work: GET http://localhost:8080/v1/memberships"
2023-07-19T12:20:28+01:00 FTL unable to provide credential info
```
