### PR TITLE
feat(tmc): sync drift run duration

### DIFF
--- a/cloud/types.go
+++ b/cloud/types.go
@@ -112,11 +112,13 @@ type (
 
 	// DriftStackPayloadRequest is the payload for the drift sync.
 	DriftStackPayloadRequest struct {
-		Stack    Stack               `json:"stack"`
-		Status   stack.Status        `json:"drift_status"`
-		Details  *DriftDetails       `json:"drift_details,omitempty"`
-		Metadata *DeploymentMetadata `json:"metadata,omitempty"`
-		Command  []string            `json:"command"`
+		Stack      Stack               `json:"stack"`
+		Status     stack.Status        `json:"drift_status"`
+		Details    *DriftDetails       `json:"drift_details,omitempty"`
+		Metadata   *DeploymentMetadata `json:"metadata,omitempty"`
+		Command    []string            `json:"command"`
+		StartedAt  *time.Time          `json:"started_at,omitempty"`
+		FinishedAt *time.Time          `json:"finished_at,omitempty"`
 	}
 
 	// DriftStackPayloadRequests is a list of DriftStackPayloadRequest

--- a/cmd/terramate/cli/cloud.go
+++ b/cmd/terramate/cli/cloud.go
@@ -205,7 +205,7 @@ func (c *cli) cloudSyncBefore(run ExecContext, _ string) {
 	c.doCloudSyncDeployment(run, deployment.Running)
 }
 
-func (c *cli) cloudSyncAfter(runContext ExecContext, exitCode int, err error) {
+func (c *cli) cloudSyncAfter(runContext ExecContext, res RunResult, err error) {
 	if !c.cloudEnabled() || !c.isCloudSync() {
 		return
 	}
@@ -213,13 +213,13 @@ func (c *cli) cloudSyncAfter(runContext ExecContext, exitCode int, err error) {
 	if c.parsedArgs.Run.CloudSyncDeployment {
 		c.cloudSyncDeployment(runContext, err)
 	} else {
-		c.cloudSyncDriftStatus(runContext, exitCode, err)
+		c.cloudSyncDriftStatus(runContext, res, err)
 	}
 }
 
 func (c *cli) cloudSyncCancelStacks(stacks []ExecContext) {
 	for _, run := range stacks {
-		c.cloudSyncAfter(run, -1, errors.E(ErrRunCanceled))
+		c.cloudSyncAfter(run, RunResult{ExitCode: -1}, errors.E(ErrRunCanceled))
 	}
 }
 

--- a/cmd/terramate/e2etests/run_cloud_signal_test.go
+++ b/cmd/terramate/e2etests/run_cloud_signal_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/madlambda/spells/assert"
@@ -193,9 +194,11 @@ func TestCLIRunWithCloudSyncDriftStatusWithSignals(t *testing.T) {
 
 			fixture := cli.newRunFixture(tc.runMode, s.RootDir(), runflags...)
 			fixture.cmd = tc.cmd // if empty, uses the runFixture default cmd.
+			minStartTime := time.Now().UTC()
 			result := fixture.run()
+			maxEndTime := time.Now().UTC()
 			assertRunResult(t, result, tc.want.run)
-			assertRunDrifts(t, addr, tc.want.drifts)
+			assertRunDrifts(t, addr, tc.want.drifts, minStartTime, maxEndTime)
 		})
 	}
 }


### PR DESCRIPTION
# Reason for This Change

Users would like to know how when and for how long the command associated with a drifted stack ran.

## Description of Changes

* Two optional attributes StartedAt and FinishedAt have been added to synced drift data. They are set whenever there was an attempt to run the command, but may be omitted in error cases where no run was attempted yet.
