### PR TITLE
Add documentation for the terramate list command

### DIFF
--- a/docs/cmdline/list.md
+++ b/docs/cmdline/list.md
@@ -1,0 +1,34 @@
+---
+title: terramate list - Command
+description: With the terramate list command you can list all stacks in the current directory recursively.
+
+prev:
+  text: 'Stacks'
+  link: '/stacks/'
+
+next:
+  text: 'Sharing Data'
+  link: '/data-sharing/'
+---
+
+# List
+
+The `list` command lists all Terramate stacks in the current directory recursively.
+
+## Usage
+
+`terramate list`
+
+## Examples
+
+List all stacks in the current directory recursively:
+
+```bash
+terramate list
+```
+
+Explicitly change the working directory:
+
+```bash
+terramate list --chdir path/to/directory
+```


### PR DESCRIPTION
# Reason for This Change

Previously we didn't have any documentation for the `terramate list` command.

## Description of Changes

This PR adds a new page to the documentation to explain the `terramate list` command.
