### PR TITLE
feat: add config setting for cloud organization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 
 - Add `--cloud-sync-terraform-plan-file=<plan>` flag for synchronizing the plan
 file in rendered ASCII and JSON (sensitive information removed).
+- Add configuration attribute `terramate.config.cloud.organization` to select which cloud organization to use when syncing with Terramate Cloud.
 
 ## 0.4.2
 

--- a/cmd/terramate/cli/cloud.go
+++ b/cmd/terramate/cli/cloud.go
@@ -109,6 +109,22 @@ func (c *cli) checkCloudSync() {
 	}
 }
 
+func (c *cli) cloudOrgName() string {
+	orgName := os.Getenv("TM_CLOUD_ORGANIZATION")
+	if orgName != "" {
+		return orgName
+	}
+
+	cfg := c.rootNode()
+	if cfg.Terramate != nil &&
+		cfg.Terramate.Config != nil &&
+		cfg.Terramate.Config.Cloud != nil {
+		return cfg.Terramate.Config.Cloud.Organization
+	}
+
+	return ""
+}
+
 func (c *cli) setupCloudConfig() error {
 	logger := log.With().
 		Str("action", "cli.setupCloudConfig").
@@ -123,7 +139,7 @@ func (c *cli) setupCloudConfig() error {
 	// at this point we know user is onboarded, ie has at least 1 organization.
 	orgs := c.cred().organizations()
 
-	useOrgName := os.Getenv("TM_CLOUD_ORGANIZATION")
+	useOrgName := c.cloudOrgName()
 	if useOrgName != "" {
 		var useOrgUUID string
 		for _, org := range orgs {
@@ -172,7 +188,7 @@ func (c *cli) setupCloudConfig() error {
 		}
 		if len(activeOrgs) > 1 {
 			logger.Error().
-				Msgf("Please set TM_CLOUD_ORGANIZATION environment variable to a specific available organization: %s", activeOrgs)
+				Msgf("Please set TM_CLOUD_ORGANIZATION environment variable or terramate.config.cloud.organization configuration attribute to a specific available organization: %s", activeOrgs)
 
 			return cloudError()
 		}

--- a/cmd/terramate/e2etests/run_cloud_config_test.go
+++ b/cmd/terramate/e2etests/run_cloud_config_test.go
@@ -1,0 +1,200 @@
+// Copyright 2023 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+package e2etest
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/terramate-io/terramate/cloud"
+	"github.com/terramate-io/terramate/cloud/testserver"
+	"github.com/terramate-io/terramate/cmd/terramate/cli/clitest"
+	"github.com/terramate-io/terramate/test/sandbox"
+)
+
+func TestCloudConfig(t *testing.T) {
+	type testcase struct {
+		name      string
+		layout    []string
+		want      runExpected
+		customEnv map[string]string
+	}
+
+	writeJSON := func(w http.ResponseWriter, str string) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(str))
+	}
+
+	const fatalErr = `FTL ` + string(clitest.ErrCloud)
+
+	for _, tc := range []testcase{
+		{
+			name: "empty cloud block == no organization set",
+			layout: []string{
+				"s:s1:id=s1",
+				`f:cfg.tm.hcl:terramate {
+					config {
+						cloud {
+						}
+					}
+				}`,
+			},
+			want: runExpected{
+				Status: 1,
+				StderrRegexes: []string{
+					`Please set TM_CLOUD_ORGANIZATION environment variable`,
+					fatalErr,
+				},
+			},
+		},
+		{
+			name: "not a member of selected organization",
+			layout: []string{
+				"s:s1:id=s1",
+				`f:cfg.tm.hcl:terramate {
+					config {
+						cloud {
+							organization = "world"
+						}
+					}
+				}`,
+			},
+			want: runExpected{
+				Status: 1,
+				StderrRegexes: []string{
+					`You are not a member of organization "world"`,
+					fatalErr,
+				},
+			},
+		},
+		{
+			name: "member of organization",
+			layout: []string{
+				"s:s1:id=s1",
+				`f:cfg.tm.hcl:terramate {
+					config {
+						cloud {
+							organization = "mineiros-io"
+						}
+					}
+				}`,
+			},
+			want: runExpected{
+				Status: 0,
+			},
+		},
+		{
+			name: "cloud organization env var overrides value from config",
+			layout: []string{
+				"s:s1:id=s1",
+				`f:cfg.tm.hcl:terramate {
+					config {
+						cloud {
+							organization = "mineiros-io"
+						}
+					}
+				}`,
+			},
+			customEnv: map[string]string{
+				"TM_CLOUD_ORGANIZATION": "override",
+			},
+			want: runExpected{
+				Status: 1,
+				StderrRegexes: []string{
+					`You are not a member of organization "override"`,
+					fatalErr,
+				},
+			},
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			router := testserver.RouterWith(map[string]bool{
+				cloud.UsersPath:       true,
+				cloud.MembershipsPath: false,
+				cloud.DeploymentsPath: true,
+				cloud.DriftsPath:      true,
+			})
+
+			fakeserver := &http.Server{
+				Handler: router,
+				Addr:    "localhost:3001",
+			}
+			testserver.RouterAddCustoms(router, testserver.Custom{
+				Routes: map[string]testserver.Route{
+					"GET": {
+						Path: cloud.MembershipsPath,
+						Handler: http.HandlerFunc(
+							func(w http.ResponseWriter, _ *http.Request) {
+								writeJSON(w, `[
+									{
+										"org_name": "terramate-io",
+										"org_display_name": "Terramate",
+										"org_uuid": "c7d721ee-f455-4d3c-934b-b1d96bbaad17",
+										"status": "active"
+									},
+									{
+										"org_name": "mineiros-io",
+										"org_display_name": "Mineiros",
+										"org_uuid": "b2f153e8-ceb1-4f26-898e-eb7789869bee",
+										"status": "active"
+									}
+								]`)
+							},
+						),
+					},
+				},
+			})
+
+			const fakeserverShutdownTimeout = 3 * time.Second
+			errChan := make(chan error)
+			go func() {
+				errChan <- fakeserver.ListenAndServe()
+			}()
+
+			t.Cleanup(func() {
+				err := fakeserver.Close()
+				if err != nil {
+					t.Logf("fakeserver HTTP Close error: %v", err)
+				}
+				select {
+				case err := <-errChan:
+					if err != nil && !errors.Is(err, http.ErrServerClosed) {
+						t.Error(err)
+					}
+				case <-time.After(fakeserverShutdownTimeout):
+					t.Error("time excedeed waiting for fakeserver shutdown")
+				}
+			})
+
+			s := sandbox.New(t)
+			layout := tc.layout
+			if len(layout) == 0 {
+				layout = []string{
+					"s:stack:id=test",
+				}
+			}
+			s.BuildTree(layout)
+			s.Git().CommitAll("created stacks")
+			env := removeEnv(os.Environ(), "CI")
+
+			for k, v := range tc.customEnv {
+				env = append(env, fmt.Sprintf("%v=%v", k, v))
+			}
+
+			tm := newCLI(t, s.RootDir(), env...)
+
+			cmd := []string{
+				"run",
+				"--cloud-sync-deployment",
+				"--", testHelperBin, "true",
+			}
+			assertRunResult(t, tm.run(cmd...), tc.want)
+		})
+	}
+}

