### PR TITLE
Add documentation for the eval command

### DIFF
--- a/docs/cmdline/eval.md
+++ b/docs/cmdline/eval.md
@@ -1,0 +1,30 @@
+---
+title: terramate eval - Command
+description: With the terramate eval command you can fully evaluate a Terramate expression.
+
+# prev:
+#   text: 'Stacks'
+#   link: '/stacks/'
+
+# next:
+#   text: 'Sharing Data'
+#   link: '/data-sharing/'
+---
+
+# Trigger
+
+**Note:** This is an experimental command that is likely subject to change in the future.
+
+The `eval` command allows you to fully evaluate a Terramate expression.
+
+## Usage
+
+`terramate experimental eval EXPRS`
+
+## Examples
+
+Evaluate an expression that returns the uppercase version of the current stack name: 
+
+```bash
+terramate experimental eval 'tm_upper(terramate.stack.name)'
+```


### PR DESCRIPTION
# Reason for This Change

Previously we didn't have any documentation for the `eval` command.

## Description of Changes

This PR adds a new page to the documentation to explain the `eval` command.
