### PR TITLE
chore(tests): add support for backend interoperability tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ coverage.txt
 cpu.prof
 mem.prof
 *.test
+*.plan
 
 # Go Workspaces artifacts
 /go.work

--- a/cloud/testserver/cloudstore/store.go
+++ b/cloud/testserver/cloudstore/store.go
@@ -242,6 +242,9 @@ func (d *Data) UpsertStack(orguuid cloud.UUID, st Stack) (int, error) {
 	if st.State.DeploymentStatus == 0 {
 		st.State.DeploymentStatus = deployment.OK
 	}
+	if st.State.Status == 0 {
+		st.State.Status = stack.Unknown
+	}
 	st.State.CreatedAt = &t
 	st.State.UpdatedAt = &t
 	st.State.SeenAt = &t

--- a/cloud/testserver/cmd/testserver/main.go
+++ b/cloud/testserver/cmd/testserver/main.go
@@ -5,7 +5,6 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"
@@ -23,11 +22,6 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	data, err := json.MarshalIndent(store, "", "  ")
-	if err != nil {
-		panic(err)
-	}
-	fmt.Fprintf(os.Stderr, "%s\n", data)
 	s := &http.Server{
 		Addr:    "0.0.0.0:3001",
 		Handler: testserver.Router(store),

--- a/cmd/terramate/e2etests/cloud/interop/interoperability_test.go
+++ b/cmd/terramate/e2etests/cloud/interop/interoperability_test.go
@@ -1,0 +1,124 @@
+// Copyright 2023 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build interop
+
+package interop_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/madlambda/spells/assert"
+	. "github.com/terramate-io/terramate/cmd/terramate/e2etests/internal/runner"
+)
+
+func TestInteropSyncDeployment(t *testing.T) {
+	tmcli := NewInteropCLI(t, datapath(t, "testdata/interop-stacks/empty"))
+	AssertRunResult(t, tmcli.Run("list"), RunExpected{
+		Stdout: nljoin("."),
+	})
+	AssertRunResult(t,
+		tmcli.Run("run", "--cloud-sync-deployment", "--", HelperPath, "false"),
+		RunExpected{
+			IgnoreStderr: true,
+			Status:       1,
+		},
+	)
+	AssertRunResult(t,
+		tmcli.Run("list", "--experimental-status=unhealthy"), RunExpected{
+			Stdout: nljoin("."),
+		},
+	)
+	AssertRun(t, tmcli.Run("run", "--cloud-sync-deployment", "--", HelperPath, "true"))
+	AssertRun(t, tmcli.Run("list", "--experimental-status=unhealthy"))
+}
+
+func TestInteropDrift(t *testing.T) {
+	tmcli := NewInteropCLI(t, datapath(t, "testdata/interop-stacks/basic-drift"))
+	AssertRunResult(t, tmcli.Run("list"), RunExpected{
+		Stdout: nljoin("."),
+	})
+	// inititialize the providers
+	AssertRunResult(t,
+		tmcli.Run("run", "--", TerraformTestPath, "init"),
+		RunExpected{
+			Status:       0,
+			IgnoreStdout: true,
+			IgnoreStderr: true,
+		},
+	)
+
+	// basic drift, without details
+	AssertRunResult(t,
+		tmcli.Run("run", "--cloud-sync-drift-status", "--", TerraformTestPath, "plan", "-detailed-exitcode"),
+		RunExpected{
+			Status:       0,
+			IgnoreStdout: true,
+			IgnoreStderr: true,
+		},
+	)
+	AssertRunResult(t,
+		tmcli.Run("list", "--experimental-status=unhealthy"), RunExpected{
+			Stdout: nljoin("."),
+		},
+	)
+	// Check if there are no drift details
+	AssertRunResult(t,
+		tmcli.Run("experimental", "cloud", "drift", "show"), RunExpected{
+			StderrRegex: "Stack .*? is drifted, but no details are available",
+			Status:      1,
+		},
+	)
+
+	// complete drift
+	AssertRunResult(t,
+		tmcli.Run(
+			"run", "--cloud-sync-drift-status", "--cloud-sync-terraform-plan-file=out.plan", "--",
+			TerraformTestPath, "plan", "-out=out.plan", "-detailed-exitcode",
+		),
+		RunExpected{
+			Status:       0,
+			IgnoreStdout: true,
+			IgnoreStderr: true,
+		},
+	)
+	AssertRunResult(t,
+		tmcli.Run("list", "--experimental-status=unhealthy"), RunExpected{
+			Stdout: nljoin("."),
+		},
+	)
+	// Check the drift details
+	AssertRunResult(t,
+		tmcli.Run("experimental", "cloud", "drift", "show"), RunExpected{
+			StdoutRegexes: []string{
+				"hello world", // content of the file
+				"local_file",  // name of the resource
+			},
+			Status: 0,
+		},
+	)
+
+	// check reseting the drift status to OK
+	AssertRun(t, tmcli.Run("run", "--cloud-sync-drift-status", "--", HelperPath, "exit", "0"))
+	AssertRun(t, tmcli.Run("list", "--experimental-status=unhealthy"))
+	AssertRunResult(t,
+		tmcli.Run("experimental", "cloud", "drift", "show"),
+		RunExpected{
+			StdoutRegex: "Stack .*? is not drifted",
+			Status:      0,
+		},
+	)
+}
+
+func datapath(t *testing.T, path string) string {
+	wd, err := os.Getwd()
+	assert.NoError(t, err)
+	return filepath.Join(wd, filepath.FromSlash(path))
+}
+
+func nljoin(stacks ...string) string {
+	return strings.Join(stacks, "\n") + "\n"
+}

--- a/cmd/terramate/e2etests/cloud/interop/main_test.go
+++ b/cmd/terramate/e2etests/cloud/interop/main_test.go
@@ -1,0 +1,48 @@
+// Copyright 2023 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build interop
+
+package interop_test
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/terramate-io/terramate/cloud"
+	"github.com/terramate-io/terramate/cmd/terramate/e2etests/internal/runner"
+)
+
+func TestMain(m *testing.M) {
+	apiHost := os.Getenv("TMC_API_HOST")
+	apiURL := os.Getenv("TMC_API_URL")
+	if apiHost == "" && apiURL == "" {
+		fmt.Printf("The interoperability tests requires exporting either TMC_API_HOST or TMC_API_URL")
+		os.Exit(1)
+	}
+	if apiHost != "" && apiURL != "" {
+		fmt.Printf("TMC_API_HOST conflicts with TMC_API_URL")
+		os.Exit(1)
+	}
+	if apiHost == cloud.Host || apiURL == cloud.BaseURL {
+		fmt.Printf("Interoperability tests MUST not be executed targeting the product API")
+		os.Exit(1)
+	}
+	packageDir, err := os.Getwd()
+	if err != nil {
+		log.Printf("failed to get test working directory: %v", err)
+		os.Exit(1)
+	}
+	// this file is inside cmd/terramate/e2etests/cloud/interop
+	// change code below if it's not the case anymore.
+	projectRoot := filepath.Join(packageDir, "../../../../..")
+	err = runner.Setup(projectRoot)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer runner.Teardown()
+	os.Exit(m.Run())
+}