--- a/docs/configuration/project-config.md
+++ b/docs/configuration/project-config.md
@@ -135,3 +135,24 @@ on `terramate.config.run.env` blocks won't affect the `env` namespace.
 
 You can have multiple `terramate.config.run.env` blocks defined on different
 files, but variable names **cannot** be defined twice.
+
+### The `terramate.config.cloud` block
+
+Properties related to Terramate Cloud can be defined inside the `terramate.config.cloud` block.
+Currently, this block is only used to set the default cloud organization name:
+```hcl
+terramate {
+  config {
+    cloud {
+      organization = "my-org-name"
+    }
+  }
+}
+```
+Setting a cloud organization name is required when
+* syncing with Terramate Cloud, i.e. by using `terramate run` with the `--cloud-sync-drift-status` or `--cloud-sync-deployment` options, and
+* the user is member of more than one cloud organizations.
+
+The specified name will be used to select which of the user's organizations to use in the scope of the project.
+
+It's also possible to select a cloud organization by setting the environment variable `TM_CLOUD_ORGANIZATION` to the organization name. If set, the value from the environment variable will override the configuration setting.

--- a/hcl/hcl_test.go
+++ b/hcl/hcl_test.go
@@ -579,6 +579,60 @@ func TestHCLParserRootConfig(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "empty config.cloud block",
+			input: []cfgfile{
+				{
+					filename: "cfg.tm",
+					body: `
+						terramate {
+							config {
+								cloud {}
+							}
+						}
+					`,
+				},
+			},
+			want: want{
+				config: hcl.Config{
+					Terramate: &hcl.Terramate{
+						Config: &hcl.RootConfig{
+							Cloud: &hcl.CloudConfig{
+								Organization: "",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "basic config.cloud block",
+			input: []cfgfile{
+				{
+					filename: "cfg.tm",
+					body: `
+						terramate {
+							config {
+								cloud {
+									organization = "my-org"
+								}
+							}
+						}
+					`,
+				},
+			},
+			want: want{
+				config: hcl.Config{
+					Terramate: &hcl.Terramate{
+						Config: &hcl.RootConfig{
+							Cloud: &hcl.CloudConfig{
+								Organization: "my-org",
+							},
+						},
+					},
+				},
+			},
+		},
 	} {
 		testParser(t, tc)
 	}

--- a/test/hcl.go
+++ b/test/hcl.go
@@ -239,6 +239,7 @@ func assertTerramateConfigBlock(t *testing.T, got, want *hcl.RootConfig) {
 	}
 
 	assertTerramateRunBlock(t, got.Run, want.Run)
+	assertTerramateCloudBlock(t, got.Cloud, want.Cloud)
 }
 
 func assertGenHCLBlocks(t *testing.T, got, want []hcl.GenHCLBlock) {
@@ -305,6 +306,22 @@ func assertTerramateRunBlock(t *testing.T, got, want *hcl.RunConfig) {
 	wantHCL := hclFromAttributes(t, want.Env.Attributes)
 
 	AssertDiff(t, gotHCL, wantHCL)
+}
+
+func assertTerramateCloudBlock(t *testing.T, got, want *hcl.CloudConfig) {
+	t.Helper()
+
+	if (want == nil) != (got == nil) {
+		t.Fatalf("want.Cloud[%+v] != got.Cloud[%+v]", want, got)
+	}
+
+	if want == nil {
+		return
+	}
+
+	if *want != *got {
+		t.Fatalf("want.Cloud[%+v] != got.Cloud[%+v]", want, got)
+	}
 }
 
 // hclFromAttributes ensures that we always build the same HCL document


### PR DESCRIPTION
# Reason for This Change

When being member of multiple cloud organizations, the user had to set the environment variable TM_CLOUD_ORGANIZATION to the name of a specific one when syncing cloud data.
In many cases it would be more convenient to set this automatically per project via configuration.


## Description of Changes

A new config setting has been added to the terramate config block. Usage example:
```
terramate {
  config {
    cloud {
      organization = "my-org-name"
    }
  }
}
```
TM_CLOUD_ORGANIZATION still works as before and overrides the config value if set.
