### PR TITLE
Add documentation for terramate get-config-value

### DIFF
--- a/docs/cmdline/get-config-value.md
+++ b/docs/cmdline/get-config-value.md
@@ -1,0 +1,30 @@
+---
+title: terramate get-config-value - Command
+description: With the terramate get-config-value command you can print the value of a specific configuration parameter.
+
+# prev:
+#   text: 'Stacks'
+#   link: '/stacks/'
+
+# next:
+#   text: 'Sharing Data'
+#   link: '/data-sharing/'
+---
+
+# Get Config Value
+
+**Note:** This is an experimental command that is likely subject to change in the future.
+
+The `get-config-value` command prints the value of a specific configuration parameter for a stack.
+
+## Usage
+
+`terramate experimental get-config-value`
+
+## Examples
+
+Return the stack name for a specific stack:
+
+```bash
+terramate get-config-value 'terramate.stack.name'
+```


### PR DESCRIPTION
# Reason for This Change

Previously we didn't have documentation for the `get-config-value` command.

## Description of Changes

This PR adds a dedicated documentation page for the `get-config-value`.
