### PR TITLE
feat(tmc): send logs of the user-supplied command to Terramate Cloud.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 - Add `--cloud-sync-terraform-plan-file=<plan>` flag for synchronizing the plan
 file in rendered ASCII and JSON (sensitive information removed).
 - Add configuration attribute `terramate.config.cloud.organization` to select which cloud organization to use when syncing with Terramate Cloud.
+- Add sync of logs to _Terramate Cloud_ when using `--cloud-sync-deployment` flag.
 
 ## 0.4.2
 

--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"net/http"
 	"path"
+	"strconv"
 
 	"github.com/terramate-io/terramate"
 	"github.com/terramate-io/terramate/cloud/stack"
@@ -131,6 +132,26 @@ func (c *Client) CreateStackDrift(
 		DriftsPath,
 		orgUUID,
 	)
+}
+
+// SyncDeploymentLogs sends a batch of deployment logs to Terramate Cloud.
+func (c *Client) SyncDeploymentLogs(
+	ctx context.Context,
+	orgUUID string,
+	stackID int,
+	deploymentUUID string,
+	logs DeploymentLogs,
+) error {
+	err := logs.Validate()
+	if err != nil {
+		return errors.E(err, "failed to prepare the request")
+	}
+	// Endpoint:/v1/stacks/{org_uuid}/{stack_id}/deployments/{deployment_uuid}/logs
+	_, err = Post[EmptyResponse](
+		ctx, c, logs,
+		StacksPath, orgUUID, strconv.Itoa(stackID), "deployments", deploymentUUID, "logs",
+	)
+	return err
 }
 
 // Get requests the endpoint components list making a GET request and decode the response into the

