### PR TITLE
fix: allow comma in the --tags of the create command

### DIFF
--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -90,7 +90,7 @@ type cliSpec struct {
 	Chdir          string   `short:"C" optional:"true" predictor:"file" help:"Sets working directory"`
 	GitChangeBase  string   `short:"B" optional:"true" help:"Git base ref for computing changes"`
 	Changed        bool     `short:"c" optional:"true" help:"Filter by changed infrastructure"`
-	Tags           []string `optional:"true" sep:"none" help:"Filter stacks by tags. Use \":\" for logical AND and \",\" for logical OR. Example: --tags app:prod filters stacks containing tag \"app\" AND \"prod\". If multiple --tags are provided, an OR expression is created. Example: \"--tags A --tags B\" is the same as \"--tags A,B\""`
+	Tags           []string `optional:"true" sep:"none" help:"Filter stacks by tags. Use \":\" for logical AND and \",\" for logical OR. Example: --tags app:prod filters stacks containing tag \"app\" AND \"prod\". If multiple --tags are provided, an OR expression is created. Example: \"--tags a --tags b\" is the same as \"--tags a,b\""`
 	NoTags         []string `optional:"true" sep:"," help:"Filter stacks that do not have the given tags"`
 	LogLevel       string   `optional:"true" default:"warn" enum:"disabled,trace,debug,info,warn,error,fatal" help:"Log level to use: 'disabled', 'trace', 'debug', 'info', 'warn', 'error', or 'fatal'"`
 	LogFmt         string   `optional:"true" default:"console" enum:"console,text,json" help:"Log format to use: 'console', 'text', or 'json'"`
@@ -1137,6 +1137,11 @@ func (c *cli) createStack() {
 		stackDescription = stackName
 	}
 
+	var tags []string
+	for _, tag := range c.parsedArgs.Tags {
+		tags = append(tags, strings.Split(tag, ",")...)
+	}
+
 	stackSpec := config.Stack{
 		Dir:         prj.PrjAbsPath(c.rootdir(), stackHostDir),
 		ID:          stackID,
@@ -1144,7 +1149,7 @@ func (c *cli) createStack() {
 		Description: stackDescription,
 		After:       c.parsedArgs.Create.After,
 		Before:      c.parsedArgs.Create.Before,
-		Tags:        c.parsedArgs.Tags,
+		Tags:        tags,
 	}
 
 	err := stack.Create(c.cfg(), stackSpec, c.parsedArgs.Create.Import...)

--- a/docs/cmdline/create.md
+++ b/docs/cmdline/create.md
@@ -58,8 +58,8 @@ file in every Terraform directory that contain a `terraform.backend` block or `p
 - `--id=STRING` ID of the stack. Defaults to a random UUIDv4 (Using the default is highly recommended).
 - `--name=STRING` Name of the stack. Defaults to stack dir base name.
 - `--description=STRING` Description of the stack. Defaults to the stack name.
-- `--tags=STRING` Adds tags to the stack. Example: `--tags a --tags b.
-- `--import=STRING`  Add import block for the given path on the stack.
+- `--tags=LIST` Adds tags to the stack. Example: `--tags a --tags b` or `--tags a,b`.
+- `--import=LIST`  Add import block for the given path on the stack. Example: `--import dir/path1 --import dir/path2` or `--import dir/path1,dir/path2`
 - `--after=LIST`, `--before=LIST` Define an explicit [order of execution](../orchestration/index.md#explicit-order-of-execution). LIST can contain relative paths `../path/to/stack` and/or tags `tag:my-tag`. These options can be used multiple times.
 - `--ignore-existing` If the stack already exists do nothing and don't fail.
 - `--all-terraform` Initialize Terramate in all directories containing `terraform.backend` blocks.


### PR DESCRIPTION
# Reason for This Change

The `--tags` was missing support for separating values with comma.
Now both ways are supported:
```
terramate create --tags a,b ...
```
and
```
terramate create --tags a --tags b
```

similarly to the other list flags (`--import`, `--after`, `--before`).

The docs were updated accordingly.