### PR TITLE
chore: fix linting issues in OSX.

### DIFF
--- a/cmd/terramate/e2etests/runner_test.go
+++ b/cmd/terramate/e2etests/runner_test.go
@@ -135,17 +135,6 @@ func (tc *testCmd) run() error {
 	return tc.cmd.Run()
 }
 
-func (tc *testCmd) start() {
-	t := tc.t
-	t.Helper()
-
-	assert.NoError(t, tc.cmd.Start())
-}
-
-func (tc *testCmd) wait() error {
-	return tc.cmd.Wait()
-}
-
 func (tc *testCmd) exitCode() int {
 	return tc.cmd.ProcessState.ExitCode()
 }

--- a/cmd/terramate/e2etests/runner_unix_test.go
+++ b/cmd/terramate/e2etests/runner_unix_test.go
@@ -4,7 +4,7 @@
 // build flags for unix below were taken from:
 // https://github.com/golang/go/blob/master/src/cmd/dist/build.go#L943
 // We can replace them by "unix" if we support only go >= 1.19 later.
-//go:build aix || android || darwin || dragonfly || freebsd || hurd || illumos || ios || linux || netbsd || openbsd || solaris
+//go:build unix && !darwin
 
 package e2etest
 
@@ -14,6 +14,17 @@ import (
 
 	"github.com/madlambda/spells/assert"
 )
+
+func (tc *testCmd) start() {
+	t := tc.t
+	t.Helper()
+
+	assert.NoError(t, tc.cmd.Start())
+}
+
+func (tc *testCmd) wait() error {
+	return tc.cmd.Wait()
+}
 
 func (tc *testCmd) setpgid() {
 	tc.cmd.SysProcAttr = &syscall.SysProcAttr{

--- a/cmd/terramate/e2etests/runner_windows_test.go
+++ b/cmd/terramate/e2etests/runner_windows_test.go
@@ -17,6 +17,17 @@ var (
 	procGenerateConsoleCtrlEvent = libkernel32.MustFindProc("GenerateConsoleCtrlEvent")
 )
 
+func (tc *testCmd) start() {
+	t := tc.t
+	t.Helper()
+
+	assert.NoError(t, tc.cmd.Start())
+}
+
+func (tc *testCmd) wait() error {
+	return tc.cmd.Wait()
+}
+
 func (tc *testCmd) setpgid() {
 	tc.cmd.SysProcAttr = &syscall.SysProcAttr{
 		CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP,


### PR DESCRIPTION
Some testing helper methods are unused because signal tests are skipped in OSX.