### PR TITLE
feat: add terramate.config.experiments feature switch.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 
 ## Unreleased
 
+### Added
+
+- Add `terramate.config.experiments` configuration to enable experimental features.
+
 ## 0.4.3
 
 ### Added

--- a/hcl/hcl.go
+++ b/hcl/hcl.go
@@ -111,9 +111,10 @@ type CloudConfig struct {
 
 // RootConfig represents the root config block of a Terramate configuration.
 type RootConfig struct {
-	Git   *GitConfig
-	Run   *RunConfig
-	Cloud *CloudConfig
+	Git         *GitConfig
+	Run         *RunConfig
+	Cloud       *CloudConfig
+	Experiments []string
 }
 
 // ManifestDesc represents a parsed manifest description.
@@ -1374,9 +1375,19 @@ func parseRootConfig(cfg *RootConfig, block *ast.MergedBlock) error {
 	errs := errors.L()
 
 	for _, attr := range block.Attributes.SortedList() {
-		errs.Append(errors.E(attr.NameRange,
-			"unrecognized attribute terramate.config.%s", attr.Name,
-		))
+		if attr.Name != "experiments" {
+			errs.Append(errors.E(attr.NameRange,
+				"unrecognized attribute terramate.config.%s", attr.Name,
+			))
+			continue
+		}
+		val, diags := attr.Expr.Value(nil)
+		if diags.HasErrors() {
+			errs.Append(errors.E(diags, attr.Expr.Range(),
+				"evaluating terramate.config.experiments attribute"))
+			continue
+		}
+		errs.Append(assignSet(attr.Attribute, &cfg.Experiments, val))
 	}
 
 	errs.AppendWrap(ErrTerramateSchema, block.ValidateSubBlocks("git", "run", "cloud"))

--- a/hcl/hcl_test.go
+++ b/hcl/hcl_test.go
@@ -320,6 +320,117 @@ func TestHCLParserTerramateBlock(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "terramate.config.experiments with wrong type",
+			input: []cfgfile{
+				{
+					filename: "cfg.tm",
+					body: `
+						terramate {
+						    config {
+								experiments = 1
+							}
+						}
+					`,
+				},
+			},
+			want: want{
+				errs: []error{
+					errors.E(hcl.ErrTerramateSchema,
+						Mkrange("cfg.tm", Start(4, 23, 60), End(4, 24, 61))),
+				},
+			},
+		},
+		{
+			name: "terramate.config.experiments with wrong item type",
+			input: []cfgfile{
+				{
+					filename: "cfg.tm",
+					body: `
+						terramate {
+						    config {
+								experiments = ["A", 1, "B"]
+							}
+						}
+					`,
+				},
+			},
+			want: want{
+				errs: []error{
+					errors.E(hcl.ErrTerramateSchema,
+						Mkrange("cfg.tm", Start(4, 23, 60), End(4, 36, 73))),
+				},
+			},
+		},
+		{
+			name: "terramate.config.experiments with duplicates",
+			input: []cfgfile{
+				{
+					filename: "cfg.tm",
+					body: `
+						terramate {
+						    config {
+								experiments = ["A", "B", "A"]
+							}
+						}
+					`,
+				},
+			},
+			want: want{
+				errs: []error{
+					errors.E(hcl.ErrTerramateSchema,
+						Mkrange("cfg.tm", Start(4, 23, 60), End(4, 38, 75))),
+				},
+			},
+		},
+		{
+			name: "terramate.config.experiments with empty set",
+			input: []cfgfile{
+				{
+					filename: "cfg.tm",
+					body: `
+						terramate {
+						    config {
+								experiments = []
+							}
+						}
+					`,
+				},
+			},
+			want: want{
+				config: hcl.Config{
+					Terramate: &hcl.Terramate{
+						Config: &hcl.RootConfig{
+							Experiments: []string{},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "terramate.config.experiments with correct values",
+			input: []cfgfile{
+				{
+					filename: "cfg.tm",
+					body: `
+						terramate {
+						    config {
+								experiments = ["scripts", "awesome-feature"]
+							}
+						}
+					`,
+				},
+			},
+			want: want{
+				config: hcl.Config{
+					Terramate: &hcl.Terramate{
+						Config: &hcl.RootConfig{
+							Experiments: []string{"scripts", "awesome-feature"},
+						},
+					},
+				},
+			},
+		},
 	} {
 		testParser(t, tc)
 	}


### PR DESCRIPTION
# Reason for This Change

Add the `terramate.config.experiments` config for enabling experimental features.

**No experimental feature is introduced with this change**.

## Description of Changes

Only the parser is changed now. Upcoming features can look into the AST for deciding when to enable the features.