### PR TITLE
feat(tmc): add --cloud-sync-terraform-plan-file option.

### DIFF
--- a/cloud/types.go
+++ b/cloud/types.go
@@ -64,6 +64,13 @@ type (
 		MetaTags        []string `json:"meta_tags,omitempty"`
 	}
 
+	// DriftDetails represents the details of a drift.
+	DriftDetails struct {
+		Provisioner    string `json:"provisioner"`
+		ChangesetASCII string `json:"changeset_ascii,omitempty"`
+		ChangesetJSON  string `json:"changeset_json,omitempty"`
+	}
+
 	// StacksResponse represents the stacks object response.
 	StacksResponse struct {
 		Stacks []StackResponse `json:"stacks"`
@@ -105,6 +112,7 @@ type (
 	DriftStackPayloadRequest struct {
 		Stack    Stack               `json:"stack"`
 		Status   stack.Status        `json:"drift_status"`
+		Details  *DriftDetails       `json:"drift_details,omitempty"`
 		Metadata *DeploymentMetadata `json:"metadata,omitempty"`
 		Command  []string            `json:"command"`
 	}
@@ -214,6 +222,7 @@ var (
 	_ = Resource(DeploymentReviewRequest{})
 	_ = Resource(DriftStackPayloadRequest{})
 	_ = Resource(DriftStackPayloadRequests{})
+	_ = Resource(DriftDetails{})
 	_ = Resource(EmptyResponse(""))
 )
 
@@ -328,11 +337,29 @@ func (d DriftStackPayloadRequest) Validate() error {
 		}
 	}
 
+	if d.Details != nil {
+		err := d.Details.Validate()
+		if err != nil {
+			return err
+		}
+	}
+
 	return d.Status.Validate()
 }
 
 // Validate the list of drift requests.
 func (ds DriftStackPayloadRequests) Validate() error { return validateResourceList(ds...) }
+
+// Validate the drift details.
+func (ds DriftDetails) Validate() error {
+	if ds.Provisioner == "" {
+		return errors.E(`field "provisioner" is required`)
+	}
+	if ds.ChangesetASCII == "" && ds.ChangesetJSON == "" {
+		return errors.E(`either "changeset_ascii" or "changeset_json" must be set`)
+	}
+	return nil
+}
 
 // Validate the list of deployment stack requests.
 func (d DeploymentStackRequests) Validate() error { return validateResourceList(d...) }

--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -140,16 +140,17 @@ type cliSpec struct {
 	} `cmd:"" help:"List stacks"`
 
 	Run struct {
-		CloudSyncDeployment   bool     `default:"false" help:"Enable synchronization of stack execution with the Terramate Cloud"`
-		CloudSyncDriftStatus  bool     `default:"false" help:"Enable drift detection and synchronization with the Terramate Cloud"`
-		DisableCheckGenCode   bool     `default:"false" help:"Disable outdated generated code check"`
-		DisableCheckGitRemote bool     `default:"false" help:"Disable checking if local default branch is updated with remote"`
-		ContinueOnError       bool     `default:"false" help:"Continue executing in other stacks in case of error"`
-		NoRecursive           bool     `default:"false" help:"Do not recurse into child stacks"`
-		DryRun                bool     `default:"false" help:"Plan the execution but do not execute it"`
-		Reverse               bool     `default:"false" help:"Reverse the order of execution"`
-		Eval                  bool     `default:"false" help:"Evaluate command line arguments as HCL strings"`
-		Command               []string `arg:"" name:"cmd" predictor:"file" passthrough:"" help:"Command to execute"`
+		CloudSyncDeployment        bool     `default:"false" help:"Enable synchronization of stack execution with the Terramate Cloud"`
+		CloudSyncDriftStatus       bool     `default:"false" help:"Enable drift detection and synchronization with the Terramate Cloud"`
+		CloudSyncTerraformPlanFile string   `default:"" help:"Enable sync of Terraform plan file"`
+		DisableCheckGenCode        bool     `default:"false" help:"Disable outdated generated code check"`
+		DisableCheckGitRemote      bool     `default:"false" help:"Disable checking if local default branch is updated with remote"`
+		ContinueOnError            bool     `default:"false" help:"Continue executing in other stacks in case of error"`
+		NoRecursive                bool     `default:"false" help:"Do not recurse into child stacks"`
+		DryRun                     bool     `default:"false" help:"Plan the execution but do not execute it"`
+		Reverse                    bool     `default:"false" help:"Reverse the order of execution"`
+		Eval                       bool     `default:"false" help:"Evaluate command line arguments as HCL strings"`
+		Command                    []string `arg:"" name:"cmd" predictor:"file" passthrough:"" help:"Command to execute"`
 	} `cmd:"" help:"Run command in the stacks"`
 
 	Generate struct{} `cmd:"" help:"Generate terraform code for stacks"`

