### PR TITLE
Add documentation for the run-graph command

### DIFF
--- a/docs/cmdline/run-graph.md
+++ b/docs/cmdline/run-graph.md
@@ -1,0 +1,30 @@
+---
+title: terramate run-graph - Command
+description: With the terramate run-graph command you can print a graph describing the order of execution of your stacks.
+
+# prev:
+#   text: 'Stacks'
+#   link: '/stacks/'
+
+# next:
+#   text: 'Sharing Data'
+#   link: '/data-sharing/'
+---
+
+# Run Graph
+
+**Note:** This is an experimental command that is likely subject to change in the future.
+
+The `run-graph` command prints a graph describing the [order of execution](../orchestration/index.md) of your stacks.
+
+## Usage
+
+`terramate experimental run-graph`
+
+## Examples
+
+Print the graph for all stacks in the current directory recursively: 
+
+```bash
+terramate experimental run-graph
+```


### PR DESCRIPTION
# Reason for This Change

Previously we didn't have any documentation for the `run-graph`.

## Description of Changes

This PR adds a new documentation page for the `run-graph` command.
