### PR TITLE
fix(tmc): panic when cloud features are used without a repository

### DIFF
--- a/cmd/terramate/cli/run.go
+++ b/cmd/terramate/cli/run.go
@@ -125,6 +125,9 @@ func (c *cli) runOnStacks() {
 	}
 
 	if c.parsedArgs.Run.CloudSyncDeployment || c.parsedArgs.Run.CloudSyncDriftStatus {
+		if !c.prj.isRepo {
+			fatal(errors.E("cloud features requires a git repository"))
+		}
 		c.ensureAllStackHaveIDs(orderedStacks)
 		c.detectCloudMetadata()
 	}


### PR DESCRIPTION
# Reason for This Change

When the project uses a `terramate.config` block to declare the project and it's not a git repository, the cloud sync features panic because `git` metadata is required.

## Description of Changes

Added a fatal error in case git is not setup and a cloud sync flag is provided.
