### PR TITLE
Split import and glob import into two different examples

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -42,7 +42,16 @@ See the example below:
 import {
     # import a specific file
     source = "/more/globals.tm.hcl"
-    # import all .tm.hcl files in a directory
+}
+```
+
+The import block supports globs as well:
+
+```hcl
+# globals.tm.hcl
+
+import {
+    # import all files in a directory
     source = "/imports/*.tm.hcl"
 }
 ```


### PR DESCRIPTION
# Reason for This Change

The current example of import and glob imports is missleading and not clearly separated.

## Description of Changes

This splits up the example into two different examples which should be more clear to the audience.
