### PR TITLE
chore(tests): ensure git >= 2.28.0 in tests.

### DIFF
--- a/makefiles/unix.mk
+++ b/makefiles/unix.mk
@@ -5,6 +5,21 @@ GO_BUILD_FLAGS=--ldflags '-extldflags "-static"'
 BUILD_ENV=CGO_ENABLED=0
 EXEC_SUFFIX=
 
+GIT_MIN_MAJOR_VERSION=2
+GIT_MIN_MINOR_VERSION=28
+GIT_MIN_VERSION=$(GIT_MIN_MAJOR_VERSION).$(GIT_MIN_MINOR_VERSION).0
+GIT_CURRENT_VERSION=$(shell git --version | grep ^git | cut -d' ' -f3)
+GIT_CURRENT_MAJOR_VERSION=$(shell echo $(GIT_CURRENT_VERSION) | cut -d. -f1)
+GIT_CURRENT_MINOR_VERSION=$(shell echo $(GIT_CURRENT_VERSION) | cut -d. -f2)
+
+IS_VALID_GIT_VERSION=$(shell expr $(GIT_CURRENT_MAJOR_VERSION) '>=' $(GIT_MIN_MAJOR_VERSION) '&' $(GIT_CURRENT_MINOR_VERSION) '>=' $(GIT_MIN_MINOR_VERSION))
+
+
+ifneq "$(IS_VALID_GIT_VERSION)" "1"
+$(error "$(IS_VALID_GIT_VERSION) Unsupported git version $(GIT_CURRENT_VERSION). Minimum supported version: $(GIT_MIN_VERSION)")
+endif
+
+
 ## build a test binary -- not static, telemetry sent to localhost, etc
 .PHONY: test/build
 test/build: test/fakecloud


### PR DESCRIPTION
# Reason for This Change

The test infrastructure initializes repositories with an alternate `default_branch` using the `git init -b` which was introduced in git 2.28.0

## Description of Changes

Only the UNIX makefiles were updated with the version check for now.