--- a/cmd/terramate/cli/clitest/messages.go
+++ b/cmd/terramate/cli/clitest/messages.go
@@ -29,4 +29,10 @@ const (
 
 	// ErrCloudStacksWithoutID indicates that some stacks are missing the ID field.
 	ErrCloudStacksWithoutID errors.Kind = "all the cloud sync features requires that selected stacks contain an ID field"
+
+	// ErrCloudTerraformPlanFile indicates there was an error gathering the plan file details.
+	ErrCloudTerraformPlanFile errors.Kind = "failed to gather drift details from plan file"
+
+	// ErrCloudInvalidTerraformPlanFilePath indicates the plan file is not valid.
+	ErrCloudInvalidTerraformPlanFilePath errors.Kind = "invalid plan file path"
 )

--- a/cmd/terramate/cli/run.go
+++ b/cmd/terramate/cli/run.go
@@ -120,6 +120,10 @@ func (c *cli) runOnStacks() {
 		fatal(errors.E("--cloud-sync-deployment conflicts with --cloud-sync-drift-status"))
 	}
 
+	if c.parsedArgs.Run.CloudSyncDeployment && c.parsedArgs.Run.CloudSyncTerraformPlanFile != "" {
+		fatal(errors.E("--cloud-sync-terraform-plan-file can only be used with --cloud-sync-drift-status"))
+	}
+
 	if c.parsedArgs.Run.CloudSyncDeployment || c.parsedArgs.Run.CloudSyncDriftStatus {
 		c.ensureAllStackHaveIDs(orderedStacks)
 		c.detectCloudMetadata()

--- a/cmd/terramate/e2etests/cmd/test/helper.go
+++ b/cmd/terramate/e2etests/cmd/test/helper.go
@@ -16,9 +16,9 @@ import (
 	"time"
 )
 
-func main() {
+func helper() {
 	if len(os.Args) < 2 {
-		log.Fatal("test requires at least one subcommand argument")
+		log.Fatalf("%s requires at least one subcommand argument", os.Args[0])
 	}
 
 	// note: unrecovered panic() aborts the program with exit code 2 and this

--- a/cmd/terramate/e2etests/cmd/test/main.go
+++ b/cmd/terramate/e2etests/cmd/test/main.go
@@ -1,0 +1,30 @@
+// Copyright 2023 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+package main
+
+import (
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/terramate-io/terramate/errors"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		log.Fatalf("%s requires at least one subcommand argument", os.Args[0])
+	}
+
+	ownPath, err := os.Executable()
+	if err != nil {
+		panic(errors.E(err, "cannot detect own path"))
+	}
+
+	name := filepath.Base(ownPath)
+	if name == "terraform" || name == "terraform.exe" {
+		terraform()
+	} else {
+		helper()
+	}
+}

--- a/cmd/terramate/e2etests/cmd/test/terraform.go
+++ b/cmd/terramate/e2etests/cmd/test/terraform.go
@@ -1,0 +1,52 @@
+// Copyright 2023 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/terramate-io/terramate/errors"
+)
+
+const envNameShowASCII = "TM_TEST_TERRAFORM_SHOW_ASCII_OUTPUT"
+
+func terraform() {
+	switch os.Args[1] {
+	case "show":
+		fs := flag.NewFlagSet("terraform show", flag.ExitOnError)
+		_ = fs.Bool("no-color", false, "-no-color (ignored)")
+		err := fs.Parse(os.Args[2:])
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			os.Exit(1)
+		}
+		if fs.NArg() != 1 {
+			fmt.Fprintf(os.Stderr, "given args: %v\n", fs.Args())
+			fmt.Fprintf(os.Stderr, "usage: %s show <file>\n", os.Args[0])
+			os.Exit(1)
+		}
+		file := fs.Arg(0)
+		st, err := os.Lstat(file)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "file not found: %s\n", file)
+			os.Exit(1)
+		}
+		if !st.Mode().IsRegular() {
+			fmt.Fprintf(os.Stderr, "not a regular file: %s\n", file)
+			os.Exit(1)
+		}
+
+		// file exists but ignore it
+
+		output := os.Getenv(envNameShowASCII)
+		if output == "" {
+			panic(errors.E("please set %s", envNameShowASCII))
+		}
+		fmt.Print(output)
+	default:
+		panic(errors.E("unsupported command: %s", os.Args[1]))
+	}
+}

--- a/cmd/terramate/e2etests/main_test.go
+++ b/cmd/terramate/e2etests/main_test.go
@@ -5,12 +5,16 @@ package e2etest
 
 import (
 	"fmt"
+	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
 	"testing"
+
+	"github.com/terramate-io/terramate/errors"
+	"github.com/terramate-io/terramate/test"
 )
 
 // terramateTestBin is the path to the terramate binary we compiled for test purposes
@@ -79,7 +83,7 @@ func setupAndRunTests(m *testing.M) (status int) {
 }
 
 func buildTestHelper(goBin, testCmdPath, binDir string) (string, error) {
-	outBinPath := filepath.Join(binDir, "test"+platExeSuffix())
+	outBinPath := filepath.Join(binDir, "helper"+platExeSuffix())
 	cmd := exec.Command(
 		goBin,
 		"build",
@@ -91,7 +95,18 @@ func buildTestHelper(goBin, testCmdPath, binDir string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to build test helper: %v (output: %s)", err, string(out))
 	}
-	return outBinPath, nil
+	data, err := ioutil.ReadFile(outBinPath)
+	if err != nil {
+		return "", errors.E(err, "reading helper binary")
+	}
+
+	tfPath := filepath.Join(binDir, "terraform"+platExeSuffix())
+	err = ioutil.WriteFile(tfPath, data, 0644)
+	if err != nil {
+		return "", errors.E(err, "writing fake terraform binary")
+	}
+	err = test.Chmod(tfPath, 0550)
+	return outBinPath, err
 }
 
 func buildTerramate(goBin, projectRoot, binDir string) (string, error) {

--- a/cmd/terramate/e2etests/run_cloud_deployment_test.go
+++ b/cmd/terramate/e2etests/run_cloud_deployment_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"net/http"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -53,6 +54,23 @@ func TestCLIRunWithCloudSyncDeployment(t *testing.T) {
 				run: runExpected{
 					Status:      1,
 					StderrRegex: string(clitest.ErrCloudStacksWithoutID),
+				},
+			},
+		},
+		{
+			name: "using --cloud-sync-terraform-plan-file with deployment sync -- fails",
+			layout: []string{
+				"s:s1",
+				`f:s1/out.tfplan:{}`,
+			},
+			runflags: []string{
+				`--cloud-sync-terraform-plan-file=out.tfplan`,
+			},
+			cmd: []string{testHelperBin, "echo", "ok"},
+			want: want{
+				run: runExpected{
+					Status:      1,
+					StderrRegex: regexp.QuoteMeta(`--cloud-sync-terraform-plan-file can only be used with --cloud-sync-drift-status`),
 				},
 			},
 		},

--- a/cmd/terramate/e2etests/run_unix_test.go
+++ b/cmd/terramate/e2etests/run_unix_test.go
@@ -58,7 +58,7 @@ func TestRunLookPathFromStackEnviron(t *testing.T) {
 
 	assert.NoError(t, dstFile.Close())
 
-	test.Chmod(t, dstFilename, srcPerm)
+	test.AssertChmod(t, dstFilename, srcPerm)
 
 	_ = s.CreateStack(stackName)
 

--- a/hcl/fmt/fmt_test.go
+++ b/hcl/fmt/fmt_test.go
@@ -1429,8 +1429,8 @@ func TestFormatTreeFailsOnNonAccessibleSubdir(t *testing.T) {
 	tmpdir := t.TempDir()
 	test.Mkdir(t, tmpdir, subdir)
 
-	test.Chmod(t, filepath.Join(tmpdir, subdir), 0)
-	defer test.Chmod(t, filepath.Join(tmpdir, subdir), 0755)
+	test.AssertChmod(t, filepath.Join(tmpdir, subdir), 0)
+	defer test.AssertChmod(t, filepath.Join(tmpdir, subdir), 0755)
 
 	_, err := fmt.FormatTree(tmpdir)
 	assert.Error(t, err)
@@ -1445,8 +1445,8 @@ func TestFormatTreeFailsOnNonAccessibleFile(t *testing.T) {
 		b = 3
 	}`)
 
-	test.Chmod(t, filepath.Join(tmpdir, filename), 0)
-	defer test.Chmod(t, filepath.Join(tmpdir, filename), 0755)
+	test.AssertChmod(t, filepath.Join(tmpdir, filename), 0)
+	defer test.AssertChmod(t, filepath.Join(tmpdir, filename), 0755)
 
 	_, err := fmt.FormatTree(tmpdir)
 	assert.Error(t, err)

--- a/test/fs.go
+++ b/test/fs.go
@@ -60,7 +60,7 @@ func AssertFileContentEquals(t *testing.T, fname string, want string) {
 	}
 }
 
-// Chmod is a portable version of the os.Chmod.
-func Chmod(t testing.TB, fname string, mode fs.FileMode) {
-	assert.NoError(t, chmod(fname, mode))
+// AssertChmod is a portable version of the os.AssertChmod.
+func AssertChmod(t testing.TB, fname string, mode fs.FileMode) {
+	assert.NoError(t, Chmod(fname, mode))
 }

--- a/test/fs_unix.go
+++ b/test/fs_unix.go
@@ -10,6 +10,7 @@ import (
 	"os"
 )
 
-func chmod(fname string, mode fs.FileMode) error {
+// Chmod changes file permissions.
+func Chmod(fname string, mode fs.FileMode) error {
 	return os.Chmod(fname, mode)
 }

--- a/test/fs_windows.go
+++ b/test/fs_windows.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hectane/go-acl"
 )
 
-func chmod(fname string, mode fs.FileMode) error {
+// Chmod changes file permissions.
+func Chmod(fname string, mode fs.FileMode) error {
 	return acl.Chmod(fname, mode)
 }

--- a/test/sandbox/sandbox.go
+++ b/test/sandbox/sandbox.go
@@ -418,7 +418,7 @@ func (de DirEntry) CreateDir(relpath string) DirEntry {
 // Chmod does the same as [test.Chmod] for the given file/dir inside
 // this DirEntry.
 func (de DirEntry) Chmod(relpath string, mode fs.FileMode) {
-	test.Chmod(de.t, filepath.Join(de.abspath, relpath), mode)
+	test.AssertChmod(de.t, filepath.Join(de.abspath, relpath), mode)
 }
 
 // ReadFile will read a file inside this dir entry with the given name.
@@ -474,7 +474,7 @@ func (fe FileEntry) Write(body string, args ...interface{}) {
 func (fe FileEntry) Chmod(mode os.FileMode) {
 	fe.t.Helper()
 
-	test.Chmod(fe.t, fe.hostpath, mode)
+	test.AssertChmod(fe.t, fe.hostpath, mode)
 }
 
 // HostPath returns the absolute path of the file.


### PR DESCRIPTION
This new flag must be used with `--cloud-sync-drift-status` to enable the sending of the rendered plan output to the Terramate Cloud.