### PR TITLE
feat: add clone support for child stacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ file in rendered ASCII and JSON (sensitive information removed).
 - Add configuration attribute `terramate.config.cloud.organization` to select which cloud organization to use when syncing with Terramate Cloud.
 - Add sync of logs to _Terramate Cloud_ when using `--cloud-sync-deployment` flag.
 - Add `terramate experimental cloud drift show` for retrieving drift details from Terramate Cloud.
+- Add support for cloning nested stacks to `terramate experimental clone`. It can also be used to clone directories that
+are not stacks themselves, but contain stacks in sub-directories.
 
 ## 0.4.2
 

--- a/cmd/terramate/e2etests/exp_clone_test.go
+++ b/cmd/terramate/e2etests/exp_clone_test.go
@@ -61,7 +61,7 @@ generate_hcl "test2.hcl" {
 	res := tmcli.run("experimental", "clone", srcStack, destStack)
 
 	assertRunResult(t, res, runExpected{
-		StdoutRegex: fmt.Sprintf("Cloned stack %s to %s with success\n", srcStack, destStack),
+		StdoutRegex: cloneSuccessMsg(1, srcStack, destStack),
 	})
 
 	destdir := filepath.Join(s.RootDir(), destStack)
@@ -92,4 +92,185 @@ generate_hcl "test2.hcl" {
 
 	test.AssertGenCodeEquals(t, genHCL, `a = "literal"`)
 	test.AssertGenCodeEquals(t, genHCL2, `b = null`)
+}
+
+func TestCloneStacksWithChildren(t *testing.T) {
+	t.Parallel()
+
+	type testcase struct {
+		Name            string
+		Layout          []string
+		Srcdir          string
+		Destdir         string
+		SkipChildStacks bool
+		WantLayout      []string
+		WantError       string
+		WantCloneCount  int
+	}
+
+	tests := []testcase{
+		{
+			Name: "clone stack dir with children",
+			Layout: []string{
+				"s:stack-1",
+				"f:stack-1/.ignored",
+				"f:stack-1/somefile.txt:foo",
+				"s:stack-1/child-a",
+				"s:stack-1/child-b",
+				"s:stack-2",
+				"s:stack-2/child-c",
+			},
+			Srcdir:  "stack-1",
+			Destdir: "cloned-stack-1",
+			WantLayout: []string{
+				"s:cloned-stack-1",
+				"s:cloned-stack-1/child-a",
+				"s:cloned-stack-1/child-b",
+				"f:cloned-stack-1/somefile.txt:foo",
+				"!e:cloned-stack-1/.ignored",
+			},
+			WantCloneCount: 3,
+		},
+		{
+			Name: "clone non-stack dir with children",
+			Layout: []string{
+				"s:stacks/stack-1",
+				"s:stacks/stack-2",
+				"s:stacks/stack-3",
+				"s:stacks/stack-4",
+			},
+			Srcdir:  "stacks",
+			Destdir: "cloned-stacks",
+			WantLayout: []string{
+				"s:cloned-stacks/stack-1",
+				"s:cloned-stacks/stack-2",
+				"s:cloned-stacks/stack-3",
+				"s:cloned-stacks/stack-4",
+			},
+			WantCloneCount: 4,
+		},
+		{
+			Name: "clone stack dir without children",
+			Layout: []string{
+				"s:stack-1",
+				"s:stack-1/child-a",
+				"s:stack-2",
+				"f:stack-2/somefile.txt:foo",
+				"f:stack-2/.ignored",
+				"s:stack-2/child-b",
+				"s:stack-2/child-c",
+				"f:stack-2/mydir/others.txt:foo",
+				"f:stack-2/mydir/stuff/.ignored2",
+			},
+			Srcdir:          "stack-2",
+			Destdir:         "cloned-stack-2",
+			SkipChildStacks: true,
+			WantLayout: []string{
+				"s:cloned-stack-2",
+				"!e:cloned-stack-2/.ignored",
+				"!e:cloned-stack-2/mydir/stuff/.ignored2",
+				"f:cloned-stack-2/somefile.txt:foo",
+				"f:cloned-stack-2/mydir/others.txt:foo",
+				"f:cloned-stack-2/mydir/others.txt:foo",
+			},
+			WantCloneCount: 1,
+		},
+		{
+			Name: "fail to clone non-stack dir if skipping children",
+			Layout: []string{
+				"f:stacks/somefile.txt:foo",
+				"s:stacks/stack-1",
+				"s:stacks/stack-2",
+				"s:stacks/stack-3",
+				"f:stacks/other/other.txt:bar",
+			},
+			Srcdir:          "stacks",
+			Destdir:         "cloned-stacks",
+			SkipChildStacks: true,
+			WantError:       "no stacks to clone",
+		},
+		{
+			Name: "destdir is in srcdir",
+			Layout: []string{
+				"s:stack-A",
+				"s:stack-A/child-stack",
+				"s:stack-A/child-stack/nested",
+				"s:stack-A/stack-A-copied",
+				"s:stack-A/stack-A-copied/child-stack",
+				"s:stack-A/stack-A-copied/child-stack/nested",
+			},
+			WantLayout: []string{
+				"s:stack-A/stack-A-copied/copied-again",
+				"s:stack-A/stack-A-copied/copied-again/child-stack",
+				"s:stack-A/stack-A-copied/copied-again/child-stack/nested",
+				"s:stack-A/stack-A-copied/copied-again/stack-A-copied",
+				"s:stack-A/stack-A-copied/copied-again/stack-A-copied/child-stack",
+				"s:stack-A/stack-A-copied/copied-again/stack-A-copied/child-stack/nested",
+			},
+			Srcdir:         "stack-A",
+			Destdir:        "stack-A/stack-A-copied/copied-again",
+			WantCloneCount: 6,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+
+		t.Run(tc.Name, func(t *testing.T) {
+			s := sandbox.NoGit(t, true)
+			s.BuildTree(tc.Layout)
+
+			tmcli := newCLI(t, s.RootDir())
+			args := []string{"experimental", "clone", tc.Srcdir, tc.Destdir}
+			if tc.SkipChildStacks {
+				args = append(args, "--skip-child-stacks")
+			}
+			res := tmcli.run(args...)
+
+			if tc.WantError == "" {
+				assertRunResult(t, res, runExpected{
+					StdoutRegex: cloneSuccessMsg(tc.WantCloneCount, tc.Srcdir, tc.Destdir),
+				})
+			} else {
+				assertRunResult(t, res, runExpected{
+					Status:      1,
+					StderrRegex: tc.WantError,
+				})
+			}
+
+			wantLayout := append(tc.Layout, tc.WantLayout...)
+			s.AssertTree(wantLayout, sandbox.WithStrictStackValidation())
+		})
+	}
+}
+
+func TestCloneErrorCleanup(t *testing.T) {
+	t.Parallel()
+
+	const (
+		dstdir = "cloned_dir"
+	)
+
+	s := sandbox.NoGit(t, true)
+	s.BuildTree([]string{
+		"s:a",
+		"s:a/b",
+		"s:a/b/c",
+	})
+
+	dir := s.DirEntry("a/b/c").CreateDir("somedir")
+	file := dir.CreateFile("file.txt", "")
+	file.Chmod(0)
+	defer file.Chmod(0755)
+
+	tmcli := newCLI(t, s.RootDir())
+	res := tmcli.run("experimental", "clone", "a", dstdir)
+
+	assert.EqualInts(t, 1, res.Status, "clone exit status")
+
+	test.DoesNotExist(t, s.RootDir(), dstdir)
+}
+
+func cloneSuccessMsg(c int, src, dst string) string {
+	return fmt.Sprintf("Cloned %d stack\\(s\\) from %s to %s with success\n", c, src, dst)
 }

--- a/docs/cmdline/clone.md
+++ b/docs/cmdline/clone.md
@@ -15,11 +15,13 @@ next:
 
 **Note:** This is an experimental command and is likely subject to change in the future.
 
-The `clone` command clones a stack. Terramate will automatically update the 
-UUID of the cloned stack.
+The `clone` command clones stacks from a source to a target directory. Terramate will recursively copy the stack
+files and directories, and automatically update the `stack.id` with generated UUIDs for the cloned stacks.
 
-**Note:** Currently, `clone` does not support nested stacks. We will add this
-functionality in the future.
+The source directory can be a stack itself, or it can contain stacks in sub-directories.
+
+The flag `--skip-child-stacks` can be set to change this behaviour, so stacks in sub-directories will be ignored;
+in this case, the source directory itself must be a stack.
 
 ## Usage
 
@@ -31,4 +33,10 @@ Clone a stack `alice` to target `bob`:
 
 ```bash
 terramate experimental clone stacks/alice stacks/bob
+```
+
+Clone all stacks within directory `stacks` to `cloned-stacks`:
+
+```bash
+terramate experimental clone stacks cloned-stacks
 ```

--- a/stack/clone_test.go
+++ b/stack/clone_test.go
@@ -90,7 +90,7 @@ func TestStackClone(t *testing.T) {
 
 			srcdir := filepath.Join(s.RootDir(), tc.src)
 			destdir := filepath.Join(s.RootDir(), tc.dest)
-			err := stack.Clone(s.Config(), destdir, srcdir)
+			_, err := stack.Clone(s.Config(), destdir, srcdir, false)
 			assert.IsError(t, err, tc.wantErr)
 
 			if tc.wantErr != nil {
@@ -107,7 +107,7 @@ func TestStackCloneSrcDirMustBeInsideRootdir(t *testing.T) {
 	s := sandbox.NoGit(t, true)
 	srcdir := test.TempDir(t)
 	destdir := filepath.Join(s.RootDir(), "new-stack")
-	err := stack.Clone(s.Config(), destdir, srcdir)
+	_, err := stack.Clone(s.Config(), destdir, srcdir, false)
 	assert.IsError(t, err, errors.E(stack.ErrInvalidStackDir))
 }
 
@@ -116,7 +116,7 @@ func TestStackCloneTargetDirMustBeInsideRootdir(t *testing.T) {
 	s := sandbox.NoGit(t, true)
 	srcdir := filepath.Join(s.RootDir(), "src-stack")
 	destdir := test.TempDir(t)
-	err := stack.Clone(s.Config(), destdir, srcdir)
+	_, err := stack.Clone(s.Config(), destdir, srcdir, false)
 	assert.IsError(t, err, errors.E(stack.ErrInvalidStackDir))
 }
 
@@ -130,7 +130,7 @@ func TestStackCloneIgnoresDotDirsAndFiles(t *testing.T) {
 	})
 	srcdir := filepath.Join(s.RootDir(), "stack")
 	destdir := filepath.Join(s.RootDir(), "cloned-stack")
-	err := stack.Clone(s.Config(), destdir, srcdir)
+	_, err := stack.Clone(s.Config(), destdir, srcdir, false)
 	assert.NoError(t, err)
 
 	entries := test.ReadDir(t, destdir)
@@ -188,7 +188,7 @@ generate_hcl "test2.hcl" {
 	srcdir := filepath.Join(s.RootDir(), "stack")
 	destdir := filepath.Join(s.RootDir(), "cloned-stack")
 
-	err := stack.Clone(s.Config(), destdir, srcdir)
+	_, err := stack.Clone(s.Config(), destdir, srcdir, false)
 	assert.NoError(t, err)
 
 	cfg := test.ParseTerramateConfig(t, destdir)
@@ -242,7 +242,7 @@ stack {
 	srcdir := filepath.Join(s.RootDir(), "stack")
 	destdir := filepath.Join(s.RootDir(), "cloned-stack")
 
-	err := stack.Clone(s.Config(), destdir, srcdir)
+	_, err := stack.Clone(s.Config(), destdir, srcdir, false)
 	assert.NoError(t, err)
 
 	cfg := test.ParseTerramateConfig(t, destdir)

--- a/test/os.go
+++ b/test/os.go
@@ -4,6 +4,7 @@
 package test
 
 import (
+	"errors"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -28,6 +29,46 @@ func TempDir(t testing.TB) string {
 		return t.TempDir()
 	}
 	return tempDir(t, tmTestRootTempdir)
+}
+
+// DoesNotExist calls os.Stat and asserts that the entry does not exist
+func DoesNotExist(t testing.TB, dir, fname string) {
+	t.Helper()
+	_, err := os.Stat(filepath.Join(dir, fname))
+	if errors.Is(err, os.ErrNotExist) {
+		return
+	}
+	assert.NoError(t, err, "stat error")
+
+	t.Fatalf("should not exist: %s", fname)
+}
+
+// IsDir calls os.Stat and asserts that the entry is a directory
+func IsDir(t testing.TB, dir, fname string) {
+	t.Helper()
+	isDirOrFile(t, dir, fname, true)
+}
+
+// IsFile calls os.Stat and asserts that the entry is a file
+func IsFile(t testing.TB, dir, fname string) {
+	t.Helper()
+	isDirOrFile(t, dir, fname, false)
+}
+
+func isDirOrFile(t testing.TB, dir, fname string, isDir bool) {
+	t.Helper()
+	fi, err := os.Stat(filepath.Join(dir, fname))
+	if errors.Is(err, os.ErrNotExist) {
+		if isDir {
+			t.Fatalf("directory does not exist: %s", fname)
+		} else {
+			t.Fatalf("file does not exist: %s", fname)
+		}
+		return
+	}
+	assert.NoError(t, err, "stat error")
+
+	assert.IsTrue(t, fi.IsDir() == isDir, "want:\n%s\ngot:\n%s\n", fi.IsDir(), isDir)
 }
 
 // ReadDir calls os.Readir asserting the success of the operation.

--- a/test/sandbox/sandbox.go
+++ b/test/sandbox/sandbox.go
@@ -19,10 +19,12 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/madlambda/spells/assert"
 	"github.com/terramate-io/terramate/config"
 	"github.com/terramate-io/terramate/fs"
@@ -190,6 +192,46 @@ func (s S) BuildTree(layout []string) {
 	s.t.Helper()
 
 	buildTree(s.t, s.Config(), s.Env, layout)
+}
+
+// AssertTree compares the current tree against the given layout specification.
+// The specification works similar to BuildTree.
+//
+// The following directives are supported:
+//
+// "s:<stackpath>" or "stack:..."
+// Assert that stackpath is a stack.
+//
+// "d:<dirpath>" or "dir:..."
+// Assert that dirpath is an existing directory.
+//
+// "f:<filepath>[:<content>]" or "file:..."
+// Assert that filepath is an existing file, optionally having the given content.
+func (s S) AssertTree(layout []string, opts ...AssertTreeOption) {
+	s.t.Helper()
+
+	o := &assertTreeOptions{}
+	for _, opt := range opts {
+		opt(o)
+	}
+
+	assertTree(s.t, s.Config(), layout, o)
+}
+
+// AssertTreeOption is the common option type for AssertTree.
+type AssertTreeOption func(o *assertTreeOptions)
+
+// WithStrictStackValidation is an option for AssertTree to validate that
+// the list of stacks given in the layout _exactly_ matches the list of stacks
+// in the tree, i.e. it doesn't just check that the given stacks exist, but also
+// that there are no other stacks beyond that.
+func WithStrictStackValidation() AssertTreeOption {
+	return func(o *assertTreeOptions) { o.withStrictStacks = true }
+}
+
+type assertTreeOptions struct {
+	withStrictStacks bool
+	//TODO(snk): add withStrictFiles
 }
 
 // IsGit tells if the sandbox is a git repository.
@@ -704,6 +746,78 @@ func buildTree(t testing.TB, root *config.Root, environ []string, layout []strin
 			assert.NoError(t, err, "failed to execute sandbox run: (output: %s)", out)
 		default:
 			t.Fatalf("unknown spec kind: %q", specKind)
+		}
+	}
+}
+
+func assertTree(t testing.TB, root *config.Root, layout []string, opts *assertTreeOptions) {
+	t.Helper()
+
+	popArg := func(spec string) (string, string) {
+		idx := strings.Index(spec, ":")
+		if idx == -1 {
+			return spec, ""
+		}
+		return spec[0:idx], spec[idx+1:]
+	}
+
+	rootdir := root.HostDir()
+
+	wantStrictStacks := []string{}
+
+	for _, spec := range layout {
+		specKind, spec := popArg(spec)
+
+		switch specKind {
+		case "d", "dir":
+			dirname, _ := popArg(spec)
+			test.IsDir(t, rootdir, dirname)
+
+		case "f", "file":
+			fname, spec := popArg(spec)
+			want, _ := popArg(spec)
+
+			if want != "" {
+				got := string(test.ReadFile(t, rootdir, fname))
+				assert.EqualStrings(t, want, got, "want:\n%s\ngot:\n%s\n", want, got)
+			} else {
+				test.IsFile(t, rootdir, fname)
+			}
+
+		case "!e", "not_exist":
+			fname, _ := popArg(spec)
+			test.DoesNotExist(t, rootdir, fname)
+
+		case "s", "stack":
+			stackdir, _ := popArg(spec)
+			prjStackdir := project.PrjAbsPath(rootdir, stackdir)
+
+			if opts.withStrictStacks {
+				wantStrictStacks = append(wantStrictStacks, prjStackdir.String())
+			} else {
+				_, err := config.LoadStack(root, prjStackdir)
+				assert.NoError(t, err, "not a valid stack")
+			}
+
+		default:
+			t.Fatalf("unknown spec kind: %q", specKind)
+		}
+	}
+
+	if opts.withStrictStacks {
+		gotStrictStacks := []string{}
+		stackEntries, err := stack.List(root.Tree())
+		assert.NoError(t, err)
+
+		for _, st := range stackEntries {
+			gotStrictStacks = append(gotStrictStacks, st.Stack.Dir.String())
+		}
+
+		sort.Strings(wantStrictStacks)
+		sort.Strings(gotStrictStacks)
+
+		if diff := cmp.Diff(wantStrictStacks, gotStrictStacks); diff != "" {
+			t.Errorf("stack list mismatch (-want +got): %s", diff)
 		}
 	}
 }


### PR DESCRIPTION
# Reason for This Change

The experimental clone command did not work correctly with nested stacks. Before, it just treated them as normal files so the cloned directory would contain duplicated stack ids.

## Description of Changes

* `clone` now detects nested stacks and updates their stack ids if required.
* An flag `--skip-child-stacks` has been added to `clone` to ignore nested stacks. Files/directories within the parent stack that are _not_ nested stacks will still be cloned recursively.
* Since nested stacks are considered, clone can also be called on directories that are not stacks. 
* Output messages have been adapted to the new semantics.
* Docs have been updated.

Internal changes:
* `sandbox.AssertTree` helper has been added. It supports specs similar to `BuildTree` to assert that certain files or directories are present. This is less verbose than checking for this by hand and enables a unified pattern of `BuildTree(spec)`, `<modify tree with commands>`, `AssertTree(newSpec)`. This function can be extended in the future to support more specification directives.
