### PR TITLE
fix: ensure --cloud-sync-terraform-plan-file require drift flag.

### DIFF
--- a/cmd/terramate/cli/run.go
+++ b/cmd/terramate/cli/run.go
@@ -135,6 +135,10 @@ func (c *cli) runOnStacks() {
 		fatal(errors.E("--cloud-sync-terraform-plan-file can only be used with --cloud-sync-drift-status"))
 	}
 
+	if c.parsedArgs.Run.CloudSyncTerraformPlanFile != "" && !c.parsedArgs.Run.CloudSyncDriftStatus {
+		fatal(errors.E("--cloud-sync-terraform-plan-file should be used with --cloud-sync-drift-status flag"))
+	}
+
 	if c.parsedArgs.Run.CloudSyncDeployment || c.parsedArgs.Run.CloudSyncDriftStatus {
 		if !c.prj.isRepo {
 			fatal(errors.E("cloud features requires a git repository"))


### PR DESCRIPTION
## Reasons for This Change

The `--cloud-sync-terraform-plan-file` can only be used with `--cloud-sync-drift-status` (for now).

## Description of changes

Added a guard against use of the flag without drift sync status flag.