### PR TITLE
chore: warn if pull request cannot be associated with the deployment

### DIFF
--- a/cmd/terramate/cli/github/client.go
+++ b/cmd/terramate/cli/github/client.go
@@ -15,6 +15,13 @@ import (
 	"github.com/terramate-io/terramate/errors"
 )
 
+const (
+	// ErrNotFound indicates the resource does not exists.
+	ErrNotFound errors.Kind = "resource not found (HTTP Status: 404)"
+	// ErrUnprocessableEntity indicates the entity cannot be processed for any reason.
+	ErrUnprocessableEntity errors.Kind = "entity cannot be processed (HTTP Status: 422)"
+)
+
 type (
 	// Client is a Github HTTP client wrapper.
 	Client struct {
@@ -68,6 +75,14 @@ func (c *Client) PullsForCommit(ctx context.Context, repository, commit string) 
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, errors.E(err, "reading response body")
+	}
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, errors.E(ErrNotFound, "retrieving %s", url)
+	}
+
+	if resp.StatusCode == http.StatusUnprocessableEntity {
+		return nil, errors.E(ErrUnprocessableEntity, "retrieving %s", url)
 	}
 
 	if resp.StatusCode != http.StatusOK {


### PR DESCRIPTION
Now it generates the warnings below:

### When local HEAD is not pushed to the remote:
```
2023-08-07T18:50:21+01:00 WRN The HEAD commit cannot be found in the remote. Did you forget to push? gh-repository=terramate-io/terramate head-commit=0ceebdaee20e56ff118a7a7077a910c1609cded0 normalized-repo=github.com/terramate-io/terramate
```

### When there's no pull request associated:
```
2023-08-07T18:54:54+01:00 WRN no pull request associated with HEAD commit gh-repository=terramate-io/terramate head-commit=12738926e2381bc243ae59d01fc07460c3c821ba normalized-repo=github.com/terramate-io/terramate
```

### When there's no `GITHUB_TOKEN` exported and the repository is private (maybe the message can be improved here because it could also occur when the token has no permission in the repo):

```
2023-08-07T18:58:32+01:00 WRN The GITHUB_TOKEN environment variable needs to be exported for private repositories. gh-repository=mineiros-io/iac-gc
```

### When `GITHUB_TOKEN` is set but API returns 404 (it means the token has no permission to read the repo):

```
2023-08-07T18:58:32+01:00 WRN The provided GitHub token does not have permission to read this repository or it does not exists. gh-repository=mineiros-io/iac-gc
```