### PR TITLE
feat: syncing drifts with Terramate Cloud

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 
 ## Unreleased
 
+### Added
+
+- Add `--cloud-sync-drift-status` flag for syncing the status of drift detection
+  to the Terramate Cloud.
+
 ### Fixed
 
 - Ensured that SIGINT aborts execution of subsequent stacks in all cases.

--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -31,6 +31,8 @@ const (
 	MembershipsPath = "/v1/memberships"
 	// DeploymentsPath is the deployments endpoint base path.
 	DeploymentsPath = "/v1/deployments"
+	// DriftsPath is the drifts endpoint base path.
+	DriftsPath = "/v1/drifts"
 	// StacksPath is the stacks endpoint base path.
 	StacksPath = "/v1/stacks"
 )
@@ -110,6 +112,25 @@ func (c *Client) CreateDeploymentStacks(
 func (c *Client) UpdateDeploymentStacks(ctx context.Context, orgUUID string, deploymentUUID string, payload UpdateDeploymentStacks) error {
 	_, err := Patch[EmptyResponse](ctx, c, payload, DeploymentsPath, orgUUID, deploymentUUID, "stacks")
 	return err
+}
+
+// CreateStackDrift pushes a new drift status for the given stack.
+func (c *Client) CreateStackDrift(
+	ctx context.Context,
+	orgUUID string,
+	driftPayload DriftStackPayloadRequest,
+) (EmptyResponse, error) {
+	err := driftPayload.Validate()
+	if err != nil {
+		return EmptyResponse(""), errors.E(err, "failed to prepare the request")
+	}
+	return Post[EmptyResponse](
+		ctx,
+		c,
+		driftPayload,
+		DriftsPath,
+		orgUUID,
+	)
 }
 
 // Get requests the endpoint components list making a GET request and decode the response into the

--- a/cloud/cloud_test.go
+++ b/cloud/cloud_test.go
@@ -266,7 +266,7 @@ func TestCloudStacks(t *testing.T) {
 			}`,
 			want: want{
 				stacks: cloud.StacksResponse{
-					Stacks: []cloud.Stack{},
+					Stacks: []cloud.StackResponse{},
 				},
 			},
 		},
@@ -347,16 +347,18 @@ func TestCloudStacks(t *testing.T) {
 			}`,
 			want: want{
 				stacks: cloud.StacksResponse{
-					Stacks: []cloud.Stack{
+					Stacks: []cloud.StackResponse{
 						{
-							ID:              666,
-							Repository:      "github.com/terramate-io/terramate",
-							Path:            "/docs",
-							MetaID:          "0aef0c2b-3314-4097-a7e5-3d6d03cb4604",
-							MetaName:        "documentation",
-							MetaDescription: "terramate documentation",
-							MetaTags:        []string{"docs"},
-							Status:          stack.Unrecognized,
+							ID: 666,
+							Stack: cloud.Stack{
+								Repository:      "github.com/terramate-io/terramate",
+								Path:            "/docs",
+								MetaID:          "0aef0c2b-3314-4097-a7e5-3d6d03cb4604",
+								MetaName:        "documentation",
+								MetaDescription: "terramate documentation",
+								MetaTags:        []string{"docs"},
+							},
+							Status: stack.Unrecognized,
 						},
 					},
 				},
@@ -443,36 +445,42 @@ func TestCloudStacks(t *testing.T) {
 			}`,
 			want: want{
 				stacks: cloud.StacksResponse{
-					Stacks: []cloud.Stack{
+					Stacks: []cloud.StackResponse{
 						{
-							ID:              666,
-							Repository:      "github.com/terramate-io/terramate",
-							Path:            "/docs",
-							MetaID:          "0aef0c2b-3314-4097-a7e5-3d6d03cb4604",
-							MetaName:        "documentation",
-							MetaDescription: "terramate documentation",
-							MetaTags:        []string{"docs"},
-							Status:          stack.OK,
+							ID: 666,
+							Stack: cloud.Stack{
+								Repository:      "github.com/terramate-io/terramate",
+								Path:            "/docs",
+								MetaID:          "0aef0c2b-3314-4097-a7e5-3d6d03cb4604",
+								MetaName:        "documentation",
+								MetaDescription: "terramate documentation",
+								MetaTags:        []string{"docs"},
+							},
+							Status: stack.OK,
 						},
 						{
-							ID:              667,
-							Repository:      "github.com/terramate-io/terramate",
-							Path:            "/",
-							MetaID:          "4ff324cd-f338-4526-8bcb-28ec33bbaeea",
-							MetaName:        "terramate",
-							MetaDescription: "terramate source code",
-							MetaTags:        []string{"golang"},
-							Status:          stack.OK,
+							ID: 667,
+							Stack: cloud.Stack{
+								Repository:      "github.com/terramate-io/terramate",
+								Path:            "/",
+								MetaID:          "4ff324cd-f338-4526-8bcb-28ec33bbaeea",
+								MetaName:        "terramate",
+								MetaDescription: "terramate source code",
+								MetaTags:        []string{"golang"},
+							},
+							Status: stack.OK,
 						},
 						{
-							ID:              668,
-							Repository:      "github.com/terramate-io/terramate",
-							Path:            "/_testdata/example-stack",
-							MetaID:          "terramate-example-stack",
-							MetaName:        "test-stacks",
-							MetaDescription: "Used in terramate tests",
-							MetaTags:        []string{"test"},
-							Status:          stack.OK},
+							ID: 668,
+							Stack: cloud.Stack{
+								Repository:      "github.com/terramate-io/terramate",
+								Path:            "/_testdata/example-stack",
+								MetaID:          "terramate-example-stack",
+								MetaName:        "test-stacks",
+								MetaDescription: "Used in terramate tests",
+								MetaTags:        []string{"test"},
+							},
+							Status: stack.OK},
 					},
 				},
 			},

--- a/cloud/stack/status.go
+++ b/cloud/stack/status.go
@@ -22,7 +22,7 @@ const (
 )
 
 type (
-	// Status of a stack or deployment.
+	// Status of a stack.
 	Status uint8
 
 	// FilterStatus represents a filter for stack statuses.

--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -131,6 +131,7 @@ type cliSpec struct {
 
 	Run struct {
 		CloudSyncDeployment   bool     `default:"false" help:"Enable synchronization of stack execution with the Terramate Cloud"`
+		CloudSyncDriftStatus  bool     `default:"false" help:"Enable drift detection and synchronization with the Terramate Cloud"`
 		DisableCheckGenCode   bool     `default:"false" help:"Disable outdated generated code check"`
 		DisableCheckGitRemote bool     `default:"false" help:"Disable checking if local default branch is updated with remote"`
 		ContinueOnError       bool     `default:"false" help:"Continue executing in other stacks in case of error"`

--- a/cmd/terramate/cli/cloud.go
+++ b/cmd/terramate/cli/cloud.go
@@ -5,8 +5,6 @@ package cli
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 	"os"
 	"strings"
 	"time"
@@ -21,7 +19,6 @@ import (
 	"github.com/terramate-io/terramate/cmd/terramate/cli/out"
 	"github.com/terramate-io/terramate/config"
 	"github.com/terramate-io/terramate/errors"
-	prj "github.com/terramate-io/terramate/project"
 )
 
 // ErrOnboardingIncomplete indicates the onboarding process is incomplete.
@@ -80,10 +77,11 @@ func (c *cli) cloudEnabled() bool {
 	return !c.cloud.disabled
 }
 
-func (c *cli) checkSyncDeployment() {
-	if !c.parsedArgs.Run.CloudSyncDeployment {
+func (c *cli) checkCloudSync() {
+	if !c.parsedArgs.Run.CloudSyncDeployment && !c.parsedArgs.Run.CloudSyncDriftStatus {
 		return
 	}
+
 	err := c.setupCloudConfig()
 	if err != nil {
 		log.Warn().Err(errors.E(err, "failed to check if credentials work")).
@@ -96,11 +94,12 @@ func (c *cli) checkSyncDeployment() {
 		return
 	}
 
-	c.cloud.run.meta2id = make(map[string]int)
-
-	c.cloud.run.runUUID, err = generateRunID()
-	if err != nil {
-		fatal(err, "generating run uuid")
+	if c.parsedArgs.Run.CloudSyncDeployment {
+		c.cloud.run.meta2id = make(map[string]int)
+		c.cloud.run.runUUID, err = generateRunID()
+		if err != nil {
+			fatal(err, "generating run uuid")
+		}
 	}
 }
 
@@ -165,203 +164,28 @@ func (c *cli) setupCloudConfig() error {
 	return nil
 }
 
-func (c *cli) createCloudDeployment(runStacks []ExecContext) {
-	logger := log.With().
-		Logger()
-
-	if !c.cloudEnabled() || !c.parsedArgs.Run.CloudSyncDeployment {
-		return
-	}
-
-	logger.Trace().Msg("Checking if selected stacks have id")
-
-	var stacksMissingIDs []string
-	for _, run := range runStacks {
-		if run.Stack.ID == "" {
-			stacksMissingIDs = append(stacksMissingIDs, run.Stack.Dir.String())
-		}
-	}
-
-	if len(stacksMissingIDs) > 0 {
-		for _, stackPath := range stacksMissingIDs {
-			logger.Error().Str("stack", stackPath).Msg("stack is missing the ID field")
-		}
-		logger.Warn().Msg("Stacks are missing IDs. You can use 'terramate create --ensure-stack-ids' to add missing IDs to all stacks.")
-		fatal(errors.E("The --cloud-sync-deployment flag requires that selected stacks contain an ID field"))
-	}
-
-	logger = logger.With().
-		Str("organization", c.cloud.run.orgUUID).
-		Logger()
-
-	ctx, cancel := context.WithTimeout(context.Background(), defaultCloudTimeout)
-	defer cancel()
-
-	var (
-		err                 error
-		deploymentCommitSHA string
-		deploymentURL       string
-		reviewRequest       *cloud.DeploymentReviewRequest
-		metadata            *cloud.DeploymentMetadata
-		normalizedRepo      string
-		ghRepo              string
-	)
-
-	if c.prj.isRepo {
-		repoURL, err := c.prj.git.wrapper.URL(c.prj.gitcfg().DefaultRemote)
-		if err == nil {
-			normalizedRepo = cloud.NormalizeGitURI(repoURL)
-			if normalizedRepo != "local" {
-				reviewRequest, metadata, ghRepo = c.tryGithubMetadata(normalizedRepo)
-			} else {
-				logger.Debug().Msg("skipping review_request for local repository")
-			}
-		} else {
-			logger.Warn().Err(err).Msg("failed to retrieve repository URL")
-		}
-
-		deploymentCommitSHA = c.prj.headCommit()
-	}
-
-	ghRunID := os.Getenv("GITHUB_RUN_ID")
-	ghAttempt := os.Getenv("GITHUB_RUN_ATTEMPT")
-	if ghRunID != "" && ghAttempt != "" && ghRepo != "" {
-		deploymentURL = fmt.Sprintf(
-			"https://github.com/%s/actions/runs/%s/attempts/%s",
-			ghRepo,
-			ghRunID,
-			ghAttempt,
-		)
-
-		logger.Debug().
-			Str("deployment_url", deploymentURL).
-			Msg("detected deployment url")
-	}
-
-	if metadata != nil {
-		data, err := json.Marshal(metadata)
-		if err == nil {
-			logger.Debug().RawJSON("provider_metadata", data).Msg("detected provider metadata")
-		} else {
-			logger.Warn().Err(err).Msg("failed to encode deployment metadata")
-		}
-	} else {
-		logger.Debug().Msg("no provider metadata detected")
-	}
-
-	payload := cloud.DeploymentStacksPayloadRequest{
-		ReviewRequest: reviewRequest,
-		Workdir:       prj.PrjAbsPath(c.rootdir(), c.wd()),
-		Metadata:      metadata,
-	}
-
-	for _, run := range runStacks {
-		tags := run.Stack.Tags
-		if tags == nil {
-			tags = []string{}
-		}
-		payload.Stacks = append(payload.Stacks, cloud.DeploymentStackRequest{
-			MetaID:            strings.ToLower(run.Stack.ID),
-			MetaName:          run.Stack.Name,
-			MetaDescription:   run.Stack.Description,
-			MetaTags:          tags,
-			Repository:        normalizedRepo,
-			Path:              run.Stack.Dir.String(),
-			CommitSHA:         deploymentCommitSHA,
-			DeploymentCommand: strings.Join(run.Cmd, " "),
-			DeploymentURL:     deploymentURL,
-		})
-	}
-	res, err := c.cloud.client.CreateDeploymentStacks(ctx, c.cloud.run.orgUUID, c.cloud.run.runUUID, payload)
-	if err != nil {
-		log.Warn().
-			Err(errors.E(err, "failed to create cloud deployment")).
-			Msg(DisablingCloudMessage)
-
-		c.cloud.disabled = true
-		return
-	}
-
-	if len(res) != len(runStacks) {
-		logger.Warn().Err(errors.E(
-			"the backend respond with an invalid number of stacks in the deployment: %d instead of %d",
-			len(res), len(runStacks)),
-		).Msg(DisablingCloudMessage)
-
-		c.cloud.disabled = true
-		return
-	}
-
-	for _, r := range res {
-		logger.Debug().Msgf("deployment created: %+v\n", r)
-		if r.StackMetaID == "" {
-			fatal(errors.E("backend returned empty meta_id"))
-		}
-		c.cloud.run.meta2id[r.StackMetaID] = r.StackID
-	}
-}
-
-func (c *cli) syncCloudDeployment(s *config.Stack, status deployment.Status) {
-	logger := log.With().
-		Str("organization", c.cloud.run.orgUUID).
-		Str("stack", s.RelPath()).
-		Stringer("status", status).
-		Logger()
-
-	stackID, ok := c.cloud.run.meta2id[s.ID]
-	if !ok {
-		logger.Error().Msg("unable to update deployment status due to invalid API response")
-		return
-	}
-
-	payload := cloud.UpdateDeploymentStacks{
-		Stacks: []cloud.UpdateDeploymentStack{
-			{
-				StackID: stackID,
-				Status:  status,
-			},
-		},
-	}
-
-	logger.Debug().Msg("updating deployment status")
-
-	ctx, cancel := context.WithTimeout(context.Background(), defaultCloudTimeout)
-	defer cancel()
-	err := c.cloud.client.UpdateDeploymentStacks(ctx, c.cloud.run.orgUUID, c.cloud.run.runUUID, payload)
-	if err != nil {
-		logger.Err(err).Str("stack_id", s.ID).Msg("failed to update deployment status for each")
-	}
-}
-
 func (c *cli) cloudSyncBefore(s *config.Stack, _ string) {
 	if !c.cloudEnabled() || !c.parsedArgs.Run.CloudSyncDeployment {
 		return
 	}
-	c.syncCloudDeployment(s, deployment.Running)
+	c.doCloudSyncDeployment(s, deployment.Running)
 }
 
-func (c *cli) cloudSyncAfter(s *config.Stack, err error) {
-	if !c.cloudEnabled() || !c.parsedArgs.Run.CloudSyncDeployment {
+func (c *cli) cloudSyncAfter(s *config.Stack, exitCode int, err error) {
+	if !c.cloudEnabled() || !c.isCloudSync() {
 		return
 	}
-	var status deployment.Status
-	switch {
-	case err == nil:
-		status = deployment.OK
-	case errors.IsKind(err, ErrRunCanceled):
-		status = deployment.Canceled
-	case errors.IsKind(err, ErrRunFailed):
-		status = deployment.Failed
-	default:
-		panic(errors.E(errors.ErrInternal, "unexpected run status"))
-	}
 
-	c.syncCloudDeployment(s, status)
+	if c.parsedArgs.Run.CloudSyncDeployment {
+		c.cloudSyncDeployment(s, err)
+	} else {
+		c.cloudSyncDriftStatus(s, exitCode, err)
+	}
 }
 
 func (c *cli) cloudSyncCancelStacks(stacks []ExecContext) {
 	for _, run := range stacks {
-		c.cloudSyncAfter(run.Stack, errors.E(ErrRunCanceled))
+		c.cloudSyncAfter(run.Stack, -1, errors.E(ErrRunCanceled))
 	}
 }
 
@@ -375,13 +199,13 @@ func (c *cli) cloudInfo() {
 	c.cloud.output.MsgStdOutV("next token refresh in: %s", time.Until(c.cred().ExpireAt()))
 }
 
-func (c *cli) tryGithubMetadata(normalizedRepo string) (*cloud.DeploymentReviewRequest, *cloud.DeploymentMetadata, string) {
+func (c *cli) tryGithubMetadata() (*cloud.DeploymentReviewRequest, *cloud.DeploymentMetadata, string) {
 	logger := log.With().
-		Str("normalized_repository", normalizedRepo).
+		Str("normalized_repository", c.prj.prettyRepo()).
 		Str("head_commit", c.prj.headCommit()).
 		Logger()
 
-	r, err := repository.Parse(normalizedRepo)
+	r, err := repository.Parse(c.prj.prettyRepo())
 	if err != nil {
 		logger.Debug().
 			Msg("repository cannot be normalized: skipping pull request retrievals for commit")
@@ -503,7 +327,7 @@ func (c *cli) tryGithubMetadata(normalizedRepo string) (*cloud.DeploymentReviewR
 
 	reviewRequest := &cloud.DeploymentReviewRequest{
 		Platform:    "github",
-		Repository:  normalizedRepo,
+		Repository:  c.prj.prettyRepo(),
 		URL:         pull.HTMLURL,
 		Number:      pull.Number,
 		Title:       pull.Title,
@@ -533,6 +357,10 @@ func (c *cli) tryGithubMetadata(normalizedRepo string) (*cloud.DeploymentReviewR
 	metadata.PullRequestClosedAt = pull.ClosedAt
 	metadata.PullRequestMergedAt = pull.MergedAt
 	return reviewRequest, metadata, ghToken
+}
+
+func (c *cli) isCloudSync() bool {
+	return c.parsedArgs.Run.CloudSyncDeployment || c.parsedArgs.Run.CloudSyncDriftStatus
 }
 
 func (c *cli) loadCredential() (credential, error) {

--- a/cmd/terramate/cli/cloud_sync_deployment.go
+++ b/cmd/terramate/cli/cloud_sync_deployment.go
@@ -1,0 +1,183 @@
+// Copyright 2023 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+package cli
+
+import (
+	"context"
+	stdjson "encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/rs/zerolog/log"
+	"github.com/terramate-io/terramate/cloud"
+	"github.com/terramate-io/terramate/cloud/deployment"
+	"github.com/terramate-io/terramate/config"
+	"github.com/terramate-io/terramate/errors"
+	prj "github.com/terramate-io/terramate/project"
+)
+
+func (c *cli) createCloudDeployment(runStacks []ExecContext) {
+	logger := log.With().
+		Logger()
+
+	if !c.cloudEnabled() {
+		return
+	}
+
+	logger = logger.With().
+		Str("organization", c.cloud.run.orgUUID).
+		Logger()
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultCloudTimeout)
+	defer cancel()
+
+	var (
+		err                 error
+		deploymentCommitSHA string
+		deploymentURL       string
+		reviewRequest       *cloud.DeploymentReviewRequest
+		metadata            *cloud.DeploymentMetadata
+		ghRepo              string
+	)
+
+	if c.prj.isRepo {
+		if c.prj.prettyRepo() != "local" {
+			reviewRequest, metadata, ghRepo = c.tryGithubMetadata()
+		} else {
+			logger.Debug().Msg("skipping review_request for local repository")
+		}
+
+		deploymentCommitSHA = c.prj.headCommit()
+	}
+
+	ghRunID := os.Getenv("GITHUB_RUN_ID")
+	ghAttempt := os.Getenv("GITHUB_RUN_ATTEMPT")
+	if ghRunID != "" && ghAttempt != "" && ghRepo != "" {
+		deploymentURL = fmt.Sprintf(
+			"https://github.com/%s/actions/runs/%s/attempts/%s",
+			ghRepo,
+			ghRunID,
+			ghAttempt,
+		)
+
+		logger.Debug().
+			Str("deployment_url", deploymentURL).
+			Msg("detected deployment url")
+	}
+
+	if metadata != nil {
+		data, err := stdjson.Marshal(metadata)
+		if err == nil {
+			logger.Debug().RawJSON("provider_metadata", data).Msg("detected provider metadata")
+		} else {
+			logger.Warn().Err(err).Msg("failed to encode deployment metadata")
+		}
+	} else {
+		logger.Debug().Msg("no provider metadata detected")
+	}
+
+	payload := cloud.DeploymentStacksPayloadRequest{
+		ReviewRequest: reviewRequest,
+		Workdir:       prj.PrjAbsPath(c.rootdir(), c.wd()),
+		Metadata:      metadata,
+	}
+
+	for _, run := range runStacks {
+		tags := run.Stack.Tags
+		if tags == nil {
+			tags = []string{}
+		}
+		payload.Stacks = append(payload.Stacks, cloud.DeploymentStackRequest{
+			Stack: cloud.Stack{
+				MetaID:          strings.ToLower(run.Stack.ID),
+				MetaName:        run.Stack.Name,
+				MetaDescription: run.Stack.Description,
+				MetaTags:        tags,
+				Repository:      c.prj.prettyRepo(),
+				Path:            run.Stack.Dir.String(),
+			},
+			CommitSHA:         deploymentCommitSHA,
+			DeploymentCommand: strings.Join(run.Cmd, " "),
+			DeploymentURL:     deploymentURL,
+		})
+	}
+	res, err := c.cloud.client.CreateDeploymentStacks(ctx, c.cloud.run.orgUUID, c.cloud.run.runUUID, payload)
+	if err != nil {
+		log.Warn().
+			Err(errors.E(err, "failed to create cloud deployment")).
+			Msg(DisablingCloudMessage)
+
+		c.cloud.disabled = true
+		return
+	}
+
+	if len(res) != len(runStacks) {
+		logger.Warn().Err(errors.E(
+			"the backend respond with an invalid number of stacks in the deployment: %d instead of %d",
+			len(res), len(runStacks)),
+		).Msg(DisablingCloudMessage)
+
+		c.cloud.disabled = true
+		return
+	}
+
+	for _, r := range res {
+		logger.Debug().Msgf("deployment created: %+v\n", r)
+		if r.StackMetaID == "" {
+			fatal(errors.E("backend returned empty meta_id"))
+		}
+		c.cloud.run.meta2id[r.StackMetaID] = r.StackID
+	}
+}
+
+func (c *cli) cloudSyncDeployment(s *config.Stack, err error) {
+	var status deployment.Status
+	switch {
+	case err == nil:
+		status = deployment.OK
+	case errors.IsKind(err, ErrRunCanceled):
+		status = deployment.Canceled
+	case errors.IsAnyKind(err, ErrRunFailed, ErrRunCommandNotFound):
+		status = deployment.Failed
+	default:
+		panic(errors.E(errors.ErrInternal, "unexpected run status"))
+	}
+
+	c.doCloudSyncDeployment(s, status)
+}
+
+func (c *cli) doCloudSyncDeployment(s *config.Stack, status deployment.Status) {
+	logger := log.With().
+		Str("organization", c.cloud.run.orgUUID).
+		Str("stack", s.RelPath()).
+		Stringer("status", status).
+		Logger()
+
+	stackID, ok := c.cloud.run.meta2id[s.ID]
+	if !ok {
+		logger.Error().Msg("unable to update deployment status due to invalid API response")
+		return
+	}
+
+	payload := cloud.UpdateDeploymentStacks{
+		Stacks: []cloud.UpdateDeploymentStack{
+			{
+				StackID: stackID,
+				Status:  status,
+			},
+		},
+	}
+
+	logger.Debug().Msg("updating deployment status")
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultCloudTimeout)
+	defer cancel()
+	err := c.cloud.client.UpdateDeploymentStacks(ctx, c.cloud.run.orgUUID, c.cloud.run.runUUID, payload)
+	if err != nil {
+		logger.Err(err).Str("stack_id", s.ID).Msg("failed to update deployment status for each")
+	} else {
+		logger.Debug().Msg("deployment status synced successfully")
+	}
+}

--- a/cmd/terramate/cli/cloud_sync_drift.go
+++ b/cmd/terramate/cli/cloud_sync_drift.go
@@ -1,0 +1,62 @@
+// Copyright 2023 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+package cli
+
+import (
+	"context"
+
+	"github.com/rs/zerolog/log"
+	"github.com/terramate-io/terramate/cloud"
+	"github.com/terramate-io/terramate/cloud/stack"
+	"github.com/terramate-io/terramate/config"
+	"github.com/terramate-io/terramate/errors"
+)
+
+func (c *cli) cloudSyncDriftStatus(st *config.Stack, exitCode int, err error) {
+	logger := log.With().
+		Str("action", "cloudSyncDriftStatus").
+		Stringer("stack", st.Dir).
+		Int("exit_code", exitCode).
+		Err(err).
+		Logger()
+
+	var status stack.Status
+	switch {
+	case exitCode == 0:
+		status = stack.OK
+	case exitCode == 2:
+		status = stack.Drifted
+	case exitCode == 1 || exitCode > 2 || errors.IsAnyKind(err, ErrRunCommandNotFound, ErrRunFailed):
+		status = stack.Failed
+	default:
+		// ignore exit codes < 0
+		logger.Debug().Msg("skipping drift sync")
+		return
+	}
+
+	logger = logger.With().
+		Stringer("drift_status", status).
+		Logger()
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultCloudTimeout)
+	defer cancel()
+
+	_, err = c.cloud.client.CreateStackDrift(ctx, c.cloud.run.orgUUID, cloud.DriftStackPayloadRequest{
+		Stack: cloud.Stack{
+			Repository:      c.prj.prettyRepo(),
+			Path:            st.Dir.String(),
+			MetaID:          st.ID,
+			MetaName:        st.Name,
+			MetaDescription: st.Description,
+			MetaTags:        st.Tags,
+		},
+		Status: status,
+	})
+
+	if err != nil {
+		logger.Error().Err(err).Msg("failed to sync the drift status")
+	} else {
+		logger.Debug().Msg("synced drift_status successfully")
+	}
+}

--- a/cmd/terramate/e2etests/exp_trigger_cloud_test.go
+++ b/cmd/terramate/e2etests/exp_trigger_cloud_test.go
@@ -34,11 +34,13 @@ func TestTriggerUnhealthyStacks(t *testing.T) {
 	git.Push("main")
 	git.CheckoutNew("trigger-the-stack")
 
-	cloudtest.PutStack(t, testserver.DefaultOrgUUID, cloud.Stack{
-		ID:         1,
-		Repository: repository,
-		MetaID:     stackID,
-		Status:     stack.Failed,
+	cloudtest.PutStack(t, testserver.DefaultOrgUUID, cloud.StackResponse{
+		ID: 1,
+		Stack: cloud.Stack{
+			Repository: repository,
+			MetaID:     stackID,
+		},
+		Status: stack.Failed,
 	})
 
 	git.SetRemoteURL("origin", fmt.Sprintf(`https://%s.git`, repository))
@@ -66,7 +68,7 @@ func TestCloudTriggerUnhealthy(t *testing.T) {
 		name       string
 		layout     []string
 		repository string
-		stacks     []cloud.Stack
+		stacks     []cloud.StackResponse
 		flags      []string
 		workingDir string
 		want       want
@@ -126,12 +128,14 @@ func TestCloudTriggerUnhealthy(t *testing.T) {
 				"s:s1:id=s1",
 				"s:s2:id=s2",
 			},
-			stacks: []cloud.Stack{
+			stacks: []cloud.StackResponse{
 				{
-					ID:         1,
-					MetaID:     "s1",
-					Repository: "github.com/terramate-io/terramate",
-					Status:     stack.OK,
+					ID: 1,
+					Stack: cloud.Stack{
+						MetaID:     "s1",
+						Repository: "github.com/terramate-io/terramate",
+					},
+					Status: stack.OK,
 				},
 			},
 			flags: []string{`--experimental-status=unhealthy`},
@@ -142,12 +146,14 @@ func TestCloudTriggerUnhealthy(t *testing.T) {
 				"s:s1:id=s1",
 				"s:s2:id=s2",
 			},
-			stacks: []cloud.Stack{
+			stacks: []cloud.StackResponse{
 				{
-					ID:         1,
-					MetaID:     "s1",
-					Repository: "gitlab.com/unknown-io/other",
-					Status:     stack.Failed,
+					ID: 1,
+					Stack: cloud.Stack{
+						MetaID:     "s1",
+						Repository: "gitlab.com/unknown-io/other",
+					},
+					Status: stack.Failed,
 				},
 			},
 			flags: []string{`--experimental-status=unhealthy`},
@@ -158,12 +164,14 @@ func TestCloudTriggerUnhealthy(t *testing.T) {
 				"s:s1:id=s1",
 				"s:s2:id=s2",
 			},
-			stacks: []cloud.Stack{
+			stacks: []cloud.StackResponse{
 				{
-					ID:         1,
-					MetaID:     "s1",
-					Repository: "github.com/terramate-io/terramate",
-					Status:     stack.Failed,
+					ID: 1,
+					Stack: cloud.Stack{
+						MetaID:     "s1",
+						Repository: "github.com/terramate-io/terramate",
+					},
+					Status: stack.Failed,
 				},
 			},
 			flags: []string{`--experimental-status=unhealthy`},
@@ -182,18 +190,22 @@ func TestCloudTriggerUnhealthy(t *testing.T) {
 				"s:s1:id=s1",
 				"s:s2:id=s2",
 			},
-			stacks: []cloud.Stack{
+			stacks: []cloud.StackResponse{
 				{
-					ID:         1,
-					MetaID:     "s1",
-					Repository: "github.com/terramate-io/terramate",
-					Status:     stack.Failed,
+					ID: 1,
+					Stack: cloud.Stack{
+						MetaID:     "s1",
+						Repository: "github.com/terramate-io/terramate",
+					},
+					Status: stack.Failed,
 				},
 				{
-					ID:         2,
-					MetaID:     "s2",
-					Repository: "github.com/terramate-io/terramate",
-					Status:     stack.OK,
+					ID: 2,
+					Stack: cloud.Stack{
+						MetaID:     "s2",
+						Repository: "github.com/terramate-io/terramate",
+					},
+					Status: stack.OK,
 				},
 			},
 			flags: []string{`--experimental-status=unhealthy`},
@@ -209,18 +221,22 @@ func TestCloudTriggerUnhealthy(t *testing.T) {
 		{
 			name:   "no local stacks, 2 unhealthy stacks, trigger nothing",
 			layout: []string{},
-			stacks: []cloud.Stack{
+			stacks: []cloud.StackResponse{
 				{
-					ID:         1,
-					MetaID:     "s1",
-					Repository: "github.com/terramate-io/terramate",
-					Status:     stack.Failed,
+					ID: 1,
+					Stack: cloud.Stack{
+						MetaID:     "s1",
+						Repository: "github.com/terramate-io/terramate",
+					},
+					Status: stack.Failed,
 				},
 				{
-					ID:         2,
-					MetaID:     "s2",
-					Repository: "github.com/terramate-io/terramate",
-					Status:     stack.Drifted,
+					ID: 2,
+					Stack: cloud.Stack{
+						MetaID:     "s2",
+						Repository: "github.com/terramate-io/terramate",
+					},
+					Status: stack.Drifted,
 				},
 			},
 			flags: []string{`--experimental-status=unhealthy`},
@@ -231,18 +247,22 @@ func TestCloudTriggerUnhealthy(t *testing.T) {
 				"s:s1:id=s1",
 				"s:s2:id=s2",
 			},
-			stacks: []cloud.Stack{
+			stacks: []cloud.StackResponse{
 				{
-					ID:         1,
-					MetaID:     "s1",
-					Repository: "github.com/terramate-io/terramate",
-					Status:     stack.Failed,
+					ID: 1,
+					Stack: cloud.Stack{
+						MetaID:     "s1",
+						Repository: "github.com/terramate-io/terramate",
+					},
+					Status: stack.Failed,
 				},
 				{
-					ID:         2,
-					MetaID:     "s2",
-					Repository: "github.com/terramate-io/terramate",
-					Status:     stack.Drifted,
+					ID: 2,
+					Stack: cloud.Stack{
+						MetaID:     "s2",
+						Repository: "github.com/terramate-io/terramate",
+					},
+					Status: stack.Drifted,
 				},
 			},
 			flags: []string{`--experimental-status=unhealthy`},
@@ -262,18 +282,22 @@ func TestCloudTriggerUnhealthy(t *testing.T) {
 				"s:s2:id=s2",
 				"s:stack-without-id",
 			},
-			stacks: []cloud.Stack{
+			stacks: []cloud.StackResponse{
 				{
-					ID:         1,
-					MetaID:     "s1",
-					Repository: "github.com/terramate-io/terramate",
-					Status:     stack.Failed,
+					ID: 1,
+					Stack: cloud.Stack{
+						MetaID:     "s1",
+						Repository: "github.com/terramate-io/terramate",
+					},
+					Status: stack.Failed,
 				},
 				{
-					ID:         2,
-					MetaID:     "s2",
-					Repository: "github.com/terramate-io/terramate",
-					Status:     stack.Drifted,
+					ID: 2,
+					Stack: cloud.Stack{
+						MetaID:     "s2",
+						Repository: "github.com/terramate-io/terramate",
+					},
+					Status: stack.Drifted,
 				},
 			},
 			flags: []string{`--experimental-status=unhealthy`},

--- a/cmd/terramate/e2etests/list_cloud_test.go
+++ b/cmd/terramate/e2etests/list_cloud_test.go
@@ -19,7 +19,7 @@ func TestCloudListUnhealthy(t *testing.T) {
 		name       string
 		layout     []string
 		repository string
-		stacks     []cloud.Stack
+		stacks     []cloud.StackResponse
 		flags      []string
 		workingDir string
 		want       runExpected
@@ -72,12 +72,14 @@ func TestCloudListUnhealthy(t *testing.T) {
 				"s:s1:id=s1",
 				"s:s2:id=s2",
 			},
-			stacks: []cloud.Stack{
+			stacks: []cloud.StackResponse{
 				{
-					ID:         1,
-					MetaID:     "s1",
-					Repository: "github.com/terramate-io/terramate",
-					Status:     stack.OK,
+					ID: 1,
+					Stack: cloud.Stack{
+						MetaID:     "s1",
+						Repository: "github.com/terramate-io/terramate",
+					},
+					Status: stack.OK,
 				},
 			},
 			flags: []string{`--experimental-status=unhealthy`},
@@ -88,12 +90,14 @@ func TestCloudListUnhealthy(t *testing.T) {
 				"s:s1:id=s1",
 				"s:s2:id=s2",
 			},
-			stacks: []cloud.Stack{
+			stacks: []cloud.StackResponse{
 				{
-					ID:         1,
-					MetaID:     "s1",
-					Repository: "gitlab.com/unknown-io/other",
-					Status:     stack.Failed,
+					ID: 1,
+					Stack: cloud.Stack{
+						MetaID:     "s1",
+						Repository: "gitlab.com/unknown-io/other",
+					},
+					Status: stack.Failed,
 				},
 			},
 			flags: []string{`--experimental-status=unhealthy`},
@@ -104,12 +108,14 @@ func TestCloudListUnhealthy(t *testing.T) {
 				"s:s1:id=s1",
 				"s:s2:id=s2",
 			},
-			stacks: []cloud.Stack{
+			stacks: []cloud.StackResponse{
 				{
-					ID:         1,
-					MetaID:     "s1",
-					Repository: "github.com/terramate-io/terramate",
-					Status:     stack.Failed,
+					ID: 1,
+					Stack: cloud.Stack{
+						MetaID:     "s1",
+						Repository: "github.com/terramate-io/terramate",
+					},
+					Status: stack.Failed,
 				},
 			},
 			flags: []string{`--experimental-status=unhealthy`},
@@ -123,18 +129,22 @@ func TestCloudListUnhealthy(t *testing.T) {
 				"s:s1:id=s1",
 				"s:s2:id=s2",
 			},
-			stacks: []cloud.Stack{
+			stacks: []cloud.StackResponse{
 				{
-					ID:         1,
-					MetaID:     "s1",
-					Repository: "github.com/terramate-io/terramate",
-					Status:     stack.Failed,
+					ID: 1,
+					Stack: cloud.Stack{
+						MetaID:     "s1",
+						Repository: "github.com/terramate-io/terramate",
+					},
+					Status: stack.Failed,
 				},
 				{
-					ID:         2,
-					MetaID:     "s2",
-					Repository: "github.com/terramate-io/terramate",
-					Status:     stack.OK,
+					ID: 2,
+					Stack: cloud.Stack{
+						MetaID:     "s2",
+						Repository: "github.com/terramate-io/terramate",
+					},
+					Status: stack.OK,
 				},
 			},
 			flags: []string{`--experimental-status=unhealthy`},
@@ -145,18 +155,22 @@ func TestCloudListUnhealthy(t *testing.T) {
 		{
 			name:   "no local stacks, 2 unhealthy stacks, return nothing",
 			layout: []string{},
-			stacks: []cloud.Stack{
+			stacks: []cloud.StackResponse{
 				{
-					ID:         1,
-					MetaID:     "s1",
-					Repository: "github.com/terramate-io/terramate",
-					Status:     stack.Failed,
+					ID: 1,
+					Stack: cloud.Stack{
+						MetaID:     "s1",
+						Repository: "github.com/terramate-io/terramate",
+					},
+					Status: stack.Failed,
 				},
 				{
-					ID:         2,
-					MetaID:     "s2",
-					Repository: "github.com/terramate-io/terramate",
-					Status:     stack.Drifted,
+					ID: 2,
+					Stack: cloud.Stack{
+						MetaID:     "s2",
+						Repository: "github.com/terramate-io/terramate",
+					},
+					Status: stack.Drifted,
 				},
 			},
 			flags: []string{`--experimental-status=unhealthy`},
@@ -167,18 +181,22 @@ func TestCloudListUnhealthy(t *testing.T) {
 				"s:s1:id=s1",
 				"s:s2:id=s2",
 			},
-			stacks: []cloud.Stack{
+			stacks: []cloud.StackResponse{
 				{
-					ID:         1,
-					MetaID:     "s1",
-					Repository: "github.com/terramate-io/terramate",
-					Status:     stack.Failed,
+					ID: 1,
+					Stack: cloud.Stack{
+						MetaID:     "s1",
+						Repository: "github.com/terramate-io/terramate",
+					},
+					Status: stack.Failed,
 				},
 				{
-					ID:         2,
-					MetaID:     "s2",
-					Repository: "github.com/terramate-io/terramate",
-					Status:     stack.Drifted,
+					ID: 2,
+					Stack: cloud.Stack{
+						MetaID:     "s2",
+						Repository: "github.com/terramate-io/terramate",
+					},
+					Status: stack.Drifted,
 				},
 			},
 			flags: []string{`--experimental-status=unhealthy`},
@@ -193,18 +211,22 @@ func TestCloudListUnhealthy(t *testing.T) {
 				"s:s2:id=s2",
 				"s:stack-without-id",
 			},
-			stacks: []cloud.Stack{
+			stacks: []cloud.StackResponse{
 				{
-					ID:         1,
-					MetaID:     "s1",
-					Repository: "github.com/terramate-io/terramate",
-					Status:     stack.Failed,
+					ID: 1,
+					Stack: cloud.Stack{
+						MetaID:     "s1",
+						Repository: "github.com/terramate-io/terramate",
+					},
+					Status: stack.Failed,
 				},
 				{
-					ID:         2,
-					MetaID:     "s2",
-					Repository: "github.com/terramate-io/terramate",
-					Status:     stack.Drifted,
+					ID: 2,
+					Stack: cloud.Stack{
+						MetaID:     "s2",
+						Repository: "github.com/terramate-io/terramate",
+					},
+					Status: stack.Drifted,
 				},
 			},
 			flags: []string{`--experimental-status=unhealthy`},

--- a/cmd/terramate/e2etests/run_cloud_drift_test.go
+++ b/cmd/terramate/e2etests/run_cloud_drift_test.go
@@ -1,0 +1,317 @@
+// Copyright 2023 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+package e2etest
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/madlambda/spells/assert"
+	"github.com/terramate-io/terramate/cloud"
+	"github.com/terramate-io/terramate/cloud/stack"
+	"github.com/terramate-io/terramate/cloud/testserver"
+	"github.com/terramate-io/terramate/test/sandbox"
+)
+
+func TestCLIRunWithCloudSyncDriftStatus(t *testing.T) {
+	type want struct {
+		run    runExpected
+		drifts cloud.DriftStackPayloadRequests
+	}
+	type testcase struct {
+		name       string
+		layout     []string
+		runflags   []string
+		workingDir string
+		cmd        []string
+		want       want
+		runMode    runMode
+	}
+
+	for _, tc := range []testcase{
+		{
+			name: "all stacks must have ids",
+			layout: []string{
+				"s:s1:id=s1",
+				"s:s2", // missing id
+			},
+			want: want{
+				run: runExpected{
+					Status:      1,
+					StderrRegex: "flag requires that selected stacks contain an ID field",
+				},
+			},
+		},
+		{
+			name:   "command not found -- set status=failed",
+			layout: []string{"s:stack:id=stack"},
+			cmd:    []string{"non-existent-command"},
+			want: want{
+				run: runExpected{
+					Status:      1,
+					StderrRegex: "executable file not found",
+				},
+				drifts: cloud.DriftStackPayloadRequests{
+					{
+						Stack: cloud.Stack{
+							Repository: "local",
+							Path:       "/stack",
+							MetaName:   "stack",
+							MetaID:     "stack",
+						},
+						Status: stack.Failed,
+					},
+				},
+			},
+		},
+		{
+			name: "failed cmd cancels execution of subsequent stacks",
+			layout: []string{
+				"s:s1:id=s1",
+				"s:s2:id=s2",
+			},
+			cmd: []string{"non-existent-command"},
+			want: want{
+				run: runExpected{
+					Status:      1,
+					StderrRegex: "executable file not found",
+				},
+				drifts: cloud.DriftStackPayloadRequests{
+					{
+						Stack: cloud.Stack{
+							Repository: "local",
+							Path:       "/s1",
+							MetaName:   "s1",
+							MetaID:     "s1",
+						},
+						Status: stack.Failed,
+					},
+				},
+			},
+		},
+
+		{
+			name: "both failed stacks and continueOnError",
+			layout: []string{
+				"s:s1:id=s1",
+				"s:s2:id=s2",
+			},
+			runflags: []string{"--continue-on-error"},
+			cmd:      []string{"non-existent-command"},
+			want: want{
+				run: runExpected{
+					Status:      1,
+					StderrRegex: "executable file not found",
+				},
+				drifts: cloud.DriftStackPayloadRequests{
+					{
+						Stack: cloud.Stack{
+							Repository: "local",
+							Path:       "/s1",
+							MetaName:   "s1",
+							MetaID:     "s1",
+						},
+						Status: stack.Failed,
+					},
+					{
+						Stack: cloud.Stack{
+							Repository: "local",
+							Path:       "/s2",
+							MetaName:   "s2",
+							MetaID:     "s2",
+						},
+						Status: stack.Failed,
+					},
+				},
+			},
+		},
+		{
+			name: "failed cmd and continueOnError",
+			layout: []string{
+				"s:s1:id=s1",
+				"s:s2:id=s2",
+				"f:s2/test.txt:test",
+			},
+			runflags: []string{"--continue-on-error"},
+			cmd:      []string{testHelperBin, "cat", "test.txt"},
+			want: want{
+				run: runExpected{
+					Status:      1,
+					Stdout:      "test",
+					StderrRegex: `(no such file or directory|The system cannot find the file specified)`,
+				},
+				drifts: cloud.DriftStackPayloadRequests{
+					{
+						Stack: cloud.Stack{
+							Repository: "local",
+							Path:       "/s1",
+							MetaName:   "s1",
+							MetaID:     "s1",
+						},
+						Status: stack.Failed,
+					},
+					{
+						Stack: cloud.Stack{
+							Repository: "local",
+							Path:       "/s2",
+							MetaName:   "s2",
+							MetaID:     "s2",
+						},
+						Status: stack.OK,
+					},
+				},
+			},
+		},
+		{
+			name:    "canceled hang command",
+			layout:  []string{"s:stack:id=stack"},
+			runMode: hangRun,
+			want: want{
+				run: runExpected{
+					Status:       1,
+					IgnoreStdout: true,
+					IgnoreStderr: true,
+				},
+			},
+		},
+		{
+			name:    "skipped subsequent stacks",
+			layout:  []string{"s:s1:id=s1", "s:s2:id=s2"},
+			runMode: sleepRun,
+			want: want{
+				run: runExpected{
+					Status:       1,
+					IgnoreStdout: true,
+					IgnoreStderr: true,
+				},
+				drifts: cloud.DriftStackPayloadRequests{
+					{
+						Stack: cloud.Stack{
+							Repository: "local",
+							Path:       "/s1",
+							MetaName:   "s1",
+							MetaID:     "s1",
+						},
+						Status: stack.Failed,
+					},
+				},
+			},
+		},
+		{
+			name:   "basic drift sync",
+			layout: []string{"s:stack:id=stack"},
+			cmd: []string{
+				testHelperBin, "exit", "2",
+			},
+			want: want{
+				drifts: cloud.DriftStackPayloadRequests{
+					{
+						Stack: cloud.Stack{
+							Repository: "local",
+							Path:       "/stack",
+							MetaName:   "stack",
+							MetaID:     "stack",
+						},
+						Status: stack.Drifted,
+					},
+				},
+			},
+		},
+		{
+			name: "only stacks inside working dir are synced",
+			layout: []string{
+				"s:parent:id=parent",
+				"s:parent/child:id=child",
+			},
+			workingDir: "parent/child",
+			want: want{
+				run: runExpected{
+					Status: 0,
+					Stdout: "/parent/child\n",
+				},
+				drifts: cloud.DriftStackPayloadRequests{
+					{
+						Stack: cloud.Stack{
+							Repository: "local",
+							Path:       "/parent/child",
+							MetaName:   "child",
+							MetaID:     "child",
+						},
+						Status: stack.OK,
+					},
+				},
+			},
+		},
+		{
+			name: "multiple drifted stacks",
+			layout: []string{
+				"s:s1:id=s1",
+				"s:s2:id=s2",
+			},
+			cmd: []string{testHelperBin, "exit", "2"},
+			want: want{
+				drifts: cloud.DriftStackPayloadRequests{
+					{
+						Stack: cloud.Stack{
+							Repository: "local",
+							Path:       "/s1",
+							MetaName:   "s1",
+							MetaID:     "s1",
+						},
+						Status: stack.Drifted,
+					},
+					{
+						Stack: cloud.Stack{
+							Repository: "local",
+							Path:       "/s2",
+							MetaName:   "s2",
+							MetaID:     "s2",
+						},
+						Status: stack.Drifted,
+					},
+				},
+			},
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			// NOTE: this test needs to be serial :-(
+			startFakeTMCServer(t)
+
+			s := sandbox.New(t)
+
+			s.BuildTree(tc.layout)
+			s.Git().CommitAll("all stacks committed")
+			cli := newCLI(t, filepath.Join(s.RootDir(), filepath.FromSlash(tc.workingDir)))
+			runflags := []string{"--cloud-sync-drift-status"}
+			runflags = append(runflags, tc.runflags...)
+
+			fixture := cli.newRunFixture(tc.runMode, s.RootDir(), runflags...)
+			fixture.cmd = tc.cmd // if empty, uses the runFixture default cmd.
+			result := fixture.run()
+			assertRunResult(t, result, tc.want.run)
+			assertRunDrifts(t, tc.want.drifts)
+		})
+	}
+}
+
+func assertRunDrifts(t *testing.T, expectedDrifts cloud.DriftStackPayloadRequests) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	res, err := cloud.Request[cloud.DriftStackPayloadRequests](ctx, &cloud.Client{
+		BaseURL:    "http://localhost:3001",
+		Credential: &credential{},
+	}, "GET", cloud.DriftsPath+"/"+testserver.DefaultOrgUUID, nil)
+	assert.NoError(t, err)
+
+	if diff := cmp.Diff(res, expectedDrifts); diff != "" {
+		t.Logf("want: %+v", expectedDrifts)
+		t.Logf("got: %+v", res)
+		t.Fatal(diff)
+	}
+}

--- a/cmd/terramate/e2etests/run_signal_test.go
+++ b/cmd/terramate/e2etests/run_signal_test.go
@@ -88,9 +88,15 @@ func testSIGINTx3(t *testing.T, continueOnError bool) {
 		"/stack1", "ready",
 	}
 
+	errs := make(chan error)
+	go func() {
+		errs <- cmd.wait()
+		close(errs)
+	}()
+
 	assert.NoError(
 		t,
-		pollBufferForMsgs(cmd.stdout, expectedStdout...),
+		pollBufferForMsgs(cmd.stdout, errs, expectedStdout...),
 		"failed to start: %s", cmd.stderr.String(),
 	)
 
@@ -105,12 +111,6 @@ func testSIGINTx3(t *testing.T, continueOnError bool) {
 	// or it is able to send messages to stdout.
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
-
-	errs := make(chan error)
-	go func() {
-		errs <- cmd.wait()
-		close(errs)
-	}()
 
 	for ctx.Err() == nil {
 		t.Log("sending last interrupt signal to terramate")
@@ -180,20 +180,20 @@ EOF
 	cmd.setpgid()
 	cmd.start()
 
-	expectedStdout := []string{
-		"/stack1", "ready",
-	}
-
-	assert.NoError(t, pollBufferForMsgs(cmd.stdout, expectedStdout...), cmd.stderr.String())
-
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-	defer cancel()
-
 	errs := make(chan error)
 	go func() {
 		errs <- cmd.wait()
 		close(errs)
 	}()
+
+	expectedStdout := []string{
+		"/stack1", "ready",
+	}
+
+	assert.NoError(t, pollBufferForMsgs(cmd.stdout, errs, expectedStdout...), cmd.stderr.String())
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
 
 	for ctx.Err() == nil {
 		t.Log("sending interrupt signal to terramate")
@@ -229,7 +229,7 @@ EOF
 // like "urgent I/O condition". This function will ignore any unknown messages
 // in between but check that at least all msgs where received in the provided
 // order (but ignoring unknown messages in between).
-func pollBufferForMsgs(buf *buffer, wantMsgs ...string) error {
+func pollBufferForMsgs(buf *buffer, done chan error, wantMsgs ...string) error {
 	const (
 		timeout      = 10 * time.Second
 		pollInterval = 30 * time.Millisecond
@@ -238,23 +238,28 @@ func pollBufferForMsgs(buf *buffer, wantMsgs ...string) error {
 	var elapsed time.Duration
 
 	for {
-		gotMsgs := strings.Split(buf.String(), "\n")
-		wantIndex := 0
+		select {
+		case err := <-done:
+			return err
+		default:
+			gotMsgs := strings.Split(buf.String(), "\n")
+			wantIndex := 0
 
-		for _, got := range gotMsgs {
-			if got == wantMsgs[wantIndex] {
-				wantIndex++
+			for _, got := range gotMsgs {
+				if got == wantMsgs[wantIndex] {
+					wantIndex++
+				}
+
+				if wantIndex == len(wantMsgs) {
+					return nil
+				}
 			}
 
-			if wantIndex == len(wantMsgs) {
-				return nil
+			time.Sleep(pollInterval)
+			elapsed += pollInterval
+			if elapsed > timeout {
+				return fmt.Errorf("timeout polling: wanted: %v got: %v", wantMsgs, gotMsgs)
 			}
-		}
-
-		time.Sleep(pollInterval)
-		elapsed += pollInterval
-		if elapsed > timeout {
-			return fmt.Errorf("timeout polling: wanted: %v got: %v", wantMsgs, gotMsgs)
 		}
 	}
 }
@@ -268,7 +273,7 @@ func sendUntilMsgIsReceived(t *testing.T, cmd *testCmd, signal os.Signal, msgs .
 
 	for {
 		cmd.signalGroup(signal)
-		err := pollBufferForMsgs(cmd.stdout, msgs...)
+		err := pollBufferForMsgs(cmd.stdout, make(chan error), msgs...)
 		if err == nil {
 			return
 		}

--- a/cmd/terramate/e2etests/runner_test.go
+++ b/cmd/terramate/e2etests/runner_test.go
@@ -5,6 +5,7 @@ package e2etest
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -220,6 +221,155 @@ func (tm tmcli) newCmd(args ...string) *testCmd {
 		stdout: stdout,
 		stderr: stderr,
 	}
+}
+
+type runMode int
+
+const (
+	normalRun runMode = iota
+	hangRun
+	sleepRun
+)
+
+type runFixture struct {
+	rootdir string
+	flags   []string
+	mode    runMode
+
+	cli *tmcli
+	cmd []string
+}
+
+const hangTimeout = time.Minute
+
+// newRunFixture returns a new runFixture ready to be executed which supports 3 execution modes:
+//   - normalRun: execute any command and wait for its completion.
+//   - hangRun:   execute an specialized command which never terminates and ignore all signals.
+//   - sleepRun:  execute an specialized command which sleeps for a configured amount of seconds.
+//
+// In the case of [hangRun] mode, the steps below will happen:
+//  1. The helper `hang` command is invoked.
+//  2. The test will poll the stdout buffer waiting for a "ready" message.
+//  3. When the process is ready, the testing will send CTRL-C twice and wait for the process acknowledge.
+//  4. The test will wait for [hangTimeout] seconds for a graceful exit, otherwise the process is killed with SIGKILL.
+//
+// In the case of [sleepRun] mode, the steps below will happen:
+//  1. The helper `sleep` command is invoked.
+//  2. The test will poll the stdout buffer waiting for a "ready" message.
+//  3. When the process is ready, the testing will send a single CTRL-C.
+//  4. The test will wait for process graceful exit.
+//
+// Usage:
+//
+//	cli := newCli(t, chdir)
+//	fixture := newRunFixture(hangRun, s.RootDir(), "--cloud-sync-deployment")
+//	result = fixture.run()
+//	assertRunResult(t, result, expected)
+func (tm *tmcli) newRunFixture(mode runMode, rootdir string, flags ...string) runFixture {
+	return runFixture{
+		rootdir: rootdir,
+		cli:     tm,
+		flags:   flags,
+		mode:    mode,
+	}
+}
+
+func (run *runFixture) run() runResult {
+	t := run.cli.t
+	t.Helper()
+
+	args := []string{"run"}
+	args = append(args, run.flags...)
+	args = append(args, "--")
+
+	switch run.mode {
+	case normalRun:
+		cmd := run.cmd
+		if len(cmd) == 0 {
+			// in normalMode the user can override the invoked command.
+			cmd = append(cmd, testHelperBin, "stack-abs-path", run.rootdir)
+		}
+		args = append(args, cmd...)
+	case hangRun:
+		args = append(args, testHelperBin, "hang")
+	case sleepRun:
+		args = append(args, testHelperBin, "sleep", "1m")
+	default:
+		t.Fatalf("unexpected run mode: %d", run.mode)
+	}
+
+	exec := run.cli.newCmd(args...)
+
+	switch run.mode {
+	case normalRun:
+		exec.start()
+		_ = exec.wait()
+	case hangRun:
+		testHangProcess(t, exec)
+	case sleepRun:
+		testSleepProcess(t, exec)
+	}
+
+	return runResult{
+		Cmd:    strings.Join(args, " "),
+		Stdout: exec.stdout.String(),
+		Stderr: exec.stderr.String(),
+		Status: exec.exitCode(),
+	}
+}
+
+func testHangProcess(t *testing.T, exec *testCmd) {
+	exec.setpgid()
+	exec.start()
+	errs := make(chan error)
+	go func() {
+		errs <- exec.wait()
+		close(errs)
+	}()
+	assert.NoError(t, pollBufferForMsgs(exec.stdout, errs, "ready"))
+	sendUntilMsgIsReceived(t, exec, os.Interrupt, "ready", "interrupt")
+	sendUntilMsgIsReceived(t, exec, os.Interrupt, "ready", "interrupt", "interrupt")
+
+	// We can't check the last interrupt message since the child process
+	// may be killed by Terramate with SIGKILL before it gets the signal
+	// or it is able to send messages to stdout.
+	ctx, cancel := context.WithTimeout(context.Background(), hangTimeout)
+	defer cancel()
+
+outer:
+	for ctx.Err() == nil {
+		t.Log("sending last interrupt signal to terramate")
+		exec.signalGroup(os.Interrupt)
+
+		sendctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+
+		select {
+		case err := <-errs:
+			t.Logf("terramate err: %v", err)
+			t.Logf("terramate stdout:\n%s\n", exec.stdout.String())
+			t.Logf("terramate stderr:\n%s\n", exec.stderr.String())
+			assert.Error(t, err)
+			break outer
+		case <-sendctx.Done():
+			t.Log("terramate still running, re-sending interrupt")
+		}
+	}
+
+	t.Logf("terramate stdout:\n%s\n", exec.stdout.String())
+	t.Logf("terramate stderr:\n%s\n", exec.stderr.String())
+}
+
+func testSleepProcess(t *testing.T, exec *testCmd) {
+	exec.setpgid()
+	exec.start()
+	done := make(chan error)
+	go func() {
+		done <- exec.wait()
+	}()
+	assert.NoError(t, pollBufferForMsgs(exec.stdout, done, "ready"))
+	exec.signalGroup(os.Interrupt)
+	<-done
 }
 
 func (tm tmcli) run(args ...string) runResult {

--- a/test/cloud/client.go
+++ b/test/cloud/client.go
@@ -19,7 +19,7 @@ const defaultTestTimeout = 1 * time.Second
 
 // PutStack sets a new stack in the /v1/stacks/<org>/<stack id>.
 // Note: this is not a real endpoint.
-func PutStack(t *testing.T, orgUUID string, st cloud.Stack) {
+func PutStack(t *testing.T, orgUUID string, st cloud.StackResponse) {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 


### PR DESCRIPTION
Introduce the `--cloud-sync-drift-status` flag for syncing drifts to the Terramate Cloud.

Usage:

```
$ terramate run --cloud-sync-drift-status -- terraform plan --detailed-exit-code
```

Below exit-code interpretation table:

| exit code | drift_status |
| ------------- | ------------- |
| 0  | ok |
| 1  | failed |
| 2  | drifted |
| n  | failed |

If for any reason the command is not invoked, or the stack execution is canceled by the user (CTRL-C), then no drift status is synced.
