### PR TITLE
fix: use stack environ for the cmd lookpath

### DIFF
--- a/cmd/terramate/e2etests/cmd/test/test.go
+++ b/cmd/terramate/e2etests/cmd/test/test.go
@@ -21,6 +21,11 @@ func main() {
 	}
 
 	switch os.Args[1] {
+	case "echo":
+		for _, arg := range os.Args[2:] {
+			fmt.Print(arg)
+		}
+		fmt.Print("\n")
 	case "true":
 		os.Exit(0)
 	case "false":

--- a/cmd/terramate/e2etests/run_unix_test.go
+++ b/cmd/terramate/e2etests/run_unix_test.go
@@ -1,0 +1,87 @@
+// Copyright 2023 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build aix || android || darwin || dragonfly || freebsd || hurd || illumos || ios || linux || netbsd || openbsd || solaris
+
+package e2etest
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/madlambda/spells/assert"
+	"github.com/terramate-io/terramate/test"
+	"github.com/terramate-io/terramate/test/hclwrite"
+	. "github.com/terramate-io/terramate/test/hclwrite/hclutils"
+	"github.com/terramate-io/terramate/test/sandbox"
+)
+
+func TestRunLookPathFromStackEnviron(t *testing.T) {
+	t.Parallel()
+
+	run := func(builders ...hclwrite.BlockBuilder) *hclwrite.Block {
+		return hclwrite.BuildBlock("run", builders...)
+	}
+	env := func(builders ...hclwrite.BlockBuilder) *hclwrite.Block {
+		return hclwrite.BuildBlock("env", builders...)
+	}
+
+	const stackName = "stack"
+
+	s := sandbox.New(t)
+
+	root := s.RootEntry()
+
+	srcFile, err := os.Open(testHelperBin)
+	assert.NoError(t, err)
+
+	defer func() { assert.NoError(t, srcFile.Close()) }()
+
+	srcStat, err := os.Stat(testHelperBin)
+	assert.NoError(t, err)
+
+	programName := "my-cmd"
+
+	srcPerm := srcStat.Mode().Perm()
+
+	tdir := filepath.Join(s.RootDir(), "bin")
+	test.MkdirAll2(t, tdir, 0777)
+	dstFilename := filepath.Join(tdir, programName)
+
+	dstFile, err := os.Create(dstFilename)
+	assert.NoError(t, err)
+
+	_, err = io.Copy(dstFile, srcFile)
+	assert.NoError(t, err)
+
+	assert.NoError(t, dstFile.Close())
+
+	test.Chmod(t, dstFilename, srcPerm)
+
+	_ = s.CreateStack(stackName)
+
+	root.CreateFile("env.tm",
+		Terramate(
+			Config(
+				run(
+					env(
+						Expr("PATH", `"${terramate.root.path.fs.absolute}/bin:${env.PATH}"`),
+					),
+				),
+			),
+		).String(),
+	)
+
+	git := s.Git()
+	git.Add(".")
+	git.CommitAll("first commit")
+
+	tm := newCLI(t, s.RootDir())
+
+	assertRunResult(t, tm.run("run", "--", programName, "echo", "Hello from myscript"),
+		runExpected{
+			Stdout: "Hello from myscript\n",
+		})
+}

--- a/docs/cmdline/run.md
+++ b/docs/cmdline/run.md
@@ -74,3 +74,37 @@ terramate run  --reverse --no-tags type:k8s -- terraform apply
 - `--no-recursive` Do not recurse into child stacks
 - `--dry-run` Plan the execution but do not execute it
 - `--reverse` Reverse the order of execution
