### PR TITLE
Chore: Enable merge queue, disable CI for document PRs.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,13 @@
 # SPDX-License-Identifier: MPL-2.0
 
 name: ci
-on: [push]
+on:
+  push:
+    paths_ignore:
+      - 'docs/**'
+  merge_group:
+    paths_ignore:
+      - 'docs/**'
 jobs:
   checks:
     runs-on: ubuntu-20.04
@@ -52,7 +58,7 @@ jobs:
 
       - name: make build
         run: make build
-      
+
       - name: check cloud info
         run: ./bin/terramate experimental cloud info
 


### PR DESCRIPTION
What it sounds like on the tin. This will enable us to

1. No longer run CI for PRs that only change documentation, and
2. Enable us to use the Merge Queue feature of github. This will be nice as it
   will no longer require endless merging of the base branch to merge a PR.

Once merged, this will require someone to manually edit the repository, it 
does not appear that the merge queue configuration is exposed, or at least 
included in the github terraform module. See how to do so [in the documentation
here](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#managing-a-merge-queue)