### PR TITLE
feat(scripts): evaluate script blocks

### DIFF
--- a/config/assert.go
+++ b/config/assert.go
@@ -7,7 +7,6 @@ import (
 	"github.com/terramate-io/terramate/errors"
 	"github.com/terramate-io/terramate/hcl"
 	"github.com/terramate-io/terramate/hcl/eval"
-	"github.com/zclconf/go-cty/cty"
 
 	hhcl "github.com/hashicorp/hcl/v2"
 )
@@ -55,32 +54,4 @@ func EvalAssert(evalctx *eval.Context, cfg hcl.AssertConfig) (Assert, error) {
 	}
 
 	return res, nil
-}
-
-func evalBool(evalctx *eval.Context, expr hhcl.Expression, name string) (bool, error) {
-	if expr == nil {
-		return false, errors.E(ErrSchema, "%s must be defined", name)
-	}
-	val, err := evalctx.Eval(expr)
-	if err != nil {
-		return false, errors.E(err, "evaluating %s", name)
-	}
-	if val.Type() != cty.Bool {
-		return false, errors.E(ErrSchema, "%s must be boolean, got %v", name, val.Type().FriendlyName())
-	}
-	return val.True(), nil
-}
-
-func evalString(evalctx *eval.Context, expr hhcl.Expression, name string) (string, error) {
-	if expr == nil {
-		return "", errors.E(ErrSchema, "%s must be defined", name)
-	}
-	val, err := evalctx.Eval(expr)
-	if err != nil {
-		return "", errors.E(err, "evaluating %s", name)
-	}
-	if val.Type() != cty.String {
-		return "", errors.E(ErrSchema, "%s must be string, got %v", name, val.Type().FriendlyName())
-	}
-	return val.AsString(), nil
 }

