### PR TITLE
fix(tmc): avoid creating a deployment if no stacks were selected.

### DIFF
--- a/cmd/terramate/cli/run.go
+++ b/cmd/terramate/cli/run.go
@@ -104,6 +104,11 @@ func (c *cli) runOnStacks() {
 		return
 	}
 
+	if len(orderedStacks) == 0 {
+		logger.Debug().Msg("no selected stacks")
+		return
+	}
+
 	var runStacks []ExecContext
 	for _, st := range orderedStacks {
 		run := ExecContext{

--- a/cmd/terramate/e2etests/run_cloud_deployment_test.go
+++ b/cmd/terramate/e2etests/run_cloud_deployment_test.go
@@ -164,7 +164,6 @@ func TestCLIRunWithCloudSyncDeployment(t *testing.T) {
 			},
 			runflags: []string{`--eval`},
 			cmd:      []string{testHelperBinAsHCL, "echo", "${terramate.stack.path.absolute}"},
-
 			want: want{
 				run: runExpected{
 					Status: 0,
@@ -174,6 +173,15 @@ func TestCLIRunWithCloudSyncDeployment(t *testing.T) {
 					"s1": []string{"pending", "running", "ok"},
 					"s2": []string{"pending", "running", "ok"},
 				},
+			},
+		},
+		{
+			name:     "no selected stacks selected do not create a deployment",
+			layout:   []string{},
+			runflags: []string{`--eval`},
+			cmd:      []string{testHelperBinAsHCL, "echo", "${terramate.stack.path.absolute}"},
+			want: want{
+				events: eventsResponse{},
 			},
 		},
 	} {
@@ -202,7 +210,9 @@ func TestCLIRunWithCloudSyncDeployment(t *testing.T) {
 			}
 
 			s.BuildTree(genIdsLayout)
-			s.Git().CommitAll("all stacks committed")
+			if len(tc.layout) > 0 {
+				s.Git().CommitAll("all stacks committed")
+			}
 			cli := newCLI(t, filepath.Join(s.RootDir(), filepath.FromSlash(tc.workingDir)))
 			uuid, err := uuid.NewRandom()
 			assert.NoError(t, err)


### PR DESCRIPTION
# Reason for This Change

If no stacks are selected, the TMC deployment should not be created.
The `/v1/deployments` was returning `400 Bad Request` because a payload containing `{"stacks": null}` is rejected by the API.

This issue has existed since v0.3.1 (the first release with `--cloud-sync-deployment`).

## Description of Changes

Return early if no stack is selected for deployment.
