### PR TITLE
chore: fix repository of the make/bench

### DIFF
--- a/makefiles/common.mk
+++ b/makefiles/common.mk
@@ -105,7 +105,7 @@ bench/all:
 .PHONY: bench/check
 bench/check: allocdelta="+20%"
 bench/check: timedelta="+20%"
-bench/check: name=github.com/mineiros-io/terramate
+bench/check: name=github.com/terramate-io/terramate
 bench/check: pkg=./...
 bench/check: old=main
 bench/check: new?=$(shell git rev-parse HEAD)


### PR DESCRIPTION
At the time that we migrated the repository this name could not be updated because the `benchcheck` command compares different revisions and we were in the middle of the transition. Keeping the old name worked fine because Github redirects requests to the new name when the repo is transferred or renamed.