### PR TITLE
feat: add run --eval for evaluating cmd args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,8 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 - Add support for globs in the `import.source` attribute to import multiple files at once.
 - Add support for listing *unhealthy* stacks with `terramate list --experimental-status=unhealthy`.
 - Add support for triggering *unhealthy* stacks with `terramate experimental  trigger --experimental-status=unhealthy`.
-
+- Add support for evaluating `terramate run` arguments with the `--eval`
+flag.
 
 ### Fixed
 

--- a/cmd/terramate/e2etests/cmd/test/test.go
+++ b/cmd/terramate/e2etests/cmd/test/test.go
@@ -22,8 +22,12 @@ func main() {
 
 	switch os.Args[1] {
 	case "echo":
-		for _, arg := range os.Args[2:] {
+		args := os.Args[2:]
+		for i, arg := range args {
 			fmt.Print(arg)
+			if i+1 < len(args) {
+				fmt.Print(" ")
+			}
 		}
 		fmt.Print("\n")
 	case "true":

--- a/cmd/terramate/e2etests/run_cloud_test.go
+++ b/cmd/terramate/e2etests/run_cloud_test.go
@@ -479,7 +479,7 @@ func TestRunGithubTokenDetection(t *testing.T) {
 	t.Run("GH_TOKEN detection", func(t *testing.T) {
 		tm := newCLI(t, s.RootDir())
 		tm.loglevel = "debug"
-		tm.env = append(os.Environ(), "GH_TOKEN=abcd")
+		tm.appendEnv = append(tm.appendEnv, "GH_TOKEN=abcd")
 
 		result := tm.run("run",
 			"--disable-check-git-remote",
@@ -492,8 +492,8 @@ func TestRunGithubTokenDetection(t *testing.T) {
 
 	t.Run("GITHUB_TOKEN detection", func(t *testing.T) {
 		tm := newCLI(t, s.RootDir())
+		tm.appendEnv = append(tm.appendEnv, "GITHUB_TOKEN=abcd")
 		tm.loglevel = "debug"
-		tm.env = append(os.Environ(), "GITHUB_TOKEN=abcd")
 
 		result := tm.run("run",
 			"--disable-check-git-remote",
@@ -518,7 +518,7 @@ func TestRunGithubTokenDetection(t *testing.T) {
     oauth_token: abcd
     git_protocol: ssh
 `)
-		tm.env = append(os.Environ(), "GH_CONFIG_DIR="+ghConfigDir)
+		tm.appendEnv = append(tm.appendEnv, "GH_CONFIG_DIR="+ghConfigDir)
 
 		result := tm.run("run",
 			"--disable-check-git-remote",

--- a/cmd/terramate/e2etests/run_eval_test.go
+++ b/cmd/terramate/e2etests/run_eval_test.go
@@ -1,0 +1,166 @@
+// Copyright 2023 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+package e2etest
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/terramate-io/terramate/test/sandbox"
+)
+
+func TestRunEval(t *testing.T) {
+	// tests the `terramate run --eval -- cmd containing '${tm_upper("hcl")}'`
+
+	type testcase struct {
+		name   string
+		layout []string
+		eval   bool
+		args   []string
+		want   runExpected
+	}
+
+	for _, tc := range []testcase{
+		{
+			name:   "no eval -- ignores $ and other HCL templating symbols",
+			layout: []string{`s:stack`},
+			eval:   false,
+			args: []string{
+				`test ${tm_upper("hcl")}`,
+				`%{ for i in tm_range(5) ~} some ${i} %{endfor}`,
+			},
+			want: runExpected{
+				Stdout: "test ${tm_upper(\"hcl\")} %{ for i in tm_range(5) ~} some ${i} %{endfor}\n",
+			},
+		},
+		{
+			name:   "with no interpolation, return as is",
+			layout: []string{`s:stack:id=stackid`},
+			eval:   true,
+			args: []string{
+				`terramate.stack.id`,
+			},
+			want: runExpected{
+				Stdout: "terramate.stack.id\n",
+			},
+		},
+		{
+			name:   "eval of interpolation supports terramate metadata",
+			layout: []string{`s:stack:id=stackid`},
+			eval:   true,
+			args: []string{
+				`${terramate.stack.id}`,
+			},
+			want: runExpected{
+				Stdout: "stackid\n",
+			},
+		},
+		{
+			name:   "function interpolation and other HCL templating symbols",
+			layout: []string{`s:stack`},
+			eval:   true,
+			args: []string{
+				`test ${tm_upper("hcl")}`,
+				`%{ for i in tm_range(5) ~} some ${i} %{endfor}`,
+			},
+			want: runExpected{
+				Stdout: "test HCL some 0 some 1 some 2 some 3 some 4 \n",
+			},
+		},
+		{
+			name:   "no eval -- ignores escaped $ and other escaped HCL templating symbols",
+			layout: []string{`s:stack`},
+			eval:   true,
+			args: []string{
+				`test $${tm_upper(\"hcl\")}`,
+				`%%{ for i in tm_range(5) ~} some $${i} %%{endfor}`,
+			},
+			want: runExpected{
+				Stdout: "test ${tm_upper(\"hcl\")} %{ for i in tm_range(5) ~} some ${i} %{endfor}\n",
+			},
+		},
+		{
+			// WHY? When using --eval, each argument is interpreted as
+			// a raw HCL string content, which means it's the same as:
+			//   OQUOTE ARG CQUOTE
+			// Then if the user wants to include a literal quote, it must be
+			// escaped:
+			//   OQUOTE \" CQUOTE
+			name:   "malformed hcl string",
+			layout: []string{`s:stack`},
+			eval:   true,
+			args: []string{
+				`"`,
+			},
+			want: runExpected{
+				Status:      1,
+				StderrRegex: `parsing expression`,
+			},
+		},
+		{
+			name:   "escaped quote return as is",
+			layout: []string{`s:stack`},
+			eval:   true,
+			args: []string{
+				`\"`,
+			},
+			want: runExpected{
+				Stdout: "\"\n",
+			},
+		},
+		{
+			name:   "fs functions are not exposed",
+			layout: []string{`s:stack`},
+			eval:   true,
+			args: []string{
+				`${tm_abspath(".")}`,
+			},
+			want: runExpected{
+				Status:      1,
+				StderrRegex: `There is no function named`,
+			},
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			s := sandbox.New(t)
+			if len(tc.layout) == 0 {
+				t.Fatal("please set tc.layout, so it run at least 1 stack")
+			}
+			s.BuildTree(tc.layout)
+			git := s.Git()
+			git.CommitAll("everything")
+			tmCli := newCLI(t, s.RootDir())
+			cmd := []string{`run`}
+			if tc.eval {
+				cmd = append(cmd, `--eval`)
+			}
+
+			// WHY?
+			// we are executing: terramate run --eval -- <helper test binary> echo <arg1, ..., argN>
+			// the problem is that --eval requires each argument to be a valid
+			// HCL string but then on Windows we cannot just paste the test binary
+			// path here because it's not a valid HCL string. Example:
+			//   terramate run --eval -- C:\Users\i4k\test.exe arg1 arg2
+			// This will construct the HCL expression below:
+			//   "C:\Users\i4k\test.exe"
+			// and then the HCL parser fails because it's gonna interpret \U as an
+			// invalid unicode sequence.
+			//
+			// The user will have to properly escape it like:
+			//   terramate run --eval -- C:\\Users\\i4k\\test.exe arg1 arg2
+			//
+			// To avoid escaping everything, we are prepending the helper
+			// binary directory to the PATH environment and then invoking
+			// just the basename.
+			//   PATH=$HELPER_DIR:$PATH terramate run --eval -- test.exe echo arg1 arg2
+			testHelperDir := filepath.Dir(testHelperBin)
+			testHelperName := filepath.Base(testHelperBin)
+			tmCli.prependToPath(testHelperDir)
+			cmd = append(cmd, "--", testHelperName, "echo")
+			cmd = append(cmd, tc.args...)
+			assertRunResult(t, tmCli.run(cmd...), tc.want)
+		})
+	}
+}

--- a/cmd/terramate/e2etests/run_test.go
+++ b/cmd/terramate/e2etests/run_test.go
@@ -1740,10 +1740,9 @@ func TestRunFailIfGitSafeguardUntracked(t *testing.T) {
 	})
 
 	t.Run("disable check using env vars", func(t *testing.T) {
-		cli := newCLI(t, s.RootDir())
-		cli.env = append([]string{
-			"TM_DISABLE_CHECK_GIT_UNTRACKED=true",
-		}, testEnviron(t)...)
+		cli := newCLI(t, s.RootDir(), testEnviron(t)...)
+		cli.appendEnv = append(cli.appendEnv, "TM_DISABLE_CHECK_GIT_UNTRACKED=true")
+
 		assertRun(t, cli.run(
 			"run",
 			"--changed",
@@ -1911,11 +1910,8 @@ func TestRunFailIfGeneratedCodeIsOutdated(t *testing.T) {
 	})
 
 	t.Run("disable check using env vars", func(t *testing.T) {
-		tmcli := newCLI(t, s.RootDir())
-		tmcli.env = append([]string{
-			"TM_DISABLE_CHECK_GEN_CODE=true",
-		}, testEnviron(t)...)
-
+		tmcli := newCLI(t, s.RootDir(), testEnviron(t)...)
+		tmcli.appendEnv = append(tmcli.appendEnv, "TM_DISABLE_CHECK_GEN_CODE=true")
 		assertRunResult(t, tmcli.run("run", "--changed", testHelperBin, "cat", generateFile), runExpected{
 			Stdout: generateFileBody,
 		})
@@ -2039,10 +2035,8 @@ func TestRunFailIfGitSafeguardUncommitted(t *testing.T) {
 	})
 
 	t.Run("disable check using env vars", func(t *testing.T) {
-		cli := newCLI(t, s.RootDir())
-		cli.env = append([]string{
-			"TM_DISABLE_CHECK_GIT_UNCOMMITTED=true",
-		}, testEnviron(t)...)
+		cli := newCLI(t, s.RootDir(), testEnviron(t)...)
+		cli.appendEnv = append(cli.appendEnv, "TM_DISABLE_CHECK_GIT_UNCOMMITTED=true")
 
 		assertRunResult(t, cli.run("run", cat, mainTfFileName), runExpected{
 			Stdout: mainTfAlteredContents,
@@ -2286,8 +2280,7 @@ func TestRunWitCustomizedEnv(t *testing.T) {
 		fmt.Sprintf("TERRAMATE_TEST=%s", exportedTerramateTest),
 	)
 
-	tm := newCLI(t, s.RootDir())
-	tm.env = clienv
+	tm := newCLI(t, s.RootDir(), clienv...)
 
 	res := tm.run("run", testHelperBin, "env")
 	if res.Status != 0 {

--- a/cmd/terramate/e2etests/safeguard_test.go
+++ b/cmd/terramate/e2etests/safeguard_test.go
@@ -112,7 +112,7 @@ func TestSafeguardCheckRemoteDisabled(t *testing.T) {
 
 	fileContents := "# whatever"
 
-	setup := func(t *testing.T) (tmcli, sandbox.FileEntry, sandbox.S) {
+	setup := func(t *testing.T, env ...string) (tmcli, sandbox.FileEntry, sandbox.S) {
 		t.Helper()
 		s := sandbox.New(t)
 
@@ -126,7 +126,7 @@ func TestSafeguardCheckRemoteDisabled(t *testing.T) {
 			stack.CreateFile("some-new-file", "testing")
 		})
 
-		return newCLI(t, s.RootDir()), someFile, s
+		return newCLI(t, s.RootDir(), env...), someFile, s
 	}
 
 	cat := test.LookPath(t, "cat")
@@ -155,10 +155,8 @@ func TestSafeguardCheckRemoteDisabled(t *testing.T) {
 	})
 
 	t.Run("disable check_remote safeguard using env vars", func(t *testing.T) {
-		tmcli, file, _ := setup(t)
-		tmcli.env = append([]string{
-			"TM_DISABLE_CHECK_GIT_REMOTE=true",
-		}, testEnviron(t)...)
+		tmcli, file, _ := setup(t, testEnviron(t)...)
+		tmcli.appendEnv = append(tmcli.appendEnv, "TM_DISABLE_CHECK_GIT_REMOTE=true")
 
 		assertRunResult(t, tmcli.run("run", cat, file.HostPath()), runExpected{
 			Stdout: fileContents,

--- a/docs/cmdline/run.md
+++ b/docs/cmdline/run.md
@@ -62,6 +62,15 @@ Run a command in all stacks that don't contain specific tags, with reversed [ord
 terramate run  --reverse --no-tags type:k8s -- terraform apply
 ```
 
+Run a command that has its command name and arguments evaluated from an HCL string
+interpolation:
+
+```bash
+terramate run --eval -- '${global.my_default_command}' '--stack=${terramate.stack.path.absolute}'
+```
+
+When using `--eval` the arguments can reference `terramate`, `global` and `tm_` functions with the exception of filesystem related functions (`tm_file`, `tm_fileset`, etc are exposed).
+
 ## Options
 
 - `-B, --git-change-base=STRING` Git base ref for computing changes
@@ -74,6 +83,7 @@ terramate run  --reverse --no-tags type:k8s -- terraform apply
 - `--no-recursive` Do not recurse into child stacks
 - `--dry-run` Plan the execution but do not execute it
 - `--reverse` Reverse the order of execution
+- `--eval` Evaluate command line arguments as HCL strings
 
 ## Project wide `run` configuration.
 

--- a/stdlib/funcs.go
+++ b/stdlib/funcs.go
@@ -67,6 +67,30 @@ func Functions(basedir string) map[string]function.Function {
 	return tmfuncs
 }
 
+// NoFS returns all Terramate functions but excluding fs-related
+// functions.
+func NoFS(basedir string) map[string]function.Function {
+	funcs := Functions(basedir)
+	fsFuncNames := []string{
+		"tm_abspath",
+		"tm_file",
+		"tm_fileexists",
+		"tm_fileset",
+		"tm_filebase64",
+		"tm_filebase64sha256",
+		"tm_filebase64sha512",
+		"tm_filemd5",
+		"tm_filesha1",
+		"tm_filesha256",
+		"tm_filesha512",
+		"tm_templatefile",
+	}
+	for _, name := range fsFuncNames {
+		delete(funcs, name)
+	}
+	return funcs
+}
+
 // Regex is a copy of Terraform [stdlib.RegexFunc] but with cached compiled
 // patterns.
 func Regex() function.Function {


### PR DESCRIPTION
Introduces the `terramate run --eval` flag.

When set, all components of the command (name and arguments) can be evaluated from HCL strings.

Examples:

Evaluating stack metadata:
```bash
$ terramate run --eval -- echo '${terramate.stack.path.absolute}'
/stacks/a
/stacks/b
```

Evaluating globals:
```bash
$ cat globals.tm
globals {
    cmd = "terraform"
    arg = "apply"
}

$ terramate run --eval -- '${global.cmd}' '${global.arg}'
```

Don't forget to use single quotes or escape the `$`, otherwise your shell will interpret the dollar sign before Terramate can do it.