+
+## Project wide `run` configuration.
+
+The `terramate` block at the project root can be used to customize
+the default exported environment variables in the 
+[terramate.config.run.env](../configuration/project-config.md#the-terramateconfigrunenv-block).
+
+It's also possible to set a different `PATH` environment variable and
+in this case, Terramate will honor it when looking up the program's
+absolute path.
+
+For example, let's say you have a `bin` directory at the root of the
+Terramate project where you define some scripts that should be ran in
+each stack. In this case, you can have declaration below in the root
+directory:
+
+```hcl
+terramate {
+  config {
+    run {
+      env {
+        # prepend the bin/ directory so it has preference.
+        PATH = "${terramate.root.path.fs.absolute}/bin:${env.PATH}"
+      }
+    }
+  }
+}
+```
+
+Then if you have the script `bin/create-stack.sh`, you can do:
+
+```bash
+$ terramate run create-stack.sh
+```

--- a/docs/configuration/project-config.md
+++ b/docs/configuration/project-config.md
@@ -134,4 +134,4 @@ Any attributes defined
 on `terramate.config.run.env` blocks won't affect the `env` namespace.
 
 You can have multiple `terramate.config.run.env` blocks defined on different
-files, but variable names can **not** be defined twice.
+files, but variable names **cannot** be defined twice.

--- a/go.mod
+++ b/go.mod
@@ -64,6 +64,6 @@ require (
 	github.com/zclconf/go-cty-yaml v1.0.2 // indirect
 	golang.org/x/crypto v0.0.0-20220517005047-85d78b3ac167 // indirect
 	golang.org/x/net v0.7.0 // indirect
-	golang.org/x/sys v0.8.0 // indirect
+	golang.org/x/sys v0.10.0
 	golang.org/x/text v0.7.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -715,8 +715,8 @@ golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211110154304-99a53858aa08/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.8.0 h1:EBmGv8NaZBZTWvrbjNoL6HVt+IVy3QDQpJs7VRIw3tU=
-golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.10.0 h1:SqMFp9UcQJZa+pmYuAKjd9xq1f0j5rLcDIk0mj4qAsA=
+golang.org/x/sys v0.10.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20201210144234-2321bbc49cbf/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/makefiles/windows.mk
+++ b/makefiles/windows.mk
@@ -29,8 +29,9 @@ test/helper:
 
 ## test code
 .PHONY: test
-test:
+test: test/helper build
 	go test -tags localhostEndpoints ./... -timeout=20m
+	./bin/terramate.exe run -- helper.exe true
 
  ## remove build artifacts
 .PHONY: clean

--- a/run/env.go
+++ b/run/env.go
@@ -5,6 +5,7 @@ package run
 
 import (
 	"os"
+	"strings"
 
 	"github.com/terramate-io/terramate/config"
 	"github.com/terramate-io/terramate/errors"
@@ -97,4 +98,19 @@ func LoadEnv(root *config.Root, st *config.Stack) (EnvVars, error) {
 	}
 
 	return envVars, nil
+}
+
+func getEnv(key string, environ []string) (string, bool) {
+	for i := len(environ) - 1; i >= 0; i-- {
+		env := environ[i]
+		for j := 0; j < len(env); j++ {
+			if env[j] == '=' {
+				k := env[0:j]
+				if strings.EqualFold(k, key) {
+					return env[j+1:], true
+				}
+			}
+		}
+	}
+	return "", false
 }

--- a/run/lookpath_unix.go
+++ b/run/lookpath_unix.go
@@ -1,0 +1,80 @@
+// Copyright 2010 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found at:
+// https://github.com/golang/go/blob/616193510f45c6c588af9cb022dfdee52400d0ca/LICENSE
+
+//go:build aix || android || darwin || dragonfly || freebsd || hurd || illumos || ios || linux || netbsd || openbsd || solaris
+
+package run
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/terramate-io/terramate/errors"
+)
+
+// ErrNotFound is the error resulting if a path search failed to find an executable file.
+const ErrNotFound errors.Kind = "executable file not found in $PATH"
+
+// lookPath searches for an executable named file in the
+// directories named by the PATH environment variable.
+// If file contains a slash, it is tried directly and the PATH is not consulted.
+// Otherwise, on success, the result is an absolute path.
+//
+// In older versions of Go, LookPath could return a path relative to the current directory.
+// As of Go 1.19, LookPath will instead return that path along with an error satisfying
+// errors.Is(err, ErrDot). See the package documentation for more details.
+func lookPath(file string, environ []string) (string, error) {
+	// NOTE(rsc): I wish we could use the Plan 9 behavior here
+	// (only bypass the path if file begins with / or ./ or ../)
+	// but that would not match all the Unix shells.
+
+	if strings.Contains(file, "/") {
+		err := findExecutable(file)
+		if err == nil {
+			return file, nil
+		}
+		return "", errors.E(ErrNotFound, err, file)
+	}
+	path, _ := getEnv("PATH", environ)
+	for _, dir := range filepath.SplitList(path) {
+		if dir == "" {
+			// Unix shell semantics: path element "" means "."
+			dir = "."
+		}
+		path := filepath.Join(dir, file)
+		if err := findExecutable(path); err == nil {
+			return path, nil
+		}
+	}
+	return "", errors.E(ErrNotFound, file)
+}
+
+func findExecutable(file string) error {
+	d, err := os.Stat(file)
+	if err != nil {
+		return err
+	}
+	m := d.Mode()
+	if m.IsDir() {
+		return syscall.EISDIR
+	}
+
+	err = unix.Access(file, unix.X_OK)
+	// ENOSYS means Eaccess is not available or not implemented.
+	// EPERM can be returned by Linux containers employing seccomp.
+	// In both cases, fall back to checking the permission bits.
+	if err == nil || (err != syscall.ENOSYS && err != syscall.EPERM) {
+		return err
+	}
+	if m&0111 != 0 {
+		return nil
+	}
+	return fs.ErrPermission
+}

--- a/run/lookpath_windows.go
+++ b/run/lookpath_windows.go
@@ -1,0 +1,147 @@
+// Copyright 2010 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found at:
+// https://github.com/golang/go/blob/616193510f45c6c588af9cb022dfdee52400d0ca/LICENSE
+
+//go:build windows
+
+package run
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/terramate-io/terramate/errors"
+)
+
+// ErrNotFound is the error resulting if a path search failed to find an executable file.
+const ErrNotFound errors.Kind = "executable file not found in %PATH%"
+
+// ErrDot indicates that a path lookup resolved to an executable
+// in the current directory due to ‘.’ being in the path, either
+// implicitly or explicitly. See the package documentation for details.
+//
+// Note that functions in this package do not return ErrDot directly.
+// Code should use errors.Is(err, ErrDot), not err == ErrDot,
+// to test whether a returned error err is due to this condition.
+const ErrDot errors.Kind = "cannot run executable found relative to current directory"
+
+func chkStat(file string) error {
+	d, err := os.Stat(file)
+	if err != nil {
+		return err
+	}
+	if d.IsDir() {
+		return fs.ErrPermission
+	}
+	return nil
+}
+
+func hasExt(file string) bool {
+	i := strings.LastIndex(file, ".")
+	if i < 0 {
+		return false
+	}
+	return strings.LastIndexAny(file, `:\/`) < i
+}
+
+func findExecutable(file string, exts []string) (string, error) {
+	if len(exts) == 0 {
+		return file, chkStat(file)
+	}
+	if hasExt(file) {
+		if chkStat(file) == nil {
+			return file, nil
+		}
+	}
+	for _, e := range exts {
+		if f := file + e; chkStat(f) == nil {
+			return f, nil
+		}
+	}
+	return "", fs.ErrNotExist
+}
+
+// LookPath searches for an executable named file in the
+// directories named by the PATH environment variable.
+// LookPath also uses PATHEXT environment variable to match
+// a suitable candidate.
+// If file contains a slash, it is tried directly and the PATH is not consulted.
+// Otherwise, on success, the result is an absolute path.
+//
+// In older versions of Go, LookPath could return a path relative to the current directory.
+// As of Go 1.19, LookPath will instead return that path along with an error satisfying
+// errors.Is(err, ErrDot). See the package documentation for more details.
+func lookPath(file string, environ []string) (string, error) {
+	var exts []string
+	x, _ := getEnv(`PATHEXT`, environ)
+	if x != "" {
+		for _, e := range strings.Split(strings.ToLower(x), `;`) {
+			if e == "" {
+				continue
+			}
+			if e[0] != '.' {
+				e = "." + e
+			}
+			exts = append(exts, e)
+		}
+	} else {
+		exts = []string{".com", ".exe", ".bat", ".cmd"}
+	}
+
+	if strings.ContainsAny(file, `:\/`) {
+		f, err := findExecutable(file, exts)
+		if err == nil {
+			return f, nil
+		}
+		return "", errors.E(ErrNotFound, err, file)
+	}
+
+	// On Windows, creating the NoDefaultCurrentDirectoryInExePath
+	// environment variable (with any value or no value!) signals that
+	// path lookups should skip the current directory.
+	// In theory we are supposed to call NeedCurrentDirectoryForExePathW
+	// "as the registry location of this environment variable can change"
+	// but that seems exceedingly unlikely: it would break all users who
+	// have configured their environment this way!
+	// https://docs.microsoft.com/en-us/windows/win32/api/processenv/nf-processenv-needcurrentdirectoryforexepathw
+	// See also go.dev/issue/43947.
+	var (
+		dotf   string
+		dotErr error
+	)
+	if _, found := getEnv("NoDefaultCurrentDirectoryInExePath", environ); !found {
+		if f, err := findExecutable(filepath.Join(".", file), exts); err == nil {
+			dotf, dotErr = f, errors.E(ErrDot, file)
+		}
+	}
+
+	path, _ := getEnv("path", environ)
+	for _, dir := range filepath.SplitList(path) {
+		if f, err := findExecutable(filepath.Join(dir, file), exts); err == nil {
+			if dotErr != nil {
+				// https://go.dev/issue/53536: if we resolved a relative path implicitly,
+				// and it is the same executable that would be resolved from the explicit %PATH%,
+				// prefer the explicit name for the executable (and, likely, no error) instead
+				// of the equivalent implicit name with ErrDot.
+				//
+				// Otherwise, return the ErrDot for the implicit path as soon as we find
+				// out that the explicit one doesn't match.
+				dotfi, dotfiErr := os.Lstat(dotf)
+				fi, fiErr := os.Lstat(f)
+				if dotfiErr != nil || fiErr != nil || !os.SameFile(dotfi, fi) {
+					return dotf, dotErr
+				}
+			}
+
+			return f, nil
+		}
+	}
+
+	if dotErr != nil {
+		return dotf, dotErr
+	}
+	return "", errors.E(ErrNotFound, file)
+}

