### PR TITLE
chore: improve change detection error message.

### DIFF
--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -1336,6 +1336,10 @@ func (c *cli) printStacks() {
 		log.Fatal().Msg("the --why flag must be used together with --changed")
 	}
 
+	if !c.prj.isRepo && c.parsedArgs.Changed {
+		log.Fatal().Msg("The --changed flag requires a git repository")
+	}
+
 	mgr := stack.NewManager(c.cfg(), c.prj.baseRef)
 
 	status := parseStatusFilter(c.parsedArgs.List.ExperimentalStatus)


### PR DESCRIPTION
Terramate detects if it's running inside a git repository early on in the bootstrap phase and then we can provide a better error message if `--changed` is used in a non-git project.

## Reason for this change

From the tracing in issue #1159, Terramate is trying to do git change detection in a project that git was not detected. This PR does not solve the reported issue but aborts it early with a meaningful error message.