--- a/config/eval.go
+++ b/config/eval.go
@@ -1,0 +1,39 @@
+// Copyright 2023 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+package config
+
+import (
+	hhcl "github.com/hashicorp/hcl/v2"
+	"github.com/terramate-io/terramate/errors"
+	"github.com/terramate-io/terramate/hcl/eval"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func evalBool(evalctx *eval.Context, expr hhcl.Expression, name string) (bool, error) {
+	if expr == nil {
+		return false, errors.E(ErrSchema, "%s must be defined", name)
+	}
+	val, err := evalctx.Eval(expr)
+	if err != nil {
+		return false, errors.E(err, "evaluating %s", name)
+	}
+	if val.Type() != cty.Bool {
+		return false, errors.E(ErrSchema, "%s must be boolean, got %v", name, val.Type().FriendlyName())
+	}
+	return val.True(), nil
+}
+
+func evalString(evalctx *eval.Context, expr hhcl.Expression, name string) (string, error) {
+	if expr == nil {
+		return "", errors.E(ErrSchema, "%s must be defined", name)
+	}
+	val, err := evalctx.Eval(expr)
+	if err != nil {
+		return "", errors.E(err, "evaluating %s", name)
+	}
+	if val.Type() != cty.String {
+		return "", errors.E(ErrSchema, "%s must be string, got %v", name, val.Type().FriendlyName())
+	}
+	return val.AsString(), nil
+}

--- a/config/script.go
+++ b/config/script.go
@@ -1,0 +1,187 @@
+// Copyright 2023 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+package config
+
+import (
+	hhcl "github.com/hashicorp/hcl/v2"
+	"github.com/terramate-io/terramate/errors"
+	"github.com/terramate-io/terramate/hcl"
+	"github.com/terramate-io/terramate/hcl/eval"
+	"github.com/terramate-io/terramate/hcl/info"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// Errors for indicating invalid script schema
+const (
+	ErrScriptSchema              errors.Kind = "script config has an invalid schema"
+	ErrScriptInvalidTypeDesc     errors.Kind = "invalid type for script.description"
+	ErrScriptInvalidTypeCommand  errors.Kind = "invalid type for script.command"
+	ErrScriptInvalidTypeCommands errors.Kind = "invalid type for script.commands"
+)
+
+// ScriptJob represents an evaluated job block
+type ScriptJob struct {
+	Cmd  []string
+	Cmds [][]string
+}
+
+// Script represents an evaluated script block
+type Script struct {
+	Range       info.Range
+	Labels      []string
+	Description string
+	Jobs        []ScriptJob
+}
+
+// Commands is a convenience method for callers who don't specifically
+// care about which command attr was set e.g. command or commands. This method
+// returns a list of commands irrespective of whether they were set through
+// job.command or job.commands
+func (es ScriptJob) Commands() [][]string {
+	if es.Cmd != nil {
+		return [][]string{es.Cmd}
+	}
+	return es.Cmds
+}
+
+// EvalScript evaluates a script block using the provided evaluation context
+func EvalScript(evalctx *eval.Context, script hcl.Script) (Script, error) {
+	evaluatedScript := Script{
+		Range:  script.Range,
+		Labels: script.Labels,
+	}
+	errs := errors.L()
+
+	desc, err := evalScriptDesc(evalctx, script.Description.Expr, "script.description")
+	errs.Append(err)
+
+	evaluatedScript.Description = desc
+
+	for _, job := range script.Jobs {
+		evaluatedJob := ScriptJob{}
+
+		if job.Command != nil {
+			command, err := evalScriptJobCommand(evalctx, job.Command.Expr, "command")
+			if err != nil {
+				errs.Append(err)
+				continue
+			}
+			evaluatedJob.Cmd = command
+		}
+
+		if job.Commands != nil {
+			commands, err := evalScriptJobCommands(evalctx, job.Commands.Expr, "commands")
+			if err != nil {
+				errs.Append(err)
+				continue
+			}
+			evaluatedJob.Cmds = commands
+		}
+
+		evaluatedScript.Jobs = append(evaluatedScript.Jobs, evaluatedJob)
+	}
+
+	if err := errs.AsError(); err != nil {
+		return Script{}, err
+	}
+
+	return evaluatedScript, nil
+}
+
+func evalScriptDesc(evalctx *eval.Context, expr hhcl.Expression, name string) (string, error) {
+	desc, err := evalString(evalctx, expr, name)
+	if err != nil {
+		return "", errors.E(ErrScriptInvalidTypeDesc, expr.Range(), err)
+	}
+
+	return desc, nil
+}
+
+func evalScriptJobCommand(evalctx *eval.Context, expr hhcl.Expression, name string) ([]string, error) {
+	val, err := evalctx.Eval(expr)
+	if err != nil {
+		return nil, errors.E(ErrScriptSchema, expr.Range(),
+			err, "evaluating %s", name)
+	}
+
+	if !val.Type().IsTupleType() {
+		return nil, errors.E(ErrScriptInvalidTypeCommand, expr.Range(),
+			"%s should be a list(string) type", name)
+	}
+
+	errs := errors.L()
+	evaluatedCommand := []string{}
+
+	index := -1
+	it := val.ElementIterator()
+	for it.Next() {
+		index++
+		_, elem := it.Element()
+		if elem.Type() != cty.String {
+			errs.Append(errors.E(ErrScriptInvalidTypeCommand, expr.Range(),
+				"field %s must be a list(string) but element %d has type %q",
+				name, index, elem.Type().FriendlyName()))
+			continue
+		}
+		evaluatedCommand = append(evaluatedCommand, elem.AsString())
+	}
+
+	if err := errs.AsError(); err != nil {
+		return nil, err
+	}
+
+	return evaluatedCommand, nil
+}
+
+func evalScriptJobCommands(evalctx *eval.Context, expr hhcl.Expression, name string) ([][]string, error) {
+	val, err := evalctx.Eval(expr)
+	if err != nil {
+		return nil, errors.E(ErrScriptSchema, expr.Range(),
+			err, "evaluating %s", name)
+	}
+
+	if !val.Type().IsTupleType() {
+		return nil, errors.E(ErrScriptInvalidTypeCommands, expr.Range(),
+			"%s should be a list(string) type", name)
+	}
+
+	errs := errors.L()
+	evaluatedCommands := [][]string{}
+
+	index := -1
+	it := val.ElementIterator()
+	for it.Next() {
+		index++
+		_, elem := it.Element()
+		if !elem.Type().IsTupleType() {
+			errs.Append(errors.E(ErrScriptInvalidTypeCommands, expr.Range(),
+				"field %s must be a list of list(string) but element %d has type %q",
+				name, index, elem.Type().FriendlyName()))
+			continue
+		}
+
+		evaluatedCommand := []string{}
+		indexCommand := -1
+		itCommand := elem.ElementIterator()
+		for itCommand.Next() {
+			indexCommand++
+			_, elem := itCommand.Element()
+			if elem.Type() != cty.String {
+				errs.Append(errors.E(ErrScriptInvalidTypeCommands, expr.Range(),
+					"field %s must be a string but element %d has type %q",
+					name, indexCommand, elem.Type().FriendlyName()))
+				continue
+			}
+			evaluatedCommand = append(evaluatedCommand, elem.AsString())
+		}
+
+		evaluatedCommands = append(evaluatedCommands, evaluatedCommand)
+	}
+
+	if err := errs.AsError(); err != nil {
+		return nil, err
+	}
+
+	return evaluatedCommands, nil
+}

--- a/config/script_test.go
+++ b/config/script_test.go
@@ -1,0 +1,312 @@
+// Copyright 2023 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+package config_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	hhcl "github.com/hashicorp/hcl/v2"
+	"github.com/madlambda/spells/assert"
+	"github.com/terramate-io/terramate/config"
+	"github.com/terramate-io/terramate/errors"
+	"github.com/terramate-io/terramate/hcl"
+	"github.com/terramate-io/terramate/hcl/ast"
+	"github.com/terramate-io/terramate/hcl/eval"
+	"github.com/terramate-io/terramate/hcl/info"
+	"github.com/terramate-io/terramate/stdlib"
+	"github.com/terramate-io/terramate/test"
+
+	. "github.com/terramate-io/terramate/test/hclutils"
+	. "github.com/terramate-io/terramate/test/hclutils/info"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestScriptEval(t *testing.T) {
+	t.Parallel()
+
+	makeAttribute := func(t *testing.T, name string, expr string) ast.Attribute {
+		t.Helper()
+		return ast.Attribute{
+			Attribute: &hhcl.Attribute{
+				Name: name,
+				Expr: test.NewExpr(t, expr),
+			},
+		}
+	}
+
+	makeCommand := func(t *testing.T, expr string) *hcl.Command {
+		parsed := hcl.Command(makeAttribute(t, "command", expr))
+		return &parsed
+	}
+
+	makeCommands := func(t *testing.T, expr string) *hcl.Commands {
+		parsed := hcl.Commands(makeAttribute(t, "commands", expr))
+		return &parsed
+	}
+
+	labels := []string{"some", "label"}
+
+	type testcase struct {
+		name    string
+		script  hcl.Script
+		globals map[string]cty.Value
+		want    config.Script
+		wantErr error
+	}
+
+	tcases := []testcase{
+		{
+			name: "description attribute wrong type",
+			script: hcl.Script{
+				Labels: labels,
+				Description: hcl.NewScriptDescription(
+					makeAttribute(t, "description", `666`)),
+			},
+			wantErr: errors.E(config.ErrScriptInvalidTypeDesc),
+		},
+		{
+			name: "description attribute with functions",
+			script: hcl.Script{
+				Labels: labels,
+				Description: hcl.NewScriptDescription(
+					makeAttribute(t, "description", `tm_upper("some description")`)),
+			},
+			want: config.Script{
+				Labels:      labels,
+				Description: "SOME DESCRIPTION",
+			},
+		},
+		{
+			name: "description attribute with functions and globals",
+			script: hcl.Script{
+				Range:  Range("script.tm", Start(1, 1, 0), End(3, 2, 37)),
+				Labels: labels,
+				Description: hcl.NewScriptDescription(
+					makeAttribute(t, "description", `tm_upper(global.some_string_var)`)),
+			},
+			globals: map[string]cty.Value{
+				"some_string_var": cty.StringVal("terramate"),
+			},
+			want: config.Script{
+				Labels:      labels,
+				Description: "TERRAMATE",
+			},
+		},
+		{
+			name: "command attribute wrong type",
+			script: hcl.Script{
+				Labels: labels,
+				Description: hcl.NewScriptDescription(
+					makeAttribute(t, "description", `"some description"`)),
+				Jobs: []*hcl.ScriptJob{
+					{
+						Command: makeCommand(t, `"echo"`),
+					},
+				},
+			},
+			globals: map[string]cty.Value{
+				"some_string_var": cty.StringVal("terramate"),
+			},
+			wantErr: errors.E(config.ErrScriptInvalidTypeCommand),
+		},
+		{
+			name: "command attribute wrong element type",
+			script: hcl.Script{
+				Labels: labels,
+				Description: hcl.NewScriptDescription(
+					makeAttribute(t, "description", `"some description"`)),
+				Jobs: []*hcl.ScriptJob{
+					{
+						Command: makeCommand(t, `["echo", 666]`),
+					},
+				},
+			},
+			wantErr: errors.E(config.ErrScriptInvalidTypeCommand),
+		},
+		{
+			name: "command attribute with functions and globals",
+			script: hcl.Script{
+				Labels: labels,
+				Description: hcl.NewScriptDescription(
+					makeAttribute(t, "description", `"some description"`)),
+				Jobs: []*hcl.ScriptJob{
+					{
+						Command: makeCommand(t, `["echo", tm_upper("hello ${global.some_string_var}")]`),
+					},
+				},
+			},
+			globals: map[string]cty.Value{
+				"some_string_var": cty.StringVal("terramate"),
+			},
+			want: config.Script{
+				Labels:      labels,
+				Description: "some description",
+				Jobs: []config.ScriptJob{
+					{
+						Cmd: []string{"echo", "HELLO TERRAMATE"},
+					},
+				},
+			},
+		},
+		{
+			name: "command with first item interpolated",
+			script: hcl.Script{
+				Labels: labels,
+				Description: hcl.NewScriptDescription(
+					makeAttribute(t, "description", `"some description"`)),
+				Jobs: []*hcl.ScriptJob{
+					{
+						Command: makeCommand(t, `["${global.some_command_name}", "--version"]`),
+					},
+				},
+			},
+			globals: map[string]cty.Value{
+				"some_command_name": cty.StringVal("ls"),
+			},
+			want: config.Script{
+				Labels:      labels,
+				Description: "some description",
+				Jobs: []config.ScriptJob{
+					{
+						Cmd: []string{"ls", "--version"},
+					},
+				},
+			},
+		},
+		{
+			name: "commands attribute wrong type",
+			script: hcl.Script{
+				Labels: labels,
+				Description: hcl.NewScriptDescription(
+					makeAttribute(t, "description", `"some description"`)),
+				Jobs: []*hcl.ScriptJob{
+					{
+						Commands: makeCommands(t, `"echo"`),
+					},
+				},
+			},
+			globals: map[string]cty.Value{
+				"some_string_var": cty.StringVal("terramate"),
+			},
+			wantErr: errors.E(config.ErrScriptInvalidTypeCommands),
+		},
+		{
+			name: "commands attribute wrong element type",
+			script: hcl.Script{
+				Labels: labels,
+				Description: hcl.NewScriptDescription(
+					makeAttribute(t, "description", `"some description"`)),
+				Jobs: []*hcl.ScriptJob{
+					{
+						Commands: makeCommands(t, `
+						  [
+							["echo", "hello"],
+							666,
+						  ]
+						`),
+					},
+				},
+			},
+			wantErr: errors.E(config.ErrScriptInvalidTypeCommands),
+		},
+		{
+			name: "commands attribute with functions and globals",
+			script: hcl.Script{
+				Labels: labels,
+				Description: hcl.NewScriptDescription(
+					makeAttribute(t, "description", `"some description"`)),
+				Jobs: []*hcl.ScriptJob{
+					{
+						Commands: makeCommands(t, `
+						  [
+							["echo", tm_upper("hello ${global.some_string_var}")],
+							["stat", "."],
+						  ]
+						`),
+					},
+				},
+			},
+			globals: map[string]cty.Value{
+				"some_string_var": cty.StringVal("terramate"),
+			},
+			want: config.Script{
+				Labels:      labels,
+				Description: "some description",
+				Jobs: []config.ScriptJob{
+					{
+						Cmds: [][]string{
+							{"echo", "HELLO TERRAMATE"},
+							{"stat", "."},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "multiple jobs",
+			script: hcl.Script{
+				Labels: labels,
+				Description: hcl.NewScriptDescription(
+					makeAttribute(t, "description", `"some description"`)),
+				Jobs: []*hcl.ScriptJob{
+					{
+						Commands: makeCommands(t, `
+						  [
+							["echo", tm_upper("hello ${global.some_string_var}")],
+							["stat", "."],
+						  ]
+						`),
+					},
+					{
+						Commands: makeCommands(t, `
+						  [
+							["echo", tm_upper("hello ${global.some_string_var}")],
+							["ls", "-l"],
+						  ]
+						`),
+					},
+				},
+			},
+			globals: map[string]cty.Value{
+				"some_string_var": cty.StringVal("terramate"),
+			},
+			want: config.Script{
+				Labels:      labels,
+				Description: "some description",
+				Jobs: []config.ScriptJob{
+					{
+						Cmds: [][]string{
+							{"echo", "HELLO TERRAMATE"},
+							{"stat", "."},
+						},
+					},
+					{
+						Cmds: [][]string{
+							{"echo", "HELLO TERRAMATE"},
+							{"ls", "-l"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tcase := range tcases {
+		tcase := tcase
+		t.Run(tcase.name, func(t *testing.T) {
+			t.Parallel()
+			hclctx := eval.NewContext(stdlib.Functions(test.TempDir(t)))
+			hclctx.SetNamespace("global", tcase.globals)
+
+			got, err := config.EvalScript(hclctx, tcase.script)
+			assert.IsError(t, err, tcase.wantErr)
+			// ignoring info.Range comparisons for now
+			if diff := cmp.Diff(tcase.want, got, cmpopts.IgnoreUnexported(info.Range{})); diff != "" {
+				t.Fatalf("unexpected result\n%s", diff)
+			}
+		})
+	}
+}

--- a/hcl/hcl_script.go
+++ b/hcl/hcl_script.go
@@ -6,6 +6,7 @@ package hcl
 import (
 	"github.com/terramate-io/terramate/errors"
 	"github.com/terramate-io/terramate/hcl/ast"
+	"github.com/terramate-io/terramate/hcl/info"
 )
 
 // Errors returned during the HCL parsing of script block
@@ -36,6 +37,7 @@ type ScriptDescription ast.Attribute
 
 // Script represents a parsed script block
 type Script struct {
+	Range       info.Range
 	Labels      []string           // Labels of the script block used for grouping scripts
 	Description *ScriptDescription // Description is a human readable description of a script
 	Jobs        []*ScriptJob       // Job represents the command(s) part of this script
@@ -63,6 +65,7 @@ func (p *TerramateParser) parseScriptBlock(block *ast.Block) (*Script, error) {
 	errs := errors.L()
 
 	parsedScript := &Script{
+		Range:  block.Range,
 		Labels: block.Labels,
 	}
 


### PR DESCRIPTION
# Reason for This Change

The attributes of a script block need to be evaluated at runtime in order to resolve any variables/globals/functions etc.

## Description of Changes

* Added an `EvalScript` function that evaluates a script based on the provided context
* Added tests for validating types + evaluating functions/globals

