### PR TITLE
Fix(create/all-terraform): Add in Name/Description in new stacks.

### DIFF
--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -1141,12 +1141,15 @@ func (c *cli) initDir(baseDir string) error {
 
 		stackDir := baseDir
 		stackID, err := uuid.NewRandom()
+		dirBasename := filepath.Base(stackDir)
 		if err != nil {
 			fatal(err, "creating stack UUID")
 		}
 		stackSpec := config.Stack{
 			Dir: prj.PrjAbsPath(c.rootdir(), stackDir),
 			ID:  stackID.String(),
+			Name: dirBasename,
+			Description: dirBasename,
 		}
 
 		err = stack.Create(c.cfg(), stackSpec)


### PR DESCRIPTION
-------

# Reason for This Change

When we run `terramate create --all-terraform`, we do not fill the `name` and
`description` fields. This is different behaviour than `terramate create
/path/to/stack`, which will use `stack` as value for both name and description.

## Description of Changes

When running `terramate create --all-terraform`, created stacks now have the
same derived names and descriptions as stacks created without the
`--all-terraform` flag.