### PR TITLE
chore(cloud): send commit_sha in the metadata

### DIFF
--- a/cloud/types.go
+++ b/cloud/types.go
@@ -137,6 +137,7 @@ type (
 		DeploymentCommitVerified       *bool  `json:"deployment_commit_verified,omitempty"`
 		DeploymentCommitVerifiedReason string `json:"deployment_commit_verified_reason,omitempty"`
 
+		DeploymentCommitSHA         string `json:"deployment_commit_sha,omitempty"`
 		DeploymentCommitTitle       string `json:"deployment_commit_title,omitempty"`
 		DeploymentCommitDescription string `json:"deployment_commit_description,omitempty"`
 

--- a/cmd/terramate/cli/cloud.go
+++ b/cmd/terramate/cli/cloud.go
@@ -381,7 +381,8 @@ func (c *cli) tryGithubMetadata(normalizedRepo string) (*cloud.DeploymentReviewR
 	ctx, cancel := context.WithTimeout(context.Background(), defaultGithubTimeout)
 	defer cancel()
 
-	pulls, err := ghClient.PullsForCommit(ctx, ghRepo, c.prj.headCommit())
+	headCommit := c.prj.headCommit()
+	pulls, err := ghClient.PullsForCommit(ctx, ghRepo, headCommit)
 	if err != nil {
 		if errors.IsKind(err, github.ErrNotFound) {
 			if ghToken == "" {
@@ -414,12 +415,13 @@ func (c *cli) tryGithubMetadata(normalizedRepo string) (*cloud.DeploymentReviewR
 		Platform:              "github",
 		DeploymentTriggeredBy: os.Getenv("GITHUB_ACTOR"),
 		DeploymentBranch:      os.Getenv("GITHUB_REF_NAME"),
+		DeploymentCommitSHA:   headCommit,
 	}
 
 	ctx, cancel = context.WithTimeout(context.Background(), defaultGithubTimeout)
 	defer cancel()
 
-	commit, err := ghClient.Commit(ctx, ghRepo, c.prj.headCommit())
+	commit, err := ghClient.Commit(ctx, ghRepo, headCommit)
 	if err != nil {
 		logger.Warn().
 			Err(err).


### PR DESCRIPTION
# Reason for This Change

The `commit_sha` was missing in the `deployment_commit_*` set of metadata.

## Description of Changes

Added the field.