### PR TITLE
Move guides and example to dedicated page instead of listing everything in the sidebar

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -251,30 +251,8 @@ export default defineConfig({
       //   ],
       // },
       {
-        text: '🤓 Guides',
-        collapsed: false,
-        items: [
-          {
-            text: 'Introducing Terramate — An Orchestrator and Code Generator for Terraform',
-            link: 'https://blog.terramate.io/introducing-terramate-an-orchestrator-and-code-generator-for-terraform-5e538c9ee055',
-          },
-          {
-            text: 'Understanding the basics of Terramate',
-            link: 'https://blog.terramate.io/understanding-the-basics-of-terramate-e0d8778f5c53',
-          },
-          {
-            text: 'Terramate and Terragrunt',
-            link: 'https://blog.terramate.io/terramate-and-terragrunt-f27f2ec4032f',
-          },
-          {
-            text: 'How to keep your Terraform code DRY by using Terramate',
-            link: 'https://blog.terramate.io/how-to-keep-your-terraform-code-dry-by-using-terramate-be5807fef8f6',
-          },
-          {
-            text: 'Introducing the Terramate VSCode Extension and Language Server',
-            link: 'https://blog.terramate.io/introducing-the-terramate-vscode-extension-and-language-server-d77bd392011c',
-          },
-        ],
+        text: '🤓 Guides & Examples',
+        link: 'guides/',
       },
     ],
 

--- a/docs/cmdline/version.md
+++ b/docs/cmdline/version.md
@@ -6,10 +6,9 @@ prev:
   text: 'Vendor Download'
   link: '/cmdline/vendor-download'
 
-# TODO: add for new commands
-# next:
-#   text: 'Version'
-#   link: '/cmdline/version'
+next:
+  text: 'Guides & Examples'
+  link: '/guides/'
 ---
 
 # Version

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -1,0 +1,36 @@
+---
+title: Guides and Examples
+description: Learn about the various use cases and features of Terramate with straightforward and easy to apply guides and examples.
+
+prev:
+  text: "version"
+  link: "/cmdline/version"
+
+next:
+  text: "Introduction"
+  link: "/introduction"
+---
+
+# Guides and Examples
+
+This page provides and overview of existing guides and examples issued by both - Terramate and our community!
+
+## Fundamentals
+
+- [Introducing Terramate — An Orchestrator and Code Generator for Terraform](https://blog.terramate.io/introducing-terramate-an-orchestrator-and-code-generator-for-terraform-5e538c9ee055)
+- [Comparing Terramate and Terragrunt](https://blog.terramate.io/terramate-and-terragrunt-f27f2ec4032f)
+
+## Guides
+
+- [Understanding the basics of Terramate](https://blog.terramate.io/understanding-the-basics-of-terramate-e0d8778f5c53)
+- [Using the Terramate Language Server and VSCode Extension](https://blog.terramate.io/introducing-the-terramate-vscode-extension-and-language-server-d77bd392011c)
+- [How to keep your Terraform code DRY by using Terramate](https://blog.terramate.io/how-to-keep-your-terraform-code-dry-by-using-terramate-be5807fef8f6)
+
+## Examples
+
+- [Generate Terraform Provider and Backend Configuration with Terramate](https://github.com/terramate-io/terramate-examples/tree/main/01-keep-terraform-dry)
+- [Terramate Code Generation for managing Google Cloud Run services](https://github.com/terramate-io/terramate-example-code-generation)
+
+## Community References
+
+- [Terramate AWS Sandbox](https://github.com/ashleymichaelwilliams/aws-sandbox#running-infracost-and-pluralith) Example project where you can experiment with different "stacks" using Terramate following generally good design practices. Maintained by [Ashley Williams](https://github.com/ashleymichaelwilliams).

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -42,6 +42,8 @@ To install Terramate please see the [Installation](https://terramate.io/docs/cli
 We recommend following our [Getting Started](https://terramate.io/docs/cli/getting-started/) guide to familiarize yourself
 with the fundamentals by building your first Terramate project.
 
+For a list of guides and examples available, please see the [guides](./guides/index.md) documentation page.
+
 ## Community
 
 Join us on [GitHub](https://github.com/terramate-io/terramate) or [Discord](https://terramate.io/discord) to ask


### PR DESCRIPTION
# Reason for This Change

Previously we had all guides listed in the sidebar of the documentation. This was quite overwhelming for our users.

## Description of Changes

This PR adds all guides and examples as well as community examples to a dedicated page `/guides` in the documentation.
