### PR TITLE
Add documenation for the terramate cloud info command

### DIFF
--- a/docs/cmdline/cloud-info.md
+++ b/docs/cmdline/cloud-info.md
@@ -1,0 +1,22 @@
+---
+title: terramate cloud info - Command
+description: With the terramate cloud info command you can see information about your current session in Terramate Cloud.
+
+# prev:
+#   text: 'Stacks'
+#   link: '/stacks/'
+
+# next:
+#   text: 'Sharing Data'
+#   link: '/data-sharing/'
+---
+
+# Cloud Info
+
+**Note:** This is an experimental command that is likely subject to change in the future.
+
+The `cloud info` command prints information about your current session in Terramate Cloud. 
+
+## Usage
+
+`terramate experimental cloud info`


### PR DESCRIPTION
# Reason for This Change

Previously we didn't have any documentation for the `cloud info` command.

## Description of Changes

This PR adds a new documentation page covering the `cloud info` command.