--- a/cloud/log_syncer.go
+++ b/cloud/log_syncer.go
@@ -1,0 +1,203 @@
+// Copyright 2023 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+package cloud
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"sync"
+	"time"
+
+	"github.com/rs/zerolog/log"
+	"github.com/terramate-io/terramate/errors"
+)
+
+type (
+	// LogSyncer is the log syncer controller type.
+	LogSyncer struct {
+		pending      DeploymentLogs
+		fds          []io.Closer
+		in           chan *DeploymentLog
+		lastEnqueued time.Time
+		syncfn       Syncer
+		wg           sync.WaitGroup
+		shutdown     chan struct{}
+
+		maxLineSize  int
+		batchSize    int
+		idleDuration time.Duration
+	}
+
+	// Syncer is the actual synchronizer callback.
+	Syncer func(l DeploymentLogs)
+)
+
+// DefaultLogMaxLineSize is the default maximum line.
+// TODO(i4k): to be removed.
+const DefaultLogMaxLineSize = 4096
+
+// DefaultLogBatchSize is the default batch size.
+const DefaultLogBatchSize = 256
+
+// DefaultLogIdleDuration is the maximum idle duration before a sync could happen.
+const DefaultLogIdleDuration = 1 * time.Second
+
+// NewLogSyncer creates a new log syncer.
+func NewLogSyncer(syncfn Syncer) *LogSyncer {
+	return NewLogSyncerWith(syncfn, DefaultLogMaxLineSize, DefaultLogBatchSize, DefaultLogIdleDuration)
+}
+
+// NewLogSyncerWith creates a new customizable syncer.
+func NewLogSyncerWith(
+	syncfn Syncer,
+	maxLineSize int,
+	batchSize int,
+	idleDuration time.Duration,
+) *LogSyncer {
+	if maxLineSize == 0 {
+		panic("max line size must be set")
+	}
+	l := &LogSyncer{
+		in:       make(chan *DeploymentLog, batchSize),
+		syncfn:   syncfn,
+		shutdown: make(chan struct{}),
+
+		maxLineSize:  maxLineSize,
+		batchSize:    batchSize,
+		idleDuration: idleDuration,
+	}
+	l.start()
+	return l
+}
+
+// NewBuffer creates a new synchronized buffer.
+func (s *LogSyncer) NewBuffer(channel LogChannel, out io.Writer) io.Writer {
+	r, w := io.Pipe()
+	s.fds = append(s.fds, w)
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+		line := int64(1)
+		scanner := bufio.NewScanner(r)
+		maxLineSize := s.maxLineSize
+		buf := make([]byte, maxLineSize)
+		scanner.Buffer(buf, maxLineSize)
+		// no internal allocation
+		scanner.Split(scanLines)
+
+		errs := errors.L()
+		for scanner.Scan() {
+			message := scanner.Text()
+			_, err := out.Write([]byte(message))
+			if err != nil {
+				errs.Append(errors.E(err, "writing to terminal"))
+				continue
+			}
+
+			t := time.Now().UTC()
+			s.in <- &DeploymentLog{
+				Channel:   channel,
+				Line:      line,
+				Message:   string(dropCRLN([]byte(message))),
+				Timestamp: &t,
+			}
+			line++
+		}
+		if err := scanner.Err(); err != nil {
+			errs.Append(errors.E(err, "scanning output lines"))
+		}
+
+		errs.Append(r.Close())
+		errs.Append(w.Close())
+		if err := errs.AsError(); err != nil {
+			log.Error().Err(err).Msg("synchroning command output")
+		}
+	}()
+	return w
+}
+
+// Wait waits for the processing of all log messages.
+// After calling this method, it's not safe to call any other method, as it
+// closes the internal channels and shutdown all goroutines.
+func (s *LogSyncer) Wait() {
+	for _, writerFD := range s.fds {
+		// only return an error when readerFD.CloseWithError(err) is called but
+		// but this is not the case.
+		_ = writerFD.Close()
+	}
+	s.wg.Wait()
+	close(s.in)
+	<-s.shutdown
+}
+
+func (s *LogSyncer) start() {
+	go func() {
+		s.lastEnqueued = time.Now()
+		for e := range s.in {
+			s.enqueue(e)
+		}
+		for len(s.pending) > 0 {
+			rest := min(s.batchSize, len(s.pending))
+			s.syncfn(s.pending[:rest])
+			s.pending = s.pending[rest:]
+		}
+		s.shutdown <- struct{}{}
+	}()
+}
+
+func (s *LogSyncer) enqueue(l *DeploymentLog) {
+	s.pending = append(s.pending, l)
+	if len(s.pending) >= s.batchSize ||
+		(len(s.pending) > 0 && time.Since(s.lastEnqueued) > s.idleDuration) {
+		rest := min(s.batchSize, len(s.pending))
+		s.syncfn(s.pending[:rest])
+		s.pending = s.pending[rest:]
+	}
+	s.lastEnqueued = time.Now()
+}
+
+// scanLines is a split function for a [bufio.Scanner] that returns each line of
+// text. It's similar to [bufio.ScanLines] but do not remove the trailing newline
+// marker and optional carriege return. The returned line may be empty.
+// The end-of-line marker is one optional carriage return followed
+// by one mandatory newline. In regular expression notation, it is `\r?\n`.
+// The last non-empty line of input will be returned even if it has no
+// newline.
+func scanLines(data []byte, atEOF bool) (advance int, token []byte, err error) {
+	if atEOF && len(data) == 0 {
+		return 0, nil, nil
+	}
+	if i := bytes.IndexByte(data, '\n'); i >= 0 {
+		// We have a full newline-terminated line.
+		return i + 1, data[0 : i+1], nil
+	}
+	// If we're at EOF, we have a final, non-terminated line. Return it.
+	if atEOF {
+		return len(data), data, nil
+	}
+	// Request more data.
+	return 0, nil, nil
+}
+
+// dropCRLN drops a terminal \r from the data.
+func dropCRLN(data []byte) []byte {
+	if len(data) == 0 {
+		return data
+	}
+	if data[len(data)-1] == '\n' {
+		data = data[0 : len(data)-1]
+	}
+	if data[len(data)-1] == '\r' {
+		data = data[0 : len(data)-1]
+	}
+	return data
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/cloud/log_syncer_test.go
+++ b/cloud/log_syncer_test.go
@@ -1,0 +1,429 @@
+// Copyright 2023 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+package cloud_test
+
+import (
+	"bytes"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/madlambda/spells/assert"
+	"github.com/terramate-io/terramate/cloud"
+)
+
+type (
+	write struct {
+		channel cloud.LogChannel
+		data    []byte
+		idle    time.Duration
+	}
+	want struct {
+		output  map[cloud.LogChannel][]byte
+		batches []cloud.DeploymentLogs
+	}
+	testcase struct {
+		name         string
+		writes       []write
+		maxLineSize  int
+		batchSize    int
+		idleDuration time.Duration
+		want         want
+	}
+)
+
+func TestCloudLogSyncer(t *testing.T) {
+	for _, tc := range []testcase{
+		{
+			name: "no output",
+		},
+		/*
+			TODO(i4k): improve scanner to not have a line size limit
+				{
+					name:        "log line bigger than maximum",
+					maxLineSize: 1,
+					writes: []write{
+						{
+							channel: cloud.StdoutLogChannel,
+							data:    []byte("AA"),
+						},
+					},
+					want: want{},
+				},
+		*/
+		{
+			name: "multiple writes with no newline",
+			writes: []write{
+				{channel: cloud.StdoutLogChannel, data: []byte("terramate ")},
+				{channel: cloud.StdoutLogChannel, data: []byte("cloud ")},
+				{channel: cloud.StdoutLogChannel, data: []byte("is ")},
+				{channel: cloud.StdoutLogChannel, data: []byte("amazing")},
+			},
+			want: want{
+				output: map[cloud.LogChannel][]byte{
+					cloud.StdoutLogChannel: []byte("terramate cloud is amazing"),
+				},
+				batches: []cloud.DeploymentLogs{
+					{
+						{
+							Line:    1,
+							Channel: cloud.StdoutLogChannel,
+							Message: "terramate cloud is amazing",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "multiple writes with newlines",
+			writes: []write{
+				{channel: cloud.StdoutLogChannel, data: []byte("terramate\ncloud\n")},
+				{channel: cloud.StdoutLogChannel, data: []byte("is\namazing")},
+			},
+			want: want{
+				output: map[cloud.LogChannel][]byte{
+					cloud.StdoutLogChannel: []byte("terramate\ncloud\nis\namazing"),
+				},
+				batches: []cloud.DeploymentLogs{
+					{
+						{
+							Line:    1,
+							Channel: cloud.StdoutLogChannel,
+							Message: "terramate",
+						},
+						{
+							Line:    2,
+							Channel: cloud.StdoutLogChannel,
+							Message: "cloud",
+						},
+						{
+							Line:    3,
+							Channel: cloud.StdoutLogChannel,
+							Message: "is",
+						},
+						{
+							Line:    4,
+							Channel: cloud.StdoutLogChannel,
+							Message: "amazing",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "multiple writes with CRLN",
+			writes: []write{
+				{channel: cloud.StdoutLogChannel, data: []byte("terramate\r\ncloud\r\n")},
+				{channel: cloud.StdoutLogChannel, data: []byte("is\r\namazing")},
+			},
+			want: want{
+				output: map[cloud.LogChannel][]byte{
+					cloud.StdoutLogChannel: []byte("terramate\r\ncloud\r\nis\r\namazing"),
+				},
+				batches: []cloud.DeploymentLogs{
+					{
+						{
+							Line:    1,
+							Channel: cloud.StdoutLogChannel,
+							Message: "terramate",
+						},
+						{
+							Line:    2,
+							Channel: cloud.StdoutLogChannel,
+							Message: "cloud",
+						},
+						{
+							Line:    3,
+							Channel: cloud.StdoutLogChannel,
+							Message: "is",
+						},
+						{
+							Line:    4,
+							Channel: cloud.StdoutLogChannel,
+							Message: "amazing",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "mix of stdout and stderr writes",
+			writes: []write{
+				{channel: cloud.StdoutLogChannel, data: []byte("A\nB\n")},
+				{channel: cloud.StderrLogChannel, data: []byte("C\nD\n")},
+				{channel: cloud.StdoutLogChannel, data: []byte("E\nF")},
+				{channel: cloud.StderrLogChannel, data: []byte("G\nH")},
+			},
+			want: want{
+				output: map[cloud.LogChannel][]byte{
+					cloud.StdoutLogChannel: []byte("A\nB\nE\nF"),
+					cloud.StderrLogChannel: []byte("C\nD\nG\nH"),
+				},
+				batches: []cloud.DeploymentLogs{
+					{
+						{
+							Line:    1,
+							Channel: cloud.StdoutLogChannel,
+							Message: "A",
+						},
+						{
+							Line:    2,
+							Channel: cloud.StdoutLogChannel,
+							Message: "B",
+						},
+						{
+							Line:    1,
+							Channel: cloud.StderrLogChannel,
+							Message: "C",
+						},
+						{
+							Line:    2,
+							Channel: cloud.StderrLogChannel,
+							Message: "D",
+						},
+						{
+							Line:    3,
+							Channel: cloud.StdoutLogChannel,
+							Message: "E",
+						},
+						{
+							Line:    4,
+							Channel: cloud.StdoutLogChannel,
+							Message: "F",
+						},
+						{
+							Line:    3,
+							Channel: cloud.StderrLogChannel,
+							Message: "G",
+						},
+						{
+							Line:    4,
+							Channel: cloud.StderrLogChannel,
+							Message: "H",
+						},
+					},
+				},
+			},
+		},
+		{
+			name:         "batch size is respected",
+			batchSize:    1,
+			idleDuration: 10 * time.Second, // just to ensure it's not used in slow envs
+			writes: []write{
+				{channel: cloud.StdoutLogChannel, data: []byte("A\n")},
+				{channel: cloud.StdoutLogChannel, data: []byte("B\nC\n")},
+				{channel: cloud.StdoutLogChannel, data: []byte("D\nE\nF\nG\n")},
+			},
+			want: want{
+				output: map[cloud.LogChannel][]byte{
+					cloud.StdoutLogChannel: []byte("A\nB\nC\nD\nE\nF\nG\n"),
+				},
+				batches: []cloud.DeploymentLogs{
+					{
+						{
+							Line:    1,
+							Channel: cloud.StdoutLogChannel,
+							Message: "A",
+						},
+					},
+					{
+						{
+							Line:    2,
+							Channel: cloud.StdoutLogChannel,
+							Message: "B",
+						},
+					},
+					{
+						{
+							Line:    3,
+							Channel: cloud.StdoutLogChannel,
+							Message: "C",
+						},
+					},
+					{
+						{
+							Line:    4,
+							Channel: cloud.StdoutLogChannel,
+							Message: "D",
+						},
+					},
+					{
+						{
+							Line:    5,
+							Channel: cloud.StdoutLogChannel,
+							Message: "E",
+						},
+					},
+					{
+						{
+							Line:    6,
+							Channel: cloud.StdoutLogChannel,
+							Message: "F",
+						},
+					},
+					{
+						{
+							Line:    7,
+							Channel: cloud.StdoutLogChannel,
+							Message: "G",
+						},
+					},
+				},
+			},
+		},
+		{
+			name:         "if no write happens after configured idle duration then pending data is synced",
+			batchSize:    6,
+			idleDuration: 100 * time.Millisecond,
+			writes: []write{
+				{channel: cloud.StdoutLogChannel, data: []byte("first write\n")},
+				{
+					// make this lower than tc.idleDuration to fail the test.
+					idle:    300 * time.Millisecond,
+					channel: cloud.StdoutLogChannel,
+					data:    []byte("write after idle time\n"),
+				},
+				{channel: cloud.StdoutLogChannel, data: []byte("another\nmultiline\nwrite\nhere")},
+			},
+			want: want{
+				output: map[cloud.LogChannel][]byte{
+					cloud.StdoutLogChannel: []byte("first write\nwrite after idle time\nanother\nmultiline\nwrite\nhere"),
+				},
+				batches: []cloud.DeploymentLogs{
+					// first batch is due to idle duration trigger.
+					{
+						{
+							Line:    1,
+							Channel: cloud.StdoutLogChannel,
+							Message: "first write",
+						},
+					},
+					{
+						{
+							Line:    2,
+							Channel: cloud.StdoutLogChannel,
+							Message: "write after idle time",
+						},
+						{
+							Line:    3,
+							Channel: cloud.StdoutLogChannel,
+							Message: "another",
+						},
+						{
+							Line:    4,
+							Channel: cloud.StdoutLogChannel,
+							Message: "multiline",
+						},
+						{
+							Line:    5,
+							Channel: cloud.StdoutLogChannel,
+							Message: "write",
+						},
+						{
+							Line:    6,
+							Channel: cloud.StdoutLogChannel,
+							Message: "here",
+						},
+					},
+				},
+			},
+		},
+	} {
+		tc := tc
+		tc.validate(t)
+		t.Run(tc.name, func(t *testing.T) {
+			var gotBatches []cloud.DeploymentLogs
+			s := cloud.NewLogSyncerWith(func(logs cloud.DeploymentLogs) {
+				gotBatches = append(gotBatches, logs)
+			}, tc.maxLineSize, tc.batchSize, tc.idleDuration)
+			var stdoutBuf, stderrBuf bytes.Buffer
+			stdoutProxy := s.NewBuffer(cloud.StdoutLogChannel, &stdoutBuf)
+			stderrProxy := s.NewBuffer(cloud.StderrLogChannel, &stderrBuf)
+
+			writeFinished := make(chan struct{})
+			go func() {
+				fdmap := map[cloud.LogChannel]io.Writer{
+					cloud.StdoutLogChannel: stdoutProxy,
+					cloud.StderrLogChannel: stderrProxy,
+				}
+				for _, write := range tc.writes {
+					time.Sleep(write.idle)
+					n, err := fdmap[write.channel].Write(write.data)
+					assert.NoError(t, err)
+					assert.EqualInts(t, len(write.data), n)
+				}
+				writeFinished <- struct{}{}
+			}()
+
+			<-writeFinished
+			s.Wait()
+
+			var gotOutputs map[cloud.LogChannel][]byte
+			stdoutBytes := stdoutBuf.Bytes()
+			stderrBytes := stderrBuf.Bytes()
+			if len(stdoutBytes) > 0 || len(stderrBytes) > 0 {
+				gotOutputs = map[cloud.LogChannel][]byte{}
+			}
+			if len(stdoutBytes) > 0 {
+				gotOutputs[cloud.StdoutLogChannel] = stdoutBytes
+			}
+			if len(stderrBytes) > 0 {
+				gotOutputs[cloud.StderrLogChannel] = stderrBytes
+			}
+			if diff := cmp.Diff(gotOutputs, tc.want.output); diff != "" {
+				t.Logf("want stdout:%s", tc.want.output[cloud.StdoutLogChannel])
+				t.Logf("got stdout:%s", gotOutputs[cloud.StdoutLogChannel])
+				t.Logf("want stderr:%s", tc.want.output[cloud.StderrLogChannel])
+				t.Logf("got stderr:%s", gotOutputs[cloud.StderrLogChannel])
+
+				t.Fatal(diff)
+			}
+
+			compareBatches(t, gotBatches, tc.want.batches)
+		})
+	}
+}
+
+func (tc *testcase) validate(t *testing.T) {
+	if tc.name == "" {
+		t.Fatalf("testcase without name: %+v", tc)
+	}
+	if tc.maxLineSize == 0 {
+		tc.maxLineSize = cloud.DefaultLogMaxLineSize
+	}
+	if tc.batchSize == 0 {
+		tc.batchSize = cloud.DefaultLogBatchSize
+	}
+	if tc.idleDuration == 0 {
+		tc.idleDuration = 1 * time.Second
+	}
+}
+
+func compareBatches(t *testing.T, got, want []cloud.DeploymentLogs) {
+	assert.EqualInts(t, len(want), len(got), "number of batches mismatch")
+
+	wantStdoutLogs, wantStderrLogs := divideBatches(want)
+	gotStdoutLogs, gotStderrLogs := divideBatches(got)
+	if diff := cmp.Diff(wantStdoutLogs, gotStdoutLogs, cmpopts.IgnoreFields(cloud.DeploymentLog{}, "Timestamp")); diff != "" {
+		t.Fatalf("log stdout mismatch: %s", diff)
+	}
+	if diff := cmp.Diff(wantStderrLogs, gotStderrLogs, cmpopts.IgnoreFields(cloud.DeploymentLog{}, "Timestamp")); diff != "" {
+		t.Fatalf("log stderr mismatch: %s", diff)
+	}
+}
+
+func divideBatches(batches []cloud.DeploymentLogs) (stdoutLogs, stderrLogs cloud.DeploymentLogs) {
+	for _, batch := range batches {
+		for _, log := range batch {
+			if log.Channel == cloud.StdoutLogChannel {
+				stdoutLogs = append(stdoutLogs, log)
+			} else {
+				stderrLogs = append(stderrLogs, log)
+			}
+		}
+	}
+	return stdoutLogs, stderrLogs
+}


### PR DESCRIPTION
# Reasons for This Change

Terramate Cloud supports visualizing the deployment logs in real-time.

## Description of the changes

A log syncer was created that proxies stdout/stderr writes using an in-memory pipe. The syncer creates 3 goroutines (1 for stdout, 1 for stderr and 1 for synchronizing logs) that *MUST* be shutdown/terminated after execution of each stack.
The syncer supports a customizable `batchSize` and `maxLineSize` but the requirement of the latter will be fixed in a separate PR.
