### PR TITLE
chore: enable GHA fail-fast.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,6 @@ jobs:
       contents: read  # This is required for actions/checkout
 
     strategy:
-      fail-fast: false
       matrix:
         os: ["ubuntu-20.04", "macos-11", "macos-12"]
         go: ["1.20"]


### PR DESCRIPTION
As we have `fail-fast` disabled we are keeping runners busy even when required jobs already failed. This creates a huge queue of PR builds waiting for available runners if multiple people contribute to the same repository.
