### PR TITLE
Add documentation for the terramate generate command

### DIFF
--- a/docs/cmdline/generate.md
+++ b/docs/cmdline/generate.md
@@ -1,0 +1,20 @@
+---
+title: terramate generate - Command
+description: With the terramate generate command Terramate will generate all files.
+
+prev:
+  text: 'Stacks'
+  link: '/stacks/'
+
+next:
+  text: 'Sharing Data'
+  link: '/data-sharing/'
+---
+
+# Generate
+
+The `generate` command generates files for all code generation strategies. For an overview of code generation strategies available please see the [code generation documentation](../code-generation/index.md).
+
+## Usage
+
+`terramate generate`


### PR DESCRIPTION
# Reason for This Change

Previously we didn't have a dedicated documentation page for the `terramate generate` command.

## Description of Changes

This PR adds a minimal documentation for the `terramate generate` command.
