### PR TITLE
chore(tests): fix windows tests depending on unix tools.

### DIFF
--- a/cmd/terramate/e2etests/run_cloud_deployment_test.go
+++ b/cmd/terramate/e2etests/run_cloud_deployment_test.go
@@ -334,7 +334,7 @@ func TestRunGithubTokenDetection(t *testing.T) {
 
 		result := tm.run("run",
 			"--disable-check-git-remote",
-			"--cloud-sync-deployment", "--", "true")
+			"--cloud-sync-deployment", "--", testHelperBin, "true")
 		assertRunResult(t, result, runExpected{
 			Status:      0,
 			StderrRegex: "GitHub token obtained from GH_TOKEN",
@@ -350,7 +350,7 @@ func TestRunGithubTokenDetection(t *testing.T) {
 
 		result := tm.run("run",
 			"--disable-check-git-remote",
-			"--cloud-sync-deployment", "--", "true")
+			"--cloud-sync-deployment", "--", testHelperBin, "true")
 		assertRunResult(t, result, runExpected{
 			Status:      0,
 			StderrRegex: "GitHub token obtained from GITHUB_TOKEN",
@@ -377,7 +377,7 @@ func TestRunGithubTokenDetection(t *testing.T) {
 
 		result := tm.run("run",
 			"--disable-check-git-remote",
-			"--cloud-sync-deployment", "--", "true")
+			"--cloud-sync-deployment", "--", testHelperBin, "true")
 		assertRunResult(t, result, runExpected{
 			Status:      0,
 			StderrRegex: "GitHub token obtained from oauth_token",

--- a/cmd/terramate/e2etests/run_test.go
+++ b/cmd/terramate/e2etests/run_test.go
@@ -1501,13 +1501,13 @@ func TestRunOrderNotChangedStackIgnored(t *testing.T) {
 	wantList := stack.RelPath() + "\n"
 	assertRunResult(t, cli.listChangedStacks(), runExpected{Stdout: wantList})
 
-	cat := test.LookPath(t, "cat")
 	wantRun := mainTfContents
 
 	assertRunResult(t, cli.run(
 		"run",
 		"--changed",
-		cat,
+		testHelperBin,
+		"cat",
 		mainTfFileName,
 	), runExpected{Stdout: wantRun})
 
@@ -1515,7 +1515,8 @@ func TestRunOrderNotChangedStackIgnored(t *testing.T) {
 	assertRunResult(t, cli.run(
 		"run",
 		"--changed",
-		cat,
+		testHelperBin,
+		"cat",
 		mainTfFileName,
 	), runExpected{Stdout: wantRun})
 
@@ -1523,7 +1524,8 @@ func TestRunOrderNotChangedStackIgnored(t *testing.T) {
 	assertRunResult(t, cli.run(
 		"run",
 		"--changed",
-		cat,
+		testHelperBin,
+		"cat",
 		mainTfFileName,
 	), runExpected{})
 }
@@ -1534,7 +1536,6 @@ func TestRunReverseExecution(t *testing.T) {
 	const testfile = "testfile"
 
 	s := sandbox.New(t)
-	cat := test.LookPath(t, "cat")
 	cli := newCLI(t, s.RootDir())
 	assertRunOrder := func(stacks ...string) {
 		t.Helper()
@@ -1547,7 +1548,8 @@ func TestRunReverseExecution(t *testing.T) {
 		assertRunResult(t, cli.run(
 			"run",
 			"--reverse",
-			cat,
+			testHelperBin,
+			"cat",
 			testfile,
 		), runExpected{Stdout: want})
 
@@ -1555,7 +1557,8 @@ func TestRunReverseExecution(t *testing.T) {
 			"run",
 			"--reverse",
 			"--changed",
-			cat,
+			testHelperBin,
+			"cat",
 			testfile,
 		), runExpected{Stdout: want})
 	}
@@ -1666,7 +1669,6 @@ func TestRunOrderAllChangedStacksExecuted(t *testing.T) {
 	wantList := stack.RelPath() + "\n" + stack2.RelPath() + "\n"
 	assertRunResult(t, cli.listChangedStacks(), runExpected{Stdout: wantList})
 
-	cat := test.LookPath(t, "cat")
 	wantRun := fmt.Sprintf(
 		"%s%s",
 		mainTfContents,
@@ -1676,7 +1678,8 @@ func TestRunOrderAllChangedStacksExecuted(t *testing.T) {
 	assertRunResult(t, cli.run(
 		"run",
 		"--changed",
-		cat,
+		testHelperBin,
+		"cat",
 		mainTfFileName,
 	), runExpected{Stdout: wantRun})
 }
@@ -1702,13 +1705,13 @@ func TestRunFailIfGitSafeguardUntracked(t *testing.T) {
 	stack.CreateFile("untracked-file.txt", `# something`)
 
 	cli := newCLI(t, s.RootDir())
-	cat := test.LookPath(t, "cat")
 
 	// check untracked with --changed
 	assertRunResult(t, cli.run(
 		"run",
 		"--changed",
-		cat,
+		testHelperBin,
+		"cat",
 		mainTfFileName,
 	), runExpected{
 		Status:      defaultErrExitStatus,
@@ -1718,7 +1721,8 @@ func TestRunFailIfGitSafeguardUntracked(t *testing.T) {
 	// check untracked *without* --changed
 	assertRunResult(t, cli.run(
 		"run",
-		cat,
+		testHelperBin,
+		"cat",
 		mainTfFileName,
 	), runExpected{
 		Status:      defaultErrExitStatus,
@@ -1732,14 +1736,16 @@ func TestRunFailIfGitSafeguardUntracked(t *testing.T) {
 			"run",
 			"--changed",
 			"--disable-check-git-untracked",
-			cat,
+			testHelperBin,
+			"cat",
 			mainTfFileName,
 		))
 
 		assertRunResult(t, cli.run(
 			"run",
 			"--disable-check-git-untracked",
-			cat,
+			testHelperBin,
+			"cat",
 			mainTfFileName,
 		), runExpected{
 			Stdout: mainTfContents,
@@ -1753,13 +1759,15 @@ func TestRunFailIfGitSafeguardUntracked(t *testing.T) {
 		assertRun(t, cli.run(
 			"run",
 			"--changed",
-			cat,
+			testHelperBin,
+			"cat",
 			mainTfFileName,
 		))
 
 		assertRunResult(t, cli.run(
 			"run",
-			cat,
+			testHelperBin,
+			"cat",
 			mainTfFileName,
 		), runExpected{
 			Stdout: mainTfContents,
@@ -1783,13 +1791,15 @@ func TestRunFailIfGitSafeguardUntracked(t *testing.T) {
 		assertRun(t, cli.run(
 			"run",
 			"--changed",
-			cat,
+			testHelperBin,
+			"cat",
 			mainTfFileName,
 		))
 
 		assertRunResult(t, cli.run(
 			"run",
-			cat,
+			testHelperBin,
+			"cat",
 			mainTfFileName,
 		), runExpected{
 			Stdout: mainTfContents,
@@ -1970,19 +1980,20 @@ func TestRunFailIfGitSafeguardUncommitted(t *testing.T) {
 	git.CommitAll("first commit")
 
 	cli := newCLI(t, s.RootDir())
-	cat := test.LookPath(t, "cat")
 
 	// everything committed, repo is clean
 	assertRunResult(t, cli.run(
 		"run",
-		cat,
+		testHelperBin,
+		"cat",
 		mainTfFileName,
 	), runExpected{Stdout: mainTfInitialContents})
 
 	assertRunResult(t, cli.run(
 		"run",
 		"--changed",
-		cat,
+		testHelperBin,
+		"cat",
 		mainTfFileName,
 	), runExpected{Stdout: mainTfInitialContents})
 
@@ -1991,7 +2002,8 @@ func TestRunFailIfGitSafeguardUncommitted(t *testing.T) {
 
 	assertRunResult(t, cli.run(
 		"run",
-		cat,
+		testHelperBin,
+		"cat",
 		mainTfFileName,
 	), runExpected{
 		Status:      defaultErrExitStatus,
@@ -2001,7 +2013,8 @@ func TestRunFailIfGitSafeguardUncommitted(t *testing.T) {
 	assertRunResult(t, cli.run(
 		"run",
 		"--changed",
-		cat,
+		testHelperBin,
+		"cat",
 		mainTfFileName,
 	), runExpected{
 		Status:      defaultErrExitStatus,
@@ -2012,7 +2025,8 @@ func TestRunFailIfGitSafeguardUncommitted(t *testing.T) {
 	assertRunResult(t, cli.run(
 		"run",
 		"--dry-run",
-		cat,
+		testHelperBin,
+		"cat",
 		mainTfFileName,
 	), runExpected{
 		IgnoreStdout: true,
@@ -2024,7 +2038,8 @@ func TestRunFailIfGitSafeguardUncommitted(t *testing.T) {
 		assertRunResult(t, cli.run(
 			"--disable-check-git-uncommitted",
 			"run",
-			cat,
+			testHelperBin,
+			"cat",
 			mainTfFileName,
 		), runExpected{
 			Stdout: mainTfAlteredContents,
@@ -2034,7 +2049,8 @@ func TestRunFailIfGitSafeguardUncommitted(t *testing.T) {
 			"--disable-check-git-uncommitted",
 			"--changed",
 			"run",
-			cat,
+			testHelperBin,
+			"cat",
 			mainTfFileName,
 		), runExpected{
 			Stdout: mainTfAlteredContents,
@@ -2045,10 +2061,12 @@ func TestRunFailIfGitSafeguardUncommitted(t *testing.T) {
 		cli := newCLI(t, s.RootDir(), testEnviron(t)...)
 		cli.appendEnv = append(cli.appendEnv, "TM_DISABLE_CHECK_GIT_UNCOMMITTED=true")
 
-		assertRunResult(t, cli.run("run", cat, mainTfFileName), runExpected{
+		assertRunResult(t, cli.run("run", testHelperBin,
+			"cat", mainTfFileName), runExpected{
 			Stdout: mainTfAlteredContents,
 		})
-		assertRunResult(t, cli.run("--changed", "run", cat, mainTfFileName), runExpected{
+		assertRunResult(t, cli.run("--changed", "run", testHelperBin,
+			"cat", mainTfFileName), runExpected{
 			Stdout: mainTfAlteredContents,
 		})
 	})
@@ -2069,10 +2087,15 @@ func TestRunFailIfGitSafeguardUncommitted(t *testing.T) {
 		git.Add(rootConfig)
 		git.Commit("commit root config")
 
-		assertRunResult(t, cli.run("run", cat, mainTfFileName), runExpected{
+		assertRunResult(t, cli.run("run",
+			testHelperBin,
+			"cat",
+			mainTfFileName), runExpected{
 			Stdout: mainTfAlteredContents,
 		})
-		assertRunResult(t, cli.run("--changed", "run", cat, mainTfFileName), runExpected{
+		assertRunResult(t, cli.run(
+			"--changed", "run", testHelperBin,
+			"cat", mainTfFileName), runExpected{
 			Stdout: mainTfAlteredContents,
 		})
 	})
@@ -2099,9 +2122,9 @@ func TestRunFailIfStackGeneratedCodeIsOutdated(t *testing.T) {
 	git.Push("main")
 
 	tmcli := newCLI(t, s.RootDir())
-	cat := test.LookPath(t, "cat")
 
-	assertRunResult(t, tmcli.run("run", cat, testFilename), runExpected{
+	assertRunResult(t, tmcli.run("run", testHelperBin,
+		"cat", testFilename), runExpected{
 		Stdout: contentsStack1 + contentsStack2,
 	})
 
@@ -2116,12 +2139,14 @@ func TestRunFailIfStackGeneratedCodeIsOutdated(t *testing.T) {
 	git.CheckoutNew("adding-stack1-config")
 	git.CommitAll("adding stack-1 config")
 
-	assertRunResult(t, tmcli.run("run", cat, testFilename), runExpected{
+	assertRunResult(t, tmcli.run("run", testHelperBin,
+		"cat", testFilename), runExpected{
 		Status:      defaultErrExitStatus,
 		StderrRegex: string(cli.ErrOutdatedGenCodeDetected),
 	})
 
-	assertRunResult(t, tmcli.run("run", "--changed", cat, testFilename), runExpected{
+	assertRunResult(t, tmcli.run("run", "--changed", testHelperBin,
+		"cat", testFilename), runExpected{
 		Status:      defaultErrExitStatus,
 		StderrRegex: string(cli.ErrOutdatedGenCodeDetected),
 	})
@@ -2129,7 +2154,8 @@ func TestRunFailIfStackGeneratedCodeIsOutdated(t *testing.T) {
 	// Check that if inside cwd it should still detect changes outside
 	tmcli = newCLI(t, stack2.Path())
 
-	assertRunResult(t, tmcli.run("run", cat, testFilename), runExpected{
+	assertRunResult(t, tmcli.run("run", testHelperBin,
+		"cat", testFilename), runExpected{
 		Status:      defaultErrExitStatus,
 		StderrRegex: string(cli.ErrOutdatedGenCodeDetected),
 	})
@@ -2172,12 +2198,14 @@ func TestRunContinueOnError(t *testing.T) {
 	git.Push("main")
 
 	cli := newCLI(t, s.RootDir())
-	assertRunResult(t, cli.run("run", "cat", "main.tf"), runExpected{
+	assertRunResult(t, cli.run("run", testHelperBin,
+		"cat", "main.tf"), runExpected{
 		StderrRegex: "one or more commands failed",
 		Status:      1,
 	})
 
-	assertRunResult(t, cli.run("run", "--continue-on-error", "cat", "main.tf"), runExpected{
+	assertRunResult(t, cli.run("run", "--continue-on-error", testHelperBin,
+		"cat", "main.tf"), runExpected{
 		IgnoreStderr: true,
 		Stdout:       expectedOutput,
 		Status:       1,
@@ -2210,26 +2238,30 @@ func TestRunNoRecursive(t *testing.T) {
 	git.Push("main")
 
 	cli := newCLI(t, s.RootDir())
-	assertRunResult(t, cli.run("run", "cat", "file.txt"), runExpected{
+	assertRunResult(t, cli.run("run", testHelperBin,
+		"cat", "file.txt"), runExpected{
 		Stdout: `parentchild1child2`,
 	})
 
 	cli = newCLI(t, parent.Path())
-	assertRunResult(t, cli.run("run", "--no-recursive", "cat", "file.txt"),
+	assertRunResult(t, cli.run("run", "--no-recursive", testHelperBin,
+		"cat", "file.txt"),
 		runExpected{
 			Stdout: `parent`,
 		},
 	)
 
 	cli = newCLI(t, child1.Path())
-	assertRunResult(t, cli.run("run", "--no-recursive", "cat", "file.txt"),
+	assertRunResult(t, cli.run("run", "--no-recursive", testHelperBin,
+		"cat", "file.txt"),
 		runExpected{
 			Stdout: `child1`,
 		},
 	)
 
 	cli = newCLI(t, s.RootDir())
-	assertRunResult(t, cli.run("run", "--no-recursive", "cat", "file.txt"),
+	assertRunResult(t, cli.run("run", "--no-recursive", testHelperBin,
+		"cat", "file.txt"),
 		runExpected{
 			Status:       1,
 			IgnoreStderr: true,

--- a/cmd/terramate/e2etests/safeguard_test.go
+++ b/cmd/terramate/e2etests/safeguard_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/terramate-io/terramate/cmd/terramate/cli"
-	"github.com/terramate-io/terramate/test"
 	"github.com/terramate-io/terramate/test/sandbox"
 	"go.lsp.dev/uri"
 )
@@ -129,13 +128,12 @@ func TestSafeguardCheckRemoteDisabled(t *testing.T) {
 		return newCLI(t, s.RootDir(), env...), someFile, s
 	}
 
-	cat := test.LookPath(t, "cat")
-
 	t.Run("make sure setup() makes origin/main unreachable", func(t *testing.T) {
 		tmcli, file, _ := setup(t)
 		assertRunResult(t, tmcli.run(
 			"run",
-			cat,
+			testHelperBin,
+			"cat",
 			file.HostPath(),
 		),
 			runExpected{
@@ -149,7 +147,8 @@ func TestSafeguardCheckRemoteDisabled(t *testing.T) {
 		assertRunResult(t, tmcli.run(
 			"run",
 			"--disable-check-git-remote",
-			cat,
+			testHelperBin,
+			"cat",
 			file.HostPath(),
 		), runExpected{Stdout: fileContents})
 	})
@@ -158,7 +157,8 @@ func TestSafeguardCheckRemoteDisabled(t *testing.T) {
 		tmcli, file, _ := setup(t, testEnviron(t)...)
 		tmcli.appendEnv = append(tmcli.appendEnv, "TM_DISABLE_CHECK_GIT_REMOTE=true")
 
-		assertRunResult(t, tmcli.run("run", cat, file.HostPath()), runExpected{
+		assertRunResult(t, tmcli.run("run", testHelperBin,
+			"cat", file.HostPath()), runExpected{
 			Stdout: fileContents,
 		})
 	})
@@ -184,7 +184,8 @@ func TestSafeguardCheckRemoteDisabled(t *testing.T) {
 
 			assertRunResult(t, tmcli.run(
 				"run",
-				cat,
+				testHelperBin,
+				"cat",
 				file.HostPath(),
 			),
 				runExpected{
@@ -212,7 +213,8 @@ func TestSafeguardCheckRemoteDisabled(t *testing.T) {
 			git.Add(rootConfig)
 			git.Commit("commit root config")
 
-			assertRunResult(t, tmcli.run("run", cat, file.HostPath()), runExpected{
+			assertRunResult(t, tmcli.run("run", testHelperBin,
+				"cat", file.HostPath()), runExpected{
 				Stdout: fileContents,
 			})
 		})
@@ -239,7 +241,8 @@ func TestSafeguardCheckRemoteDisabled(t *testing.T) {
 			assertRunResult(t, tmcli.run(
 				"run",
 				"--disable-check-git-remote",
-				cat,
+				testHelperBin,
+				"cat",
 				file.HostPath(),
 			), runExpected{Stdout: fileContents})
 		})
@@ -269,10 +272,10 @@ func TestSafeguardCheckRemoteDisabledWorksWithoutNetworking(t *testing.T) {
 
 	tm := newCLI(t, s.RootDir())
 
-	cat := test.LookPath(t, "cat")
 	assertRunResult(t, tm.run(
 		"run",
-		cat,
+		testHelperBin,
+		"cat",
 		stackFile.HostPath(),
 	), runExpected{
 		Status:      1,
@@ -281,7 +284,8 @@ func TestSafeguardCheckRemoteDisabledWorksWithoutNetworking(t *testing.T) {
 	assertRunResult(t, tm.run(
 		"run",
 		"--disable-check-git-remote",
-		cat,
+		testHelperBin,
+		"cat",
 		stackFile.HostPath(),
 	), runExpected{
 		Stdout: fileContents,
@@ -307,10 +311,10 @@ func TestSafeguardCheckRemoteDisjointBranchesAreUnreachable(t *testing.T) {
 
 	tm := newCLI(t, s.RootDir())
 
-	cat := test.LookPath(t, "cat")
 	assertRunResult(t, tm.run(
 		"run",
-		cat,
+		testHelperBin,
+		"cat",
 		stackFile.HostPath(),
 	), runExpected{
 		Status:      1,

--- a/cmd/terramate/e2etests/version_check_test.go
+++ b/cmd/terramate/e2etests/version_check_test.go
@@ -19,19 +19,19 @@ import (
 func TestVersionCheck(t *testing.T) {
 	t.Parallel()
 
-	checkedCmds := []string{
-		"experimental metadata",
-		"experimental globals",
-		"experimental run-order",
-		"experimental run-graph",
-		"generate",
-		"list",
-		fmt.Sprintf("run cat %s", stack.DefaultFilename),
+	checkedCmds := map[string]string{
+		"experimental metadata":  "experimental metadata",
+		"experimental globals":   "experimental globals",
+		"experimental run-order": "experimental run-order",
+		"experimental run-graph": "experimental run-graph",
+		"generate":               "generate",
+		"list":                   "list",
+		"run":                    fmt.Sprintf("run %s cat %s", testHelperBin, stack.DefaultFilename),
 	}
-	uncheckedCmds := []string{
-		"--help",
-		"--version",
-		"version",
+	uncheckedCmds := map[string]string{
+		"help":            "--help",
+		"version flag":    "--version",
+		"version command": "version",
 	}
 
 	run := func(t *testing.T, cmd string, version string) runResult {
@@ -54,8 +54,8 @@ func TestVersionCheck(t *testing.T) {
 		invalidVersion = "0.0.0"
 	)
 
-	for _, checkedCmd := range checkedCmds {
-		name := fmt.Sprintf("%s is checked", checkedCmd)
+	for name, checkedCmd := range checkedCmds {
+		name := fmt.Sprintf("name %s is checked", name)
 		checkedCmd := checkedCmd
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -65,8 +65,8 @@ func TestVersionCheck(t *testing.T) {
 			})
 		})
 	}
-	for _, uncheckedCmd := range uncheckedCmds {
-		name := fmt.Sprintf("%s isnt checked", uncheckedCmd)
+	for name, uncheckedCmd := range uncheckedCmds {
+		name := fmt.Sprintf("name %s isnt checked", name)
 		uncheckedCmd := uncheckedCmd
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -77,9 +77,16 @@ func TestVersionCheck(t *testing.T) {
 		})
 	}
 
-	cmds := append(checkedCmds, uncheckedCmds...)
-	for _, cmd := range cmds {
-		name := fmt.Sprintf("%s works with valid version", cmd)
+	cmds := map[string]string{}
+	for name, cmd := range checkedCmds {
+		cmds[name] = cmd
+	}
+	for name, cmd := range uncheckedCmds {
+		cmds[name] = cmd
+	}
+
+	for name, cmd := range cmds {
+		name := fmt.Sprintf("%s works with valid version", name)
 		cmd := cmd
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()


### PR DESCRIPTION
# Reason for This Change

The Windows tests depended upon the installation of cygwin tools like `cat`, `true`, etc.
Now a brand new Windows box can run Terramate tests.

## Description of Changes

All occurrences of `cat`, `true`, etc, were replaced by `[testHelperBin, <cmd>]`.