### PR TITLE
Add documentation for the vendor download command

### DIFF
--- a/docs/cmdline/vendor-download.md
+++ b/docs/cmdline/vendor-download.md
@@ -1,0 +1,34 @@
+---
+title: terramate vendor download - Command
+description: With the terramate vendor download command you can vendor a dependency.
+
+# prev:
+#   text: 'Stacks'
+#   link: '/stacks/'
+
+# next:
+#   text: 'Sharing Data'
+#   link: '/data-sharing/'
+---
+
+# Vendor Download
+
+**Note:** This is an experimental command that is likely subject to change in the future.
+
+The `vendor download` command vendors dependencies such as Terraform modules.
+
+## Usage
+
+`terramate experimental vendor download [options] DEPENDENCY VERSION`
+
+## Examples
+
+Vendor a specific Terraform module version: 
+
+```bash
+terramate experimental vendor download github.com/mineiros-io/terraform-google-cloud-run v0.2.1
+```
+
+## Options
+
+- `--dir=STRING` The directory to download the dependency to.


### PR DESCRIPTION
# Reason for This Change

Previously we didn't have any documentation for the `vendor download` command.

## Description of Changes

Adds a new page to the documentation explaining the `vendor download` command.
