### PR TITLE
chore: fix links in docs

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -179,7 +179,7 @@ export default defineConfig({
         collapsed: false,
         items: [
           { text: 'Globals', link: 'data-sharing/#globals' },
-          { text: 'Lazy Evaluation', link: 'data-sharing/#lazy-evaluation' },
+          { text: 'Lazy Evaluation', link: 'data-sharing/#lazy-evaluation-in-terramate' },
           { text: 'Metadata', link: 'data-sharing/#metadata' },
           { text: 'Map', link: 'map' },
         ],

--- a/docs/change-detection/index.md
+++ b/docs/change-detection/index.md
@@ -65,8 +65,8 @@ merged but alternatively the terraform plan/apply can be run in the PR's branch
 just before merge using the default branch base ref (`origin/main`).
 
 The `baseref` can be manually changed by the terramate command line at any given
-point in time using the `--git-change-base` option or through the [project configuration]
-(../configuration/project-config.md), so different strategies for computing the changes are
+point in time using the `--git-change-base` option or through the [project configuration](../configuration/project-config.md),
+so different strategies for computing the changes are
 supported.
 
 If you you adopt the rebase merge strategy and need to apply modifications to stacks


### PR DESCRIPTION
- chore: Fix .vitepress/config.ts link in docs
- chore: Fix change-detection link in docs

closes #1140 
closes #1138 

This is needed as we can not yet run external PRs due to missing credentials for integration tests.