### PR TITLE
chore: Don't run ci-experimental and coverage on documentation PRs.

### DIFF
--- a/.github/workflows/ci-experimental.yml
+++ b/.github/workflows/ci-experimental.yml
@@ -2,7 +2,11 @@
 # SPDX-License-Identifier: MPL-2.0
 
 name: ci-experimental
-on: [push]
+on:
+  push:
+    paths-ignore:
+      - 'docs/**'
+
 jobs:
   build_test:
     name: Build and Test

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -7,9 +7,13 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - 'docs/**'
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - 'docs/**'
 
 jobs:
   build:


### PR DESCRIPTION
# Reason for This Change

We run the full CI suite on any PR, however, documentation lives alongside code,
so we run a full suite for things that touch no code. This stops that, and
should speed up CI for documentation changes. Follow up to #1057. 

## Description of Changes

The jobs `ci-experimental` and `coverage` no longer run on pushes that only
change files in `docs/**`.