### PR TITLE
chore: improve running tests in docker.

### DIFF
--- a/cmd/terramate/e2etests/main_test.go
+++ b/cmd/terramate/e2etests/main_test.go
@@ -109,6 +109,7 @@ func buildTestHelper(goBin, testCmdPath, binDir string) (string, error) {
 	cmd := exec.Command(
 		goBin,
 		"build",
+		"-buildvcs=false",
 		"-o",
 		outBinPath,
 		testCmdPath,
@@ -128,6 +129,7 @@ func buildTerramate(goBin, projectRoot, binDir string) (string, error) {
 	cmd := exec.Command(
 		goBin,
 		"build",
+		"-buildvcs=false",
 		"-tags",
 		"localhostEndpoints",
 		"-race",

--- a/containers/test/Dockerfile
+++ b/containers/test/Dockerfile
@@ -2,18 +2,21 @@
 # SPDX-License-Identifier: MPL-2.0
 
 FROM golang:1.20-alpine3.16 AS base
+# Needed for go test -race
+RUN apk add --no-cache git gcc g++ make bash
 WORKDIR /build
+RUN adduser -S tmuser
+# Change to non-root user for testing permissions properly
+USER tmuser
+
 COPY go.mod .
 COPY go.sum .
 RUN go mod download
 
-
 FROM base AS test
 
-# Needed for go test -race
-RUN apk add --no-cache git gcc g++
 ENV CGO_ENABLED=1
 
 RUN --mount=target=. \
   --mount=type=cache,target=/root/.cache/go-build \
-  go test -race -count=1 ./cmd/terramate/e2etests
+  make test

--- a/makefiles/common.mk
+++ b/makefiles/common.mk
@@ -69,6 +69,11 @@ coverage:
 coverage/show: coverage
 	go tool cover -html=$(COVERAGE_REPORT)
 
+## run tests within docker
+.PHONY: test/docker
+test/docker:
+	docker build --progress=plain --rm -f containers/test/Dockerfile .
+
 ## start fuzzying to generate some new corpus/find errors on partial eval
 .PHONY: test/fuzz/eval
 test/fuzz/eval:
@@ -161,9 +166,4 @@ help:
 				printf "  ${GREEN}%-30s${RESET} %s\n", cmd, msg; \
 			} \
 	} \
-	{ lastLine = $$0 }' $(MAKEFILE_LIST)
-
-## run tests within docker
-.PHONY: docker/test
-docker/test:
-	docker build --rm -f containers/test/Dockerfile .
+	{ lastLine = $$0 }' $(MAKEFILE_LIST) | sort


### PR DESCRIPTION
The changes below were implemented:

- `make docker/test` -> `make test/docker`.

Reasoning: All test commands begin with `test`.

- Run `make test` in the container build instead of `go test ... cmd/terramate/e2etests`.

Reasoning: Convenience, so we can use a single command to check if everything works.

- Make rules sorted alphabetically.

Then it's easier to spot the rules when running just `make` or `make help`.

- In the e2e tests, builds terramate and helper with -buildvcs=off

Reasoning: In order to embed git meta information, Go needs a configured `git` client and file permissions must be correct. The VCS embedding is not needed in the e2e binaries, then disabling it is easier than making it work in the docker env.
