### PR TITLE
chore(tmc): add verbose messages when refreshing tokens.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
         run: terramate run --tags golang --changed -- make build
 
       - name: check cloud info
-        run: terramate run --tags golang --changed -- ./bin/terramate experimental cloud info
+        run: terramate run --tags golang --changed -- ./bin/terramate -vv experimental cloud info
 
   gh_integration_test:
     name: GHA Integration Test

--- a/cmd/terramate/cli/cloud_credential_github.go
+++ b/cmd/terramate/cli/cloud_credential_github.go
@@ -92,7 +92,18 @@ func (g *githubOIDC) ExpireAt() time.Time {
 	return g.expireAt
 }
 
-func (g *githubOIDC) Refresh() error {
+func (g *githubOIDC) Refresh() (err error) {
+	if g.token != "" {
+		g.output.MsgStdOutV("refreshing token...")
+
+		defer func() {
+			if err == nil {
+				g.output.MsgStdOutV("token successfully refreshed.")
+				g.output.MsgStdOutV("next token refresh in: %s", time.Until(g.ExpireAt()))
+			}
+		}()
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), defaultGithubTimeout)
 	defer cancel()
 

--- a/cmd/terramate/cli/cloud_credential_google.go
+++ b/cmd/terramate/cli/cloud_credential_google.go
@@ -474,13 +474,16 @@ func (g *googleCredential) ExpireAt() time.Time {
 }
 
 func (g *googleCredential) Refresh() (err error) {
-	g.output.MsgStdOutV("refreshing token...")
+	if g.token != "" {
+		g.output.MsgStdOutV("refreshing token...")
 
-	defer func() {
-		if err == nil {
-			g.output.MsgStdOutV("token successfully refreshed.")
-		}
-	}()
+		defer func() {
+			if err == nil {
+				g.output.MsgStdOutV("token successfully refreshed.")
+				g.output.MsgStdOutV("next token refresh in: %s", time.Until(g.ExpireAt()))
+			}
+		}()
+	}
 
 	const oidcTimeout = 3 // seconds
 	const refreshTokenURL = "https://securetoken.googleapis.com/v1/token"


### PR DESCRIPTION
These messages can be enabled with `terramate -v ...` and they will help us troubleshoot issues related to token refreshing.
