### PR TITLE
fix(gha,benchmark): GITHUB_SHA isn't the sha that triggered pr event.

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -27,7 +27,7 @@ jobs:
         id: benchmark
         run: |
           echo "result<<EOF" >> $GITHUB_OUTPUT
-          echo "$(make bench/check new=$GITHUB_SHA)" >> $GITHUB_OUTPUT
+          echo "$(make bench/check new=${{ github.event.pull_request.head.sha }})" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
       
       - uses: marocchino/sticky-pull-request-comment@v2

--- a/cmd/terramate/main.go
+++ b/cmd/terramate/main.go
@@ -17,5 +17,6 @@ import (
 )
 
 func main() {
+	// TO BE REMOVED - force triggering of benchmark
 	cli.Exec(terramate.Version(), os.Args[1:], os.Stdin, os.Stdout, os.Stderr)
 }


### PR DESCRIPTION
When the event is of type `pull_request`, the `GITHUB_SHA` environment
variable contains the sha of the merge branch created under the hood.
The merge commit is not reachable in the project's git tree.

It was changed to use `${{ github.event.pull_request.head.sha }}` which
points to the head of the PR at the time that the event triggered.
Note: when re-running the event, the same payload is used then the same
HEAD commit is used even if PR HEAD moved.

