### PR TITLE
chore: add make target to run tests within docker

### DIFF
--- a/cmd/terramate/e2etests/create_test.go
+++ b/cmd/terramate/e2etests/create_test.go
@@ -185,9 +185,8 @@ func TestCreateStackIgnoreExistingFatalOnOtherErrors(t *testing.T) {
 
 	s := sandbox.New(t)
 	root := s.RootEntry()
-	root.CreateDir("stack")
-	// Here we fail stack creating with an access error
-	root.Chmod("stack", 0444)
+	root.CreateFile("stack", "")
+	// Here we fail stack creating because a file with the same name exists
 	cli := newCLI(t, s.RootDir())
 
 	assertRunResult(t, cli.run("create", "stack", "--ignore-existing"), runExpected{

--- a/containers/test/Dockerfile
+++ b/containers/test/Dockerfile
@@ -1,0 +1,19 @@
+# Copyright 2023 Terramate GmbH
+# SPDX-License-Identifier: MPL-2.0
+
+FROM golang:1.20-alpine3.16
+
+RUN apk add --no-cache git gcc g++
+
+# Needed for go test -race
+ENV CGO_ENABLED=1
+
+WORKDIR /build
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+
+COPY . .
+
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    go test -race -count=1 -v ./cmd/terramate/e2etests

--- a/makefiles/common.mk
+++ b/makefiles/common.mk
@@ -162,3 +162,8 @@ help:
 			} \
 	} \
 	{ lastLine = $$0 }' $(MAKEFILE_LIST)
+
+## run tests within docker
+.PHONY: docker/test
+docker/test:
+	docker build --rm -f containers/test/Dockerfile .


### PR DESCRIPTION
# Reason for This Change

On Macos and Windows, running the tests is slower by a factor of 3-4 when compared to Linux, which has a negative impact on the development workflow on these systems.
When running the tests in a Docker container on the other hand, the performance is comparable to native Linux.

## Description of Changes

A Dockerfile and make target are added to run the tests with Docker build. Usage:
`make docker/test`

Currently, only the e2etests are executed, because when running terramate as root within the container, some filesystem related tests break. The one e2etest that breaks this way has been adapted
