### PR TITLE
chore(tmc): send workflow name and ref in the metadata

### DIFF
--- a/cloud/types.go
+++ b/cloud/types.go
@@ -202,6 +202,8 @@ type (
 		GithubActionsDeploymentTriggeredBy string `json:"github_actions_triggered_by,omitempty"`
 		GithubActionsRunID                 string `json:"github_actions_run_id,omitempty"`
 		GithubActionsRunAttempt            string `json:"github_actions_run_attempt,omitempty"`
+		GithubActionsWorkflowName          string `json:"github_actions_workflow_name,omitempty"`
+		GithubActionsWorkflowRef           string `json:"github_actions_workflow_ref,omitempty"`
 	}
 
 	// DeploymentReviewRequest is the review_request object.

--- a/cmd/terramate/cli/cloud.go
+++ b/cmd/terramate/cli/cloud.go
@@ -461,6 +461,8 @@ func setGithubActionsMetadata(md *cloud.DeploymentMetadata) {
 	md.GithubActionsDeploymentBranch = os.Getenv("GITHUB_REF_NAME")
 	md.GithubActionsRunID = os.Getenv("GITHUB_RUN_ID")
 	md.GithubActionsRunAttempt = os.Getenv("GITHUB_RUN_ATTEMPT")
+	md.GithubActionsWorkflowName = os.Getenv("GITHUB_WORKFLOW")
+	md.GithubActionsWorkflowRef = os.Getenv("GITHUB_WORKFLOW_REF")
 }
 
 func setGithubCommitMetadata(md *cloud.DeploymentMetadata, commit *github.Commit) {


### PR DESCRIPTION
Add 2 additional metadata when synchronising deployments or drifts with the _Terramate Cloud_.
- `metadata.github_actions_workflow_name`
- `metadata.github_actions_workflow_ref`