### PR TITLE
chore(gha): remove merge_group feature.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@
 name: ci
 on:
   pull_request:
-  merge_group:
 
 jobs:
   checks:


### PR DESCRIPTION
# Reason for This Change

This feature was enabled to speed up the workflow but it actually made it slower.
Let's rollback to the default workflow.

## Description of Changes

Removed the `merge_group` option from the ci.yml file.
