### PR TITLE
fix(cloud): deployment commit_sha is not sent anymore.

### DIFF
--- a/cloud/testserver/handlers.go
+++ b/cloud/testserver/handlers.go
@@ -119,6 +119,15 @@ func (dhandler *deploymentHandler) ServeHTTP(w http.ResponseWriter, r *http.Requ
 			return
 		}
 
+		// deployment commit_sha is not required but must be present in all test cases.
+		for _, st := range p.Stacks {
+			if st.CommitSHA == "" {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write([]byte(`commit_sha is missing`))
+				return
+			}
+		}
+
 		res := cloud.DeploymentStacksResponse{}
 		for _, s := range p.Stacks {
 			next := atomic.LoadInt64(&dhandler.nextStackID)

--- a/cmd/terramate/cli/cloud.go
+++ b/cmd/terramate/cli/cloud.go
@@ -220,6 +220,8 @@ func (c *cli) createCloudDeployment(runStacks []run.ExecContext) {
 		} else {
 			logger.Warn().Err(err).Msg("failed to retrieve repository URL")
 		}
+
+		deploymentCommitSHA = c.prj.headCommit()
 	}
 
 	ghRunID := os.Getenv("GITHUB_RUN_ID")


### PR DESCRIPTION
The issue was introduced in v0.4.1 by commit 403e2e4e3abd8fd416516fa8035bae331ab07e69.