--- a/terramate.tm.hcl
+++ b/terramate.tm.hcl
@@ -1,0 +1,29 @@
+// Copyright 2023 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+# This file is here just to e2etest on Windows if the `terramate run` respects
+# the `terramate.config.run.env.PATH` environment variable.
+# This behavior is not tested in Go because it requires a lot of "unsafe"
+# non-portable code.
+# It's used by the `make test` implemented for Windows at ./makefiles/windows.mk
+
+terramate {
+    config {
+        run {
+            env {
+                PATH = "${terramate.root.path.fs.absolute}/bin${global.PS}${env.PATH}"
+            }
+        }
+
+        git {
+            check_untracked     = false
+            check_uncommitted   = false
+            check_remote        = false
+        }
+    }
+}
+
+globals {
+    # TODO(i4k): very brittle but works for now.
+    PS = tm_fileexists("/etc/hosts") ? ":" : ";"
+}

--- a/test/os.go
+++ b/test/os.go
@@ -4,6 +4,7 @@
 package test
 
 import (
+	"io/fs"
 	"os"
 	"path/filepath"
 	"testing"
@@ -94,6 +95,13 @@ func MkdirAll(t testing.TB, path string) {
 	t.Helper()
 
 	assert.NoError(t, os.MkdirAll(path, 0700), "failed to create temp directory")
+}
+
+// MkdirAll2 creates a temporary directory with provided permissions.
+func MkdirAll2(t testing.TB, path string, perm fs.FileMode) {
+	t.Helper()
+
+	assert.NoError(t, os.MkdirAll(path, perm), "failed to create temp directory")
 }
 
 // Symlink calls [os.Symlink] failing the test if there is an error.

--- a/test/sandbox/sandbox.go
+++ b/test/sandbox/sandbox.go
@@ -463,6 +463,8 @@ func (fe FileEntry) Write(body string, args ...interface{}) {
 
 	body = fmt.Sprintf(body, args...)
 
+	test.MkdirAll(fe.t, filepath.Dir(fe.hostpath))
+
 	if err := os.WriteFile(fe.hostpath, []byte(body), 0700); err != nil {
 		fe.t.Fatalf("os.WriteFile(%q) = %v", fe.hostpath, err)
 	}


### PR DESCRIPTION
When executing the commands provided to `terramate run`, the actual path of the program was being resolved using Terramate's own `PATH` environment variable instead of the stack's environment (that could be changed using `terramate.config.run.env.PATH` configuration.

The fix ensures that the program to be invoked is resolved using the stack's environment.