### PR TITLE
Fix(cloud): typo: Context-Type → Content-Type

### DIFF
--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -230,7 +230,7 @@ func (c *Client) newRequest(ctx context.Context, method string, relativeURL stri
 	}
 	req.Header.Add("User-Agent", "terramate/v"+terramate.Version())
 	req.Header.Add("Authorization", "Bearer "+token)
-	req.Header.Add("Context-Type", contentType)
+	req.Header.Add("Content-Type", contentType)
 	return req, nil
 }
 


### PR DESCRIPTION
We used to not check for content type in the backend, we now do, therefore
requests fail now because of this. We're adding a middleware to the backend that
translates `Context-Type` to `Content-Type` for backwards compatability.