### PR TITLE
feat: We use terramate to orchestrate terramate builds

### DIFF
--- a/.github/workflows/ci-experimental.yml
+++ b/.github/workflows/ci-experimental.yml
@@ -6,6 +6,10 @@ on:
   push:
     paths-ignore:
       - 'docs/**'
+      - 'makefiles/**'
+      - '.github/**'
+      - '**/*.tm.hcl'
+      - '.tool-versions'
 
 jobs:
   build_test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,8 @@
 name: ci
 on:
   push:
-    paths_ignore:
-      - 'docs/**'
   merge_group:
-    paths_ignore:
-      - 'docs/**'
+
 jobs:
   checks:
     runs-on: ubuntu-20.04
@@ -16,20 +13,26 @@ jobs:
     steps:
       - name: checkout repo
         uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
 
       - name: setup go
         uses: actions/setup-go@v3
         with:
           go-version: "1.20"
 
+      - name: Configure asdf and plugins needed
+        uses: asdf-vm/actions/install@83133f03f5693901c2296a8e622955087dc20267
+
       - name: checking go mod tidyness
-        run: make mod/check
+        run: terramate run --tags golang --changed -- make mod/check
 
       - name: linting code
-        run: make lint
+        run: terramate run --tags golang --changed -- make lint
 
       - name: checking license on source code
-        run: make license/check
+        run: terramate run --tags golang --changed -- make license/check
 
   build_test:
     name: Build and Test
@@ -47,20 +50,26 @@ jobs:
     steps:
       - name: checkout repo
         uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
 
       - name: setup go
         uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go }}
 
+      - name: Configure asdf and plugins needed
+        uses: asdf-vm/actions/install@83133f03f5693901c2296a8e622955087dc20267
+
       - name: make test
-        run: make test
+        run: terramate run --tags golang --changed -- make test
 
       - name: make build
-        run: make build
+        run: terramate run --tags golang --changed -- make build
 
       - name: check cloud info
-        run: ./bin/terramate experimental cloud info
+        run: terramate run --tags golang --changed -- ./bin/terramate experimental cloud info
 
   gh_integration_test:
     name: GHA Integration Test
@@ -71,6 +80,7 @@ jobs:
       - name: checkout repo
         uses: actions/checkout@v2
         with:
+          ref: ${{ github.head_ref }}
           fetch-depth: 0
 
       - name: setup go
@@ -78,8 +88,11 @@ jobs:
         with:
           go-version: "1.20"
 
+      - name: Configure asdf and plugins needed
+        uses: asdf-vm/actions/install@83133f03f5693901c2296a8e622955087dc20267
+
       - name: make test/ci
-        run: make test/ci
+        run: terramate run --tags golang --changed -- make test/ci
 
   release_dry_run:
     name: Release Dry Run
@@ -89,17 +102,27 @@ jobs:
     steps:
       - name: checkout repo
         uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
 
       - name: setup go
         uses: actions/setup-go@v3
         with:
           go-version: "1.20"
 
+      - name: Configure asdf and plugins needed
+        uses: asdf-vm/actions/install@83133f03f5693901c2296a8e622955087dc20267
+
       - name: release dry run
-        run: make release/dry-run
+        run: terramate run --tags golang --changed -- make release/dry-run
 
   ci:
-    needs: [checks, build_test, gh_integration_test, release_dry_run]
+    needs:
+      - checks
+      - build_test
+      - gh_integration_test
+      - release_dry_run
     runs-on: ubuntu-20.04
     steps:
       - name: Required Checks

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,11 +9,19 @@ on:
       - main
     paths-ignore:
       - 'docs/**'
+      - 'makefiles/**'
+      - '.github/**'
+      - '**/*.tm.hcl'
+      - '.tool-versions'
   pull_request:
     branches:
       - main
     paths-ignore:
       - 'docs/**'
+      - 'makefiles/**'
+      - '.github/**'
+      - '**/*.tm.hcl'
+      - '.tool-versions'
 
 jobs:
   build:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,1 @@
-golang 1.18.7
-pnpm 8.3.0
+terramate 0.4.0

--- a/_testdata/example-stack/stack.tm.hcl
+++ b/_testdata/example-stack/stack.tm.hcl
@@ -2,5 +2,10 @@
 // SPDX-License-Identifier: MPL-2.0
 
 stack {
-    id = "terramate-example-stack"
+  id          = "terramate-example-stack"
+  name        = "test-stacks"
+  description = "Used in terramate tests"
+  tags = [
+    "test",
+  ]
 }

--- a/docs/stack.tm.hcl
+++ b/docs/stack.tm.hcl
@@ -1,0 +1,11 @@
+// Copyright 2023 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+stack {
+  name        = "documentation"
+  description = "terramate documentation"
+  id          = "0aef0c2b-3314-4097-a7e5-3d6d03cb4604"
+  tags = [
+    "docs",
+  ]
+}

--- a/makefiles/common.mk
+++ b/makefiles/common.mk
@@ -136,6 +136,7 @@ cloud/sync/ok: build test/helper
 	./bin/terramate --log-level=info		\
 			--disable-check-git-untracked   \
 			--disable-check-git-uncommitted \
+			--tags test \
 			run --cloud-sync-deployment --  \
 			$(PWD)/bin/helper true
 
@@ -145,6 +146,7 @@ cloud/sync/failed: build test/helper
 	./bin/terramate --log-level=info		\
 			--disable-check-git-untracked   \
 			--disable-check-git-uncommitted \
+			--tags test \
 			run --cloud-sync-deployment --  \
 			$(PWD)/bin/helper false
 

--- a/stack.tm.hcl
+++ b/stack.tm.hcl
@@ -1,0 +1,11 @@
+// Copyright 2023 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+stack {
+  name        = "terramate"
+  description = "terramate source code"
+  id          = "4ff324cd-f338-4526-8bcb-28ec33bbaeea"
+  tags = [
+    "golang",
+  ]
+}


### PR DESCRIPTION
GHA filters made the required CI run be skipped and thus the requirement was not met anymore blocking our docs PRs.

Now we use `terramate` Change Detection to skip golang builds and tests on docs changes.

This should speed up docs only PRs by 10x and more and save tons of build minutes and thus energy - save the planet ;)

Features used a combination of:
- Terramate Change Detection: e.g. `terramate run --changed`
- Terramate Orchestration: e.g. `terramate run --tags golang`
- Terramate Execute anything: e.g. `terramate run make test`
- leading to `terramate run --changed --tags golang -- make whatever-you-need`

We install Terramate in the CI/CD using `asdf` but will provide a GHA soon.
