### PR TITLE
fix(tmc): limit query parameter was deprecated

### DIFF
--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -115,11 +115,9 @@ func (c *Client) GetStack(ctx context.Context, orgUUID, repo, metaID string) (St
 }
 
 // StackDrifts returns the drifts of the given stack.
-func (c *Client) StackDrifts(ctx context.Context, orgUUID string, stackID int, limit int) (DriftsStackPayloadResponse, error) {
+func (c *Client) StackDrifts(ctx context.Context, orgUUID string, stackID int, page, perPage int) (DriftsStackPayloadResponse, error) {
 	path := path.Join(StacksPath, orgUUID, strconv.Itoa(stackID), "drifts")
-	if limit != 0 {
-		path += "?limit=" + strconv.Itoa(limit)
-	}
+	path += fmt.Sprintf("?page=%d&per_page=%d", page, perPage)
 	return Get[DriftsStackPayloadResponse](ctx, c, path)
 }
 

--- a/cmd/terramate/cli/cloud.go
+++ b/cmd/terramate/cli/cloud.go
@@ -272,7 +272,7 @@ func (c *cli) cloudDriftShow() {
 	defer cancel()
 
 	// stack is drifted
-	driftsResp, err := c.cloud.client.StackDrifts(ctx, c.cloud.run.orgUUID, stackResp.ID, 1)
+	driftsResp, err := c.cloud.client.StackDrifts(ctx, c.cloud.run.orgUUID, stackResp.ID, 1, 1)
 	if err != nil {
 		fatal(err)
 	}


### PR DESCRIPTION
# Reason for This Change

The `limit` query parameter is deprecated.

## Description of Changes

Changed to use `page` and `per_page` query parameters.
