### PR TITLE
chore: replace "means" with "mean" in the generate output.

### DIFF
--- a/cmd/terramate/e2etests/generate_test.go
+++ b/cmd/terramate/e2etests/generate_test.go
@@ -116,7 +116,7 @@ Successes:
 	[+] file.hcl
 	[+] file.txt
 
-Hint: '+', '~' and '-' means the file was created, changed and deleted, respectively.
+Hint: '+', '~' and '-' mean the file was created, changed and deleted, respectively.
 `,
 				},
 				files: []file{
@@ -166,7 +166,7 @@ Successes:
 	[+] file.hcl
 	[+] file.txt
 
-Hint: '+', '~' and '-' means the file was created, changed and deleted, respectively.
+Hint: '+', '~' and '-' mean the file was created, changed and deleted, respectively.
 Vendor report:
 
 [+] %s
@@ -254,7 +254,7 @@ Successes:
 - /stack2
 	[+] file.hcl
 
-Hint: '+', '~' and '-' means the file was created, changed and deleted, respectively.
+Hint: '+', '~' and '-' mean the file was created, changed and deleted, respectively.
 `,
 				},
 				files: []file{

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -308,7 +308,7 @@ Successes:
 - /dev/mysite
         [~] mysite.tf
 
-Hint: '+', '~' and '-' means the file was created, changed and deleted, respectively.
+Hint: '+', '~' and '-' mean the file was created, changed and deleted, respectively.
 ```
 
 Commit the changed files with `git commit -am 'changed dev title'`, then run `terramate list --changed`. This command displays stacks with outstanding changes compared to the main branch:

--- a/generate/report.go
+++ b/generate/report.go
@@ -124,7 +124,7 @@ func (r Report) Full() string {
 	}
 
 	if needsHint {
-		addLine("Hint: '+', '~' and '-' means the file was created, changed and deleted, respectively.")
+		addLine("Hint: '+', '~' and '-' mean the file was created, changed and deleted, respectively.")
 	}
 
 	return strings.Join(report, "\n")

--- a/generate/report_test.go
+++ b/generate/report_test.go
@@ -107,7 +107,7 @@ Successes:
 	[-] removed1.tf
 	[-] removed2.tf
 
-Hint: '+', '~' and '-' means the file was created, changed and deleted, respectively.`,
+Hint: '+', '~' and '-' mean the file was created, changed and deleted, respectively.`,
 			wantMinimal: `Created file /test/test
 Changed file /test2/test
 Deleted file /test3/test
@@ -155,7 +155,7 @@ Failures:
 	[-] removed1.tf
 	[-] removed2.tf
 
-Hint: '+', '~' and '-' means the file was created, changed and deleted, respectively.`,
+Hint: '+', '~' and '-' mean the file was created, changed and deleted, respectively.`,
 			wantMinimal: `Error on /test: full error
 Error on /test2: partial error
 Created file /test2/created1.tf
@@ -219,7 +219,7 @@ Failures:
 - /failed2
 	error: error
 
-Hint: '+', '~' and '-' means the file was created, changed and deleted, respectively.`,
+Hint: '+', '~' and '-' mean the file was created, changed and deleted, respectively.`,
 			wantMinimal: `Created file /success/created.tf
 Changed file /success/changed.tf
 Deleted file /success/removed.tf
@@ -269,7 +269,7 @@ Failures:
 	error: error1
 	error: error2
 
-Hint: '+', '~' and '-' means the file was created, changed and deleted, respectively.`,
+Hint: '+', '~' and '-' mean the file was created, changed and deleted, respectively.`,
 			wantMinimal: `Error on /failed: error
 Error on /failed2: error1
 Error on /failed2: error2`,
@@ -299,7 +299,7 @@ Successes:
 Fatal failure while cleaning up generated code outside stacks:
 	error: cleanup error
 
-Hint: '+', '~' and '-' means the file was created, changed and deleted, respectively.`,
+Hint: '+', '~' and '-' mean the file was created, changed and deleted, respectively.`,
 			wantMinimal: `Created file /success/created.tf
 Changed file /success/changed.tf
 Deleted file /success/removed.tf


### PR DESCRIPTION
It's a typo because the object it follows is plural.

Closes #1218 

We cannot yet run external PRs due to missing credentials for integration tests.
Thanks @grggls for the contribution.