### PR TITLE
chore: remove temporary comment

### DIFF
--- a/cmd/terramate/main.go
+++ b/cmd/terramate/main.go
@@ -17,6 +17,5 @@ import (
 )
 
 func main() {
-	// TO BE REMOVED - force triggering of benchmark
 	cli.Exec(terramate.Version(), os.Args[1:], os.Stdin, os.Stdout, os.Stderr)
 }


### PR DESCRIPTION
Removes a temporary comment accidentally merged.