### PR TITLE
fix(tmc): panic due to index out of range in logsyncer

### DIFF
--- a/cloud/log_syncer.go
+++ b/cloud/log_syncer.go
@@ -181,15 +181,18 @@ func scanLines(data []byte, atEOF bool) (advance int, token []byte, err error) {
 	return 0, nil, nil
 }
 
-// dropCRLN drops a terminal \r from the data.
+// dropCRLN drops a terminating \n and \r from the data.
 func dropCRLN(data []byte) []byte {
+	data = dropByte(data, '\n')
+	data = dropByte(data, '\r')
+	return data
+}
+
+func dropByte(data []byte, b byte) []byte {
 	if len(data) == 0 {
 		return data
 	}
-	if data[len(data)-1] == '\n' {
-		data = data[0 : len(data)-1]
-	}
-	if data[len(data)-1] == '\r' {
+	if data[len(data)-1] == b {
 		data = data[0 : len(data)-1]
 	}
 	return data

--- a/cloud/log_syncer_test.go
+++ b/cloud/log_syncer_test.go
@@ -114,6 +114,26 @@ func TestCloudLogSyncer(t *testing.T) {
 			},
 		},
 		{
+			name: "empty line -- regression check",
+			writes: []write{
+				{channel: cloud.StdoutLogChannel, data: []byte("\n")},
+			},
+			want: want{
+				output: map[cloud.LogChannel][]byte{
+					cloud.StdoutLogChannel: []byte("\n"),
+				},
+				batches: []cloud.DeploymentLogs{
+					{
+						{
+							Line:    1,
+							Channel: cloud.StdoutLogChannel,
+							Message: "",
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "multiple writes with CRLN",
 			writes: []write{
 				{channel: cloud.StdoutLogChannel, data: []byte("terramate\r\ncloud\r\n")},


### PR DESCRIPTION
## Reasons For This Change

When providing an stdout/stderr containing an empty line, the log syncer crashes:

```
panic: runtime error: index out of range [-1]

goroutine 213 [running]:
github.com/terramate-io/terramate/cloud.dropCRLN(...)
        /vagrant/terramate/cloud/log_syncer.go:192
github.com/terramate-io/terramate/cloud.(*LogSyncer).NewBuffer.func1()
        /vagrant/terramate/cloud/log_syncer.go:103 +0x6fd
created by github.com/terramate-io/terramate/cloud.(*LogSyncer).NewBuffer
        /vagrant/terramate/cloud/log_syncer.go:80 +0x2a5
FAIL    github.com/terramate-io/terramate/cloud 0.055s
FAIL
```

### Description of Changes

A bounds check is added before removing the CRLN from the line.