--- a/cmd/terramate/e2etests/cloud/interop/testdata/interop-stacks/basic-drift/main.tf
+++ b/cmd/terramate/e2etests/cloud/interop/testdata/interop-stacks/basic-drift/main.tf
@@ -1,0 +1,9 @@
+/**
+ * Copyright 2023 Terramate GmbH
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+resource "local_file" "foo" {
+  content  = "hello world"
+  filename = "${path.module}/foo.bar"
+}

--- a/cmd/terramate/e2etests/cloud/interop/testdata/interop-stacks/basic-drift/stack.tm.hcl
+++ b/cmd/terramate/e2etests/cloud/interop/testdata/interop-stacks/basic-drift/stack.tm.hcl
@@ -1,0 +1,8 @@
+// Copyright 2023 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+stack {
+  name        = "basic-drift"
+  description = "basic-drift"
+  id          = "2530f1b3-2691-48dc-b418-e966f7e1441c"
+}

--- a/cmd/terramate/e2etests/cloud/interop/testdata/interop-stacks/empty/stack.tm.hcl
+++ b/cmd/terramate/e2etests/cloud/interop/testdata/interop-stacks/empty/stack.tm.hcl
@@ -1,0 +1,8 @@
+// Copyright 2023 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+stack {
+  name        = "empty"
+  description = "empty"
+  id          = "04437b1f-27a9-4eab-8e63-1df968b76f6b"
+}

--- a/cmd/terramate/e2etests/internal/runner/runner.go
+++ b/cmd/terramate/e2etests/internal/runner/runner.go
@@ -89,6 +89,23 @@ func NewCLI(t *testing.T, chdir string, env ...string) CLI {
 	return tm
 }
 
+// NewInteropCLI creates a new runner CLI suited for interop tests.
+func NewInteropCLI(t *testing.T, chdir string, env ...string) CLI {
+	if toolsetTestPath == "" {
+		panic("runner is not initialized: use runner.Setup()")
+	}
+	tm := CLI{
+		t:     t,
+		Chdir: chdir,
+	}
+	if len(env) == 0 {
+		env = os.Environ()
+	}
+	env = append(env, "CHECKPOINT_DISABLE=1")
+	tm.environ = env
+	return tm
+}
+
 // PrependToPath prepend the provided directory to the OS's PATH
 // environment variable in a portable way.
 func (tm *CLI) PrependToPath(dir string) {


### PR DESCRIPTION
## Reasons For This Change

It provides a way of doing e2e tests of the CLI against real backends.

Usage:

````
$ TMC_API_URL=http://0.0.0.0:8000 go test -tags interop ./cmd/terramate/e2etests/cloud/interop -count=1 -v
toolsetPath: /var/folders/bs/t0s9dnm124v1k8g_f38kpzk00000gn/T/cmd-terramate-test-35195610
=== RUN   TestInteropSyncDeployment
--- PASS: TestInteropSyncDeployment (5.96s)
=== RUN   TestInteropDrift
--- PASS: TestInteropDrift (7.62s)
PASS
ok      github.com/terramate-io/terramate/cmd/terramate/e2etests/cloud/interop  16.125s
```