### PR TITLE
Add documentation for terramate version command

### DIFF
--- a/docs/cmdline/version.md
+++ b/docs/cmdline/version.md
@@ -1,0 +1,25 @@
+---
+title: terramate version - Command
+description: With the terramate version command you can see your current and the latest Terramate version.
+
+prev:
+  text: 'Stacks'
+  link: '/stacks/'
+
+next:
+  text: 'Sharing Data'
+  link: '/data-sharing/'
+---
+
+# Version
+
+The `version` commands allows you to see your current and the latest Terramate version.
+
+## Usage
+
+`terramate version [options]`
+
+## Options
+
+`--disable-checkpoint` Disable checkpoint checks for updates.
+`--disable-checkpoint-signature` Disable checkpoint signature.


### PR DESCRIPTION
# Reason for This Change

Previously we didn't have any documentation for the `terramate version` command.

## Description of Changes

This PR adds a new page to the documentation explaining the `terramate version` command.
