### PR TITLE
chore: remove unused trace logs 🧹 

### DIFF
--- a/cmd/terramate-ls/main.go
+++ b/cmd/terramate-ls/main.go
@@ -68,8 +68,6 @@ func runServer(conn io.ReadWriteCloser) {
 		Str("action", "main.runServer()").
 		Logger()
 
-	logger.Trace().Msg("Creating context for OS signals.")
-
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, os.Kill, syscall.SIGTERM)
 	defer stop()
 

--- a/cmd/terramate/cli/cloud.go
+++ b/cmd/terramate/cli/cloud.go
@@ -562,8 +562,6 @@ func (c *cli) ensureAllStackHaveIDs(stacks config.List[*config.SortableStack]) {
 		Str("action", "cli.ensureAllStackHaveIDs").
 		Logger()
 
-	logger.Trace().Msg("Checking if selected stacks have id")
-
 	var stacksMissingIDs []string
 	for _, st := range stacks {
 		if st.ID == "" {

--- a/cmd/terramate/cli/cloud_credential_google.go
+++ b/cmd/terramate/cli/cloud_credential_google.go
@@ -227,11 +227,6 @@ func createAuthURI(continueURI string, idpKey string) (createAuthURIResponse, er
 		return createAuthURIResponse{}, errors.E(err)
 	}
 
-	logger.Trace().
-		Str("response-body", string(data)).
-		Int("response-status-code", resp.StatusCode).
-		Msg("response")
-
 	if resp.StatusCode != 200 {
 		return createAuthURIResponse{}, errors.E("%s request returned %d", req.URL, resp.StatusCode)
 	}
@@ -298,11 +293,6 @@ func (h *tokenHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		Str("action", "tokenHandler.ServeHTTP").
 		Logger()
 
-	logger.Trace().
-		Str("endpoint", signInEndpoint).
-		Str("post-body", string(data)).
-		Msg("prepared request body")
-
 	url := endpointURL(signInEndpoint, h.idpKey)
 	req, err := http.NewRequest("POST", url.String(), bytes.NewBuffer(data))
 	if err != nil {
@@ -328,11 +318,6 @@ func (h *tokenHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.errChan <- errors.E(err)
 		return
 	}
-
-	logger.Trace().
-		Str("response-body", string(data)).
-		Int("response-status-code", resp.StatusCode).
-		Msg("response")
 
 	if resp.StatusCode != 200 {
 		h.handleErr(w, errors.E("%s request returned %d", req.URL, resp.StatusCode))

--- a/cmd/terramate/cli/cloud_sync_drift.go
+++ b/cmd/terramate/cli/cloud_sync_drift.go
@@ -125,8 +125,6 @@ func (c *cli) getTerraformDriftDetails(runContext ExecContext, planfile string) 
 		return nil, nil
 	}
 
-	logger.Trace().Msg("drift details gathered successfully")
-
 	return &cloud.DriftDetails{
 		Provisioner:    "terraform",
 		ChangesetASCII: renderedPlan,
@@ -182,7 +180,6 @@ func (c *cli) runTerraformShow(runContext ExecContext, planfile string, flags ..
 		Str("command", cmd.String()).
 		Logger()
 
-	logger.Trace().Msg("executing")
 	err := cmd.Run()
 	if err != nil {
 		logger.Error().Str("stderr", stderr.String()).Msg("command stderr")

--- a/cmd/terramate/cli/project.go
+++ b/cmd/terramate/cli/project.go
@@ -197,12 +197,6 @@ func (p *project) setDefaults() error {
 }
 
 func (p project) checkDefaultRemote() error {
-	logger := log.With().
-		Str("action", "checkDefaultRemote()").
-		Logger()
-
-	logger.Trace().Msg("Get list of configured git remotes.")
-
 	remotes, err := p.git.wrapper.Remotes()
 	if err != nil {
 		return fmt.Errorf("checking if remote %q exists: %v", defaultRemote, err)
@@ -212,8 +206,6 @@ func (p project) checkDefaultRemote() error {
 
 	gitcfg := p.gitcfg()
 
-	logger.Trace().
-		Msg("Find default git remote.")
 	for _, remote := range remotes {
 		if remote.Name == gitcfg.DefaultRemote {
 			defRemote = &remote
@@ -227,7 +219,6 @@ func (p project) checkDefaultRemote() error {
 		)
 	}
 
-	logger.Trace().Msg("Find default git branch.")
 	for _, branch := range defRemote.Branches {
 		if branch == gitcfg.DefaultBranch {
 			return nil

--- a/cmd/terramate/cli/run.go
+++ b/cmd/terramate/cli/run.go
@@ -82,7 +82,6 @@ func (c *cli) runOnStacks() {
 			fatal(err, "computing selected stacks")
 		}
 	}
-	logger.Trace().Msg("Get order of stacks to run command on.")
 
 	orderedStacks, reason, err := run.Sort(c.cfg(), stacks)
 	if err != nil {
@@ -94,13 +93,10 @@ func (c *cli) runOnStacks() {
 	}
 
 	if c.parsedArgs.Run.Reverse {
-		logger.Trace().Msg("Reversing stacks order.")
 		config.ReverseStacks(orderedStacks)
 	}
 
 	if c.parsedArgs.Run.DryRun {
-		logger.Trace().
-			Msg("Do a dry run - get order without actually running command.")
 		if len(orderedStacks) > 0 {
 			c.output.MsgStdOut("The stacks will be executed using order below:")
 
@@ -179,10 +175,6 @@ func (c *cli) runOnStacks() {
 // If SIGINT is sent 3x then Terramate will send a SIGKILL to the currently
 // running process and abort the execution of all subsequent stacks.
 func (c *cli) RunAll(runStacks []ExecContext, isSuccessCode func(exitCode int) bool) error {
-	logger := log.With().
-		Str("action", "cli.RunAll()").
-		Logger()
-
 	errs := errors.L()
 
 	// we load/check the env of all stacks beforehand then no stack is executed
@@ -191,8 +183,6 @@ func (c *cli) RunAll(runStacks []ExecContext, isSuccessCode func(exitCode int) b
 	if err != nil {
 		return err
 	}
-
-	logger.Trace().Msg("loaded stacks run environment variables, running commands")
 
 	const signalsBufferSize = 10
 	signals := make(chan os.Signal, signalsBufferSize)
@@ -305,7 +295,6 @@ func (c *cli) RunAll(runStacks []ExecContext, isSuccessCode func(exitCode int) b
 					return errors.E(ErrRunCanceled, "execution aborted by CTRL-C (3x)")
 				}
 			case result := <-results:
-				logger.Trace().Msg("got command result")
 				logSyncWait()
 				var err error
 				if !isSuccessCode(result.cmd.ProcessState.ExitCode()) {
@@ -392,12 +381,6 @@ func newEnvironFrom(stackEnviron []string) []string {
 }
 
 func (c *cli) loadAllStackEnvs(runStacks []ExecContext) (map[prj.Path]run.EnvVars, error) {
-	logger := log.With().
-		Str("action", "cli.loadAllStackEnvs").
-		Logger()
-
-	logger.Trace().Msg("loading stacks run environment variables")
-
 	errs := errors.L()
 	stackEnvs := map[prj.Path]run.EnvVars{}
 	for _, elem := range runStacks {

--- a/cmd/terramate/e2etests/logging_test.go
+++ b/cmd/terramate/e2etests/logging_test.go
@@ -13,15 +13,15 @@ func TestLoggingChangeChannel(t *testing.T) {
 	t.Parallel()
 	s := sandbox.NoGit(t, true)
 	cli := newCLI(t, s.RootDir())
-	cli.loglevel = "trace"
+	cli.loglevel = "debug"
 
 	assertRunResult(t, cli.listStacks(), runExpected{
-		StderrRegex: "TRC",
+		StderrRegex: "DBG",
 	})
 	assertRunResult(t, cli.listStacks("--log-destination", "stderr"), runExpected{
-		StderrRegex: "TRC",
+		StderrRegex: "DBG",
 	})
 	assertRunResult(t, cli.listStacks("--log-destination", "stdout"), runExpected{
-		StdoutRegex: "TRC",
+		StdoutRegex: "DBG",
 	})
 }

--- a/config/config.go
+++ b/config/config.go
@@ -73,13 +73,6 @@ type List[T DirElem] []T
 // configpath != "" and found as true.
 func TryLoadConfig(fromdir string) (tree *Root, configpath string, found bool, err error) {
 	for {
-		logger := log.With().
-			Str("action", "config.TryLoadConfig()").
-			Str("path", fromdir).
-			Logger()
-
-		logger.Trace().Msg("Parse Terramate config.")
-
 		cfg, err := hcl.ParseDir(fromdir, fromdir)
 		if err != nil {
 			// the imports only works for the correct rootdir.
@@ -142,8 +135,6 @@ func (root *Root) StacksByPaths(base project.Path, relpaths ...string) List[*Tre
 		Strs("paths", relpaths).
 		Logger()
 
-	logger.Trace().Msg("lookup paths")
-
 	normalizePaths := func(paths []string) []project.Path {
 		pathmap := map[string]struct{}{}
 		var normalized []project.Path
@@ -173,8 +164,6 @@ func (root *Root) StacksByPaths(base project.Path, relpaths ...string) List[*Tre
 	}
 
 	sort.Sort(stacks)
-
-	logger.Trace().Msgf("found %d stacks out of %d paths", len(stacks), len(relpaths))
 
 	return stacks
 }
@@ -382,8 +371,6 @@ func loadTree(rootdir string, cfgdir string, rootcfg *hcl.Config) (_ *Tree, err 
 		err = errors.L(err, f.Close()).AsError()
 	}()
 
-	logger.Trace().Msg("reading directory file names")
-
 	names, err := f.Readdirnames(0)
 	if err != nil {
 		return nil, errors.E(err, "failed to read files in %s", cfgdir)
@@ -413,7 +400,6 @@ func loadTree(rootdir string, cfgdir string, rootcfg *hcl.Config) (_ *Tree, err 
 			Logger()
 
 		if Skip(name) {
-			logger.Trace().Msg("skipping file")
 			continue
 		}
 		dir := filepath.Join(cfgdir, name)
@@ -422,11 +408,8 @@ func loadTree(rootdir string, cfgdir string, rootcfg *hcl.Config) (_ *Tree, err 
 			return nil, errors.E(err, "failed to stat %s", dir)
 		}
 		if !st.IsDir() {
-			logger.Trace().Msg("ignoring non-directory file")
 			continue
 		}
-
-		logger.Trace().Msg("loading children tree")
 
 		node, err := LoadTree(rootdir, dir)
 		if err != nil {

--- a/config/stack.go
+++ b/config/stack.go
@@ -218,12 +218,6 @@ func (s *Stack) HostDir(root *Root) string {
 
 // RuntimeValues returns the runtime "terramate" namespace for the stack.
 func (s *Stack) RuntimeValues(root *Root) map[string]cty.Value {
-	logger := log.With().
-		Str("action", "stack.stackMetaToCtyMap()").
-		Logger()
-
-	logger.Trace().Msg("creating stack metadata")
-
 	stackpath := cty.ObjectVal(map[string]cty.Value{
 		"absolute": cty.StringVal(s.Dir.String()),
 		"relative": cty.StringVal(s.RelPath()),
@@ -237,10 +231,6 @@ func (s *Stack) RuntimeValues(root *Root) map[string]cty.Value {
 		"path":        stackpath,
 	}
 	if s.ID != "" {
-		logger.Trace().
-			Str("id", s.ID).
-			Msg("adding stack ID to metadata")
-
 		stackMapVals["id"] = cty.StringVal(s.ID)
 	}
 	stack := cty.ObjectVal(stackMapVals)
@@ -325,7 +315,6 @@ func LoadAllStacks(cfg *Tree) (List[*SortableStack], error) {
 		stacks = append(stacks, stack.Sortable())
 
 		if stack.ID != "" {
-			logger.Trace().Msg("stack has ID, checking for duplicate")
 			if otherStack, ok := stacksIDs[strings.ToLower(stack.ID)]; ok {
 				return List[*SortableStack]{}, errors.E(ErrStackDuplicatedID,
 					"stack %q and %q have same ID %q",

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -7,47 +7,30 @@ import (
 	"os"
 	"strings"
 
-	"github.com/rs/zerolog/log"
 	"github.com/terramate-io/terramate/errors"
 )
 
 // ListTerramateFiles returns a list of terramate related files from the
 // directory dir.
 func ListTerramateFiles(dir string) ([]string, error) {
-	logger := log.With().
-		Str("action", "fs.listTerramateFiles()").
-		Str("dir", dir).
-		Logger()
-
-	logger.Trace().Msg("listing files")
-
 	dirEntries, err := os.ReadDir(dir)
 	if err != nil {
 		return nil, errors.E(err, "reading dir to list Terramate files")
 	}
 
-	logger.Trace().Msg("looking for Terramate files")
-
 	files := []string{}
 
 	for _, dirEntry := range dirEntries {
-		logger := logger.With().
-			Str("entryName", dirEntry.Name()).
-			Logger()
-
 		if strings.HasPrefix(dirEntry.Name(), ".") {
-			logger.Trace().Msg("ignoring dotfile")
 			continue
 		}
 
 		if dirEntry.IsDir() {
-			logger.Trace().Msg("ignoring dir")
 			continue
 		}
 
 		filename := dirEntry.Name()
 		if isTerramateFile(filename) {
-			logger.Trace().Msg("Found Terramate file")
 			files = append(files, filename)
 		}
 	}
@@ -58,34 +41,20 @@ func ListTerramateFiles(dir string) ([]string, error) {
 // ListTerramateDirs lists Terramate dirs, which are any dirs
 // except ones starting with ".".
 func ListTerramateDirs(dir string) ([]string, error) {
-	logger := log.With().
-		Str("action", "fs.ListTerramateDirs()").
-		Str("dir", dir).
-		Logger()
-
-	logger.Trace().Msg("listing dirs")
-
 	dirEntries, err := os.ReadDir(dir)
 	if err != nil {
 		return nil, errors.E(err, "reading dir to list Terramate dirs")
 	}
 
-	logger.Trace().Msg("looking for Terramate directories")
-
 	dirs := []string{}
 
 	for _, dirEntry := range dirEntries {
-		logger := logger.With().
-			Str("entryName", dirEntry.Name()).
-			Logger()
 
 		if !dirEntry.IsDir() {
-			logger.Trace().Msg("ignoring non-dir")
 			continue
 		}
 
 		if strings.HasPrefix(dirEntry.Name(), ".") {
-			logger.Trace().Msg("ignoring dotdir")
 			continue
 		}
 

--- a/hcl/fmt/formatter.go
+++ b/hcl/fmt/formatter.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/hashicorp/hcl/v2/hclwrite"
-	"github.com/rs/zerolog/log"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -21,12 +20,6 @@ func FormatAttributes(attrs map[string]cty.Value) string {
 		return ""
 	}
 
-	logger := log.With().
-		Str("action", "FormatAttributes()").
-		Logger()
-
-	logger.Trace().
-		Msg("Create empty hcl file.")
 	f := hclwrite.NewEmptyFile()
 	body := f.Body()
 	sortedAttrNames := make([]string, 0, len(attrs))
@@ -35,12 +28,8 @@ func FormatAttributes(attrs map[string]cty.Value) string {
 		sortedAttrNames = append(sortedAttrNames, name)
 	}
 
-	logger.Trace().
-		Msg("Sort attributes.")
 	sort.Strings(sortedAttrNames)
 
-	logger.Trace().
-		Msg("Set attribute values.")
 	for _, name := range sortedAttrNames {
 		body.SetAttributeValue(name, attrs[name])
 	}

--- a/hcl/printer.go
+++ b/hcl/printer.go
@@ -4,7 +4,6 @@
 package hcl
 
 import (
-	"fmt"
 	"io"
 
 	"github.com/hashicorp/hcl/v2/hclwrite"
@@ -14,13 +13,6 @@ import (
 
 // PrintImports will print the given imports list as import blocks.
 func PrintImports(w io.Writer, imports []string) error {
-	logger := log.With().
-		Str("action", "PrintImports()").
-		Str("imports", fmt.Sprint(imports)).
-		Logger()
-
-	logger.Trace().Msg("Create empty hcl file")
-
 	f := hclwrite.NewEmptyFile()
 	rootBody := f.Body()
 
@@ -42,13 +34,10 @@ func PrintConfig(w io.Writer, cfg Config) error {
 		Str("stack", cfg.Stack.Name).
 		Logger()
 
-	logger.Trace().Msg("Create empty hcl file")
-
 	f := hclwrite.NewEmptyFile()
 	rootBody := f.Body()
 
 	if cfg.Terramate != nil {
-		logger.Trace().Msg("Append terramate block")
 
 		tm := cfg.Terramate
 		tmBlock := rootBody.AppendNewBlock("terramate", nil)
@@ -61,7 +50,6 @@ func PrintConfig(w io.Writer, cfg Config) error {
 	}
 
 	if cfg.Stack != nil {
-		logger.Trace().Msg("Append 'stack' block")
 
 		stack := cfg.Stack
 		stackBlock := rootBody.AppendNewBlock("stack", nil)

--- a/ls/ls.go
+++ b/ls/ls.go
@@ -84,7 +84,6 @@ func (s *Server) Handler(ctx context.Context, reply jsonrpc2.Replier, r jsonrpc2
 		return handler(ctx, reply, r, logger)
 	}
 
-	logger.Trace().Msg("not implemented")
 	return reply(ctx, nil, jsonrpc2.ErrMethodNotFound)
 }
 
@@ -331,16 +330,9 @@ func listFiles(fromFile string) ([]string, error) {
 		return nil, err
 	}
 
-	log.Trace().Msg("looking for Terramate files")
-
 	files := []string{}
 	for _, dirEntry := range dirEntries {
-		logger := log.With().
-			Str("entryName", dirEntry.Name()).
-			Logger()
-
 		if dirEntry.IsDir() {
-			logger.Trace().Msg("ignoring dir")
 			continue
 		}
 
@@ -368,8 +360,6 @@ func (s *Server) checkFiles(files []string, currentFile string, currentContent s
 	if !found {
 		rootdir = s.workspace
 	}
-
-	log.Trace().Msgf("using project root: %s (found: %t)", rootdir, found)
 
 	parser, err := hcl.NewTerramateParser(rootdir, dir)
 	if err != nil {

--- a/modvendor/manifest/manifest.go
+++ b/modvendor/manifest/manifest.go
@@ -9,20 +9,12 @@ import (
 	"path/filepath"
 
 	"github.com/go-git/go-git/v5/plumbing/format/gitignore"
-	"github.com/rs/zerolog/log"
 	"github.com/terramate-io/terramate/errors"
 	"github.com/terramate-io/terramate/hcl"
 )
 
 // LoadFileMatcher will load a gitignore.Matcher
 func LoadFileMatcher(rootdir string) (gitignore.Matcher, error) {
-	logger := log.With().
-		Str("action", "modvendor.loadFileMatcher").
-		Str("rootdir", rootdir).
-		Logger()
-
-	logger.Trace().Msg("checking for manifest on .terramate")
-
 	dotTerramate := filepath.Join(rootdir, ".terramate")
 	dotTerramateInfo, err := os.Stat(dotTerramate)
 
@@ -32,12 +24,9 @@ func LoadFileMatcher(rootdir string) (gitignore.Matcher, error) {
 			return nil, errors.E(err, "parsing manifest on .terramate")
 		}
 		if hasVendorManifest(cfg) {
-			logger.Trace().Msg("found manifest on .terramate")
 			return newMatcher(cfg), nil
 		}
 	}
-
-	logger.Trace().Msg("checking for manifest on root")
 
 	cfg, err := hcl.ParseDir(rootdir, rootdir)
 	if err != nil {
@@ -45,7 +34,6 @@ func LoadFileMatcher(rootdir string) (gitignore.Matcher, error) {
 	}
 
 	if hasVendorManifest(cfg) {
-		logger.Trace().Msg("found manifest on root")
 		return newMatcher(cfg), nil
 	}
 

--- a/project/project.go
+++ b/project/project.go
@@ -12,7 +12,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/rs/zerolog/log"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -131,25 +130,11 @@ func AbsPath(root, prjAbsPath string) string {
 
 // FriendlyFmtDir formats the directory in a friendly way for tooling output.
 func FriendlyFmtDir(root, wd, dir string) (string, bool) {
-	logger := log.With().
-		Str("action", "FriendlyFmtDir()").
-		Logger()
-
-	logger.Trace().
-		Str("prefix", wd).
-		Str("root", root).
-		Str("dir", dir).
-		Msg("Get relative path.")
-
 	trimPart := PrjAbsPath(root, wd).String()
 	if !strings.HasPrefix(dir, trimPart) {
 		return "", false
 	}
 
-	logger.Trace().
-		Str("dir", dir).
-		Str("prefix", trimPart).
-		Msg("Trim prefix.")
 	dir = strings.TrimPrefix(dir, trimPart)
 
 	if dir == "" {
@@ -157,10 +142,6 @@ func FriendlyFmtDir(root, wd, dir string) (string, bool) {
 	} else if dir[0] == '/' {
 		dir = dir[1:]
 	}
-
-	logger.Trace().
-		Str("newdir", dir).
-		Msg("Get friendly dir.")
 
 	return dir, true
 }

--- a/run/env.go
+++ b/run/env.go
@@ -45,14 +45,9 @@ func LoadEnv(root *config.Root, st *config.Stack) (EnvVars, error) {
 		Stringer("stack", st).
 		Logger()
 
-	logger.Trace().Msg("checking if we have run env config")
-
 	if !root.Tree().Node.HasRunEnv() {
-		logger.Trace().Msg("no run env config found, nothing to do")
 		return nil, nil
 	}
-
-	logger.Trace().Msg("loading globals")
 
 	globalsReport := globals.ForStack(root, st)
 	if err := globalsReport.AsError(); err != nil {
@@ -75,14 +70,10 @@ func LoadEnv(root *config.Root, st *config.Stack) (EnvVars, error) {
 			Str("attribute", attr.Name).
 			Logger()
 
-		logger.Trace().Msg("evaluating")
-
 		val, err := evalctx.Eval(attr.Expr)
 		if err != nil {
 			return nil, errors.E(ErrEval, err)
 		}
-
-		logger.Trace().Msg("checking evaluated value type")
 
 		if val.Type() != cty.String {
 			return nil, errors.E(
@@ -94,7 +85,6 @@ func LoadEnv(root *config.Root, st *config.Stack) (EnvVars, error) {
 		}
 		envVars = append(envVars, attr.Name+"="+val.AsString())
 
-		logger.Trace().Msg("env var loaded")
 	}
 
 	return envVars, nil

--- a/run/order.go
+++ b/run/order.go
@@ -28,8 +28,6 @@ func Sort(root *config.Root, stacks config.List[*config.SortableStack]) (config.
 		Str("root", root.HostDir()).
 		Logger()
 
-	logger.Trace().Msg("Computes implicit hierarchical order.")
-
 	isParentStack := func(s1, s2 *config.Stack) bool {
 		return s1.Dir.HasPrefix(s2.Dir.String() + "/")
 	}
@@ -48,8 +46,6 @@ func Sort(root *config.Root, stacks config.List[*config.SortableStack]) (config.
 			}
 		}
 	}
-
-	logger.Trace().Msg("Sorting stacks.")
 
 	visited := dag.Visited{}
 	for _, elem := range stacks {
@@ -77,20 +73,14 @@ func Sort(root *config.Root, stacks config.List[*config.SortableStack]) (config.
 		}
 	}
 
-	logger.Trace().Msg("Validate DAG.")
-
 	reason, err := d.Validate()
 	if err != nil {
 		return nil, reason, err
 	}
 
-	logger.Trace().Msg("Get topologically order DAG.")
-
 	order := d.Order()
 
 	orderedStacks := make(config.List[*config.SortableStack], 0, len(order))
-
-	logger.Trace().Msg("Get ordered stacks.")
 
 	isSelectedStack := func(s *config.Stack) bool {
 		// Stacks may be added on the DAG from after/before references
@@ -113,9 +103,6 @@ func Sort(root *config.Root, stacks config.List[*config.SortableStack]) (config.
 		}
 		s := val.(*config.Stack)
 		if !isSelectedStack(s) {
-			logger.Trace().
-				Stringer("stack", s.Dir).
-				Msg("ignoring since not part of selected stacks")
 			continue
 		}
 		orderedStacks = append(orderedStacks, s.Sortable())
@@ -226,8 +213,6 @@ func BuildDAG(
 	stacks = append(stacks, ancestorStacks...)
 	stacks = append(stacks, descendantStacks...)
 
-	logger.Trace().Msg("Range over stacks.")
-
 	for _, elem := range stacks {
 		logger = log.With().
 			Str("action", "run.BuildDAG()").
@@ -238,8 +223,6 @@ func BuildDAG(
 		if _, ok := visited[dag.ID(elem.Dir().String())]; ok {
 			continue
 		}
-
-		logger.Trace().Msg("Build DAG.")
 
 		err = BuildDAG(d, root, elem.Stack, descendantsName, getDescendants,
 			ancestorsName, getAncestors, visited)

--- a/stack/create.go
+++ b/stack/create.go
@@ -10,7 +10,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/rs/zerolog/log"
 	"github.com/terramate-io/terramate/config"
 	"github.com/terramate-io/terramate/errors"
 	"github.com/terramate-io/terramate/hcl"
@@ -41,10 +40,6 @@ const (
 // If the stack already exists it will return an error and no changes will be
 // made to the stack.
 func Create(root *config.Root, stack config.Stack, imports ...string) (err error) {
-	logger := log.With().
-		Str("action", "stack.Create()").
-		Logger()
-
 	err = stack.Validate()
 	if err != nil {
 		return err
@@ -59,14 +54,10 @@ func Create(root *config.Root, stack config.Stack, imports ...string) (err error
 		return errors.E(ErrStackAlreadyExists)
 	}
 
-	logger.Trace().Msg("creating stack dir if absent")
-
 	hostpath := stack.Dir.HostPath(root.HostDir())
 	if err := os.MkdirAll(hostpath, createDirMode); err != nil {
 		return errors.E(err, "failed to create new stack directories")
 	}
-
-	logger.Trace().Msg("validating create configuration")
 
 	_, err = os.Stat(filepath.Join(hostpath, DefaultFilename))
 	if err == nil {
@@ -90,8 +81,6 @@ func Create(root *config.Root, stack config.Stack, imports ...string) (err error
 	}
 
 	tmCfg.Stack = &stackCfg
-
-	logger.Trace().Msg("creating stack file")
 
 	stackFile, err := os.Create(filepath.Join(hostpath, DefaultFilename))
 	if err != nil {

--- a/tf/terraform.go
+++ b/tf/terraform.go
@@ -37,14 +37,10 @@ func ParseModules(path string) ([]Module, error) {
 		Str("path", path).
 		Logger()
 
-	logger.Trace().Msg("Get path information.")
-
 	_, err := os.Stat(path)
 	if err != nil {
 		return nil, errors.E(err, "stat failed on %q", path)
 	}
-
-	logger.Trace().Msg("Create new parser")
 
 	p := hclparse.NewParser()
 
@@ -56,8 +52,6 @@ func ParseModules(path string) ([]Module, error) {
 	}
 
 	body := f.Body.(*hclsyntax.Body)
-
-	logger.Trace().Msg("Parse modules")
 
 	var modules []Module
 	for _, block := range body.Blocks {
@@ -78,7 +72,6 @@ func ParseModules(path string) ([]Module, error) {
 			Str("module", moduleName).
 			Logger()
 
-		logger.Trace().Msg("Get source attribute.")
 		source, ok, err := findStringAttr(block, "source")
 		if err != nil {
 			logger.Debug().
@@ -116,8 +109,6 @@ func IsStack(path string) (bool, error) {
 
 	body := f.Body.(*hclsyntax.Body)
 
-	logger.Trace().Msg("Parse terraform.backend blocks")
-
 	for _, block := range body.Blocks {
 		switch block.Type {
 		case "terraform":
@@ -126,7 +117,6 @@ func IsStack(path string) (bool, error) {
 					continue
 				}
 
-				logger.Trace().Msg("found a backend block")
 				return true, nil
 			}
 		case "provider":
@@ -138,12 +128,6 @@ func IsStack(path string) (bool, error) {
 }
 
 func findStringAttr(block *hclsyntax.Block, attrName string) (string, bool, error) {
-	logger := log.With().
-		Str("action", "findStringAttr()").
-		Logger()
-
-	logger.Trace().Msg("Range over attributes.")
-
 	attrs := ast.AsHCLAttributes(block.Body.Attributes)
 
 	for _, attr := range ast.SortRawAttributes(attrs) {
@@ -151,14 +135,11 @@ func findStringAttr(block *hclsyntax.Block, attrName string) (string, bool, erro
 			continue
 		}
 
-		logger.Trace().Msg("Found attribute that we were looking for.")
-		logger.Trace().Msg("Get attribute value.")
 		attrVal, diags := attr.Expr.Value(nil)
 		if diags.HasErrors() {
 			return "", false, errors.E(diags)
 		}
 
-		logger.Trace().Msg("Check value type is correct.")
 		if attrVal.Type() != cty.String {
 			return "", false, errors.E(
 				"attribute %q is not a string", attr.Name, attr.Expr.Range(),


### PR DESCRIPTION
# Reason for This Change

There are trace logs spread across the code base that are unused.

## Description of Changes

* Remove all `logger.Trace()` calls and unused `logger` instances
* Update `cmd/terramate/e2etests/logging_test.go` to use DBG level instead of TRC


