### PR TITLE
Add documentation for the trigger command

### DIFF
--- a/docs/cmdline/trigger.md
+++ b/docs/cmdline/trigger.md
@@ -1,0 +1,33 @@
+---
+title: terramate trigger - Command
+description: With the terramate trigger command you can mark a stack to be considered by the change detection.
+
+# prev:
+#   text: 'Stacks'
+#   link: '/stacks/'
+
+# next:
+#   text: 'Sharing Data'
+#   link: '/data-sharing/'
+---
+
+# Trigger
+
+**Note:** This is an experimental command that is likely subject to change in the future.
+
+The `trigger` command creates a trigger that marks a stack for as changed to be
+considered by the [change detection](../change-detection/index.md).
+
+Per default, triggers are managed in the `.tmtriggers` directory.
+
+## Usage
+
+`terramate experimental trigger PATH`
+
+## Examples
+
+Create a change trigger for a stack: 
+
+```bash
+terramate experimental trigger /path/to/stack
+```


### PR DESCRIPTION
# Reason for This Change

Previously we didn't have any documentation for the `trigger` command.

## Description of Changes

This PR adds a new documentation page for the `trigger` command.