### PR TITLE
feat(cloud): Give support to optional parameters in Content Type from tmc

### DIFF
--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"mime"
 	"net/http"
 	"net/http/httputil"
 	"os"
@@ -295,7 +296,7 @@ func Request[T Resource](ctx context.Context, c *Client, method string, resource
 		return entity, nil
 	}
 
-	if ctype := resp.Header.Get("Content-Type"); ctype != contentType {
+	if ctype, _, _ := mime.ParseMediaType(resp.Header.Get("Content-Type")); ctype != contentType {
 		return entity, errors.E(ErrUnexpectedResponseBody, "client expects the Content-Type: %s but got %s", contentType, ctype)
 	}
 

--- a/cloud/cloud_test.go
+++ b/cloud/cloud_test.go
@@ -26,7 +26,7 @@ func TestCloudCustomHTTPClient(t *testing.T) {
 	isCalled := false
 	s := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		isCalled = true
-		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		_, _ = io.WriteString(w, "[]")
 	}))
 	defer s.Close()
@@ -528,7 +528,7 @@ func newTestServer(statusCode int, body string, headers http.Header) *httptest.S
 				w.Header().Set(k, v[0])
 			}
 		} else {
-			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		}
 		w.WriteHeader(statusCode)
 		_, _ = io.WriteString(w, body)

--- a/cmd/terramate/e2etests/run_cloud_config_test.go
+++ b/cmd/terramate/e2etests/run_cloud_config_test.go
@@ -29,7 +29,7 @@ func TestCloudConfig(t *testing.T) {
 	}
 
 	writeJSON := func(w http.ResponseWriter, str string) {
-		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		_, _ = w.Write([]byte(str))
 	}
 

--- a/cmd/terramate/e2etests/run_cloud_uimode_test.go
+++ b/cmd/terramate/e2etests/run_cloud_uimode_test.go
@@ -42,7 +42,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 	}
 
 	writeJSON := func(w http.ResponseWriter, str string) {
-		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		_, _ = w.Write([]byte(str))
 	}
 


### PR DESCRIPTION
# Reason for This Change

With this change, the client is able to receive responses from the
cloud that contain optional parameters like `charset` in the
`Content-Type` header value.

## Description of Changes

Accepting optional parameters using `mime` package from standard library.

Change all test servers to return an optional parameter to mimic real behaviour.
