### PR TITLE
Add documentation for the terramate cloud login command

### DIFF
--- a/docs/cmdline/cloud-login.md
+++ b/docs/cmdline/cloud-login.md
@@ -1,0 +1,22 @@
+---
+title: terramate cloud login - Command
+description: With the terramate cloud login command you can log in to your Terramate Cloud account.
+
+# prev:
+#   text: 'Stacks'
+#   link: '/stacks/'
+
+# next:
+#   text: 'Sharing Data'
+#   link: '/data-sharing/'
+---
+
+# Cloud Login
+
+**Note:** This is an experimental command that is likely subject to change in the future.
+
+The `cloud login` command authorizes Terramate CLI to access Terramate Cloud.
+
+## Usage
+
+`terramate experimental cloud login`


### PR DESCRIPTION
# Reason for This Change

Previously we didn't have any documentation for the `cloud login` command.

## Description of Changes

This PR adds a new page to the documentation explaining the `cloud login` command.
