### PR TITLE
Fix link to linkedin page

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -254,7 +254,7 @@ export default defineConfig({
       { icon: 'github', link: 'https://github.com/terramate-io/terramate' },
       { icon: 'discord', link: 'https://terramate.io/discord' },
       { icon: 'twitter', link: 'https://twitter.com/terramateio' },
-      { icon: 'linkedin', link: 'https://www.linkedin.com/company/terramate' },
+      { icon: 'linkedin', link: 'https://www.linkedin.com/company/terramate-io/' },
     ],
   },
 })


### PR DESCRIPTION
# Reason for This Change

Currently we have a dead link in the linkedin icon on the documentation page.

## Description of Changes

This PR fixes the link to point to the right location.
