### PR TITLE
feat(tmc): add support for additional stack statuses.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 ### Added
 
 - Add `terramate.config.experiments` configuration to enable experimental features.
+- Add support for statuses `ok, failed, drifted and healthy` to the `--experimental-status` flag.
 
 ### Fixed
 

--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -92,7 +92,7 @@ func (c *Client) MemberOrganizations(ctx context.Context) (orgs MemberOrganizati
 // StacksByStatus returns all stacks for the given organization.
 func (c *Client) StacksByStatus(ctx context.Context, orgUUID UUID, status stack.FilterStatus) (StacksResponse, error) {
 	path := path.Join(StacksPath, string(orgUUID))
-	if status == stack.UnhealthyFilter {
+	if status != stack.NoFilter {
 		path += "?status=" + status.String()
 	}
 	return Get[StacksResponse](ctx, c, path)

--- a/cloud/stack/status_test.go
+++ b/cloud/stack/status_test.go
@@ -19,7 +19,7 @@ func TestStackStatus(t *testing.T) {
 
 	var s stack.Status
 	errtest.Assert(t, s.Validate(), errors.E(stack.ErrInvalidStatus))
-	s = stack.Canceled + 1
+	s = stack.Failed + 1
 	errtest.Assert(t, s.Validate(), errors.E(stack.ErrInvalidStatus))
 
 	type testcase struct {
@@ -29,8 +29,6 @@ func TestStackStatus(t *testing.T) {
 	for _, tc := range []testcase{
 		{str: "ok", want: stack.OK},
 		{str: "drifted", want: stack.Drifted},
-		{str: "canceled", want: stack.Canceled},
-		{str: "unknown", want: stack.Unknown},
 		{str: "okay", want: stack.Unrecognized},
 		{str: "OK", want: stack.Unrecognized},
 		{str: "Ok", want: stack.Unrecognized},

--- a/cloud/testserver/cloudstore/store.go
+++ b/cloud/testserver/cloudstore/store.go
@@ -244,7 +244,7 @@ func (d *Data) UpsertStack(orguuid cloud.UUID, st Stack) (int, error) {
 		st.State.DeploymentStatus = deployment.OK
 	}
 	if st.State.Status == 0 {
-		st.State.Status = stack.Unknown
+		st.State.Status = stack.OK
 	}
 	st.State.CreatedAt = &t
 	st.State.UpdatedAt = &t

--- a/cloud/testserver/stacks.go
+++ b/cloud/testserver/stacks.go
@@ -61,13 +61,13 @@ func GetStacks(store *cloudstore.Data, w http.ResponseWriter, r *http.Request, p
 		return
 	}
 
-	if filterStatusStr != "" && filterStatusStr != "unhealthy" {
-		w.WriteHeader(http.StatusBadRequest)
-		return
-	}
-
-	if filterStatusStr == "unhealthy" {
-		filterStatus = stack.UnhealthyFilter
+	if filterStatusStr != "" {
+		filterStatus = stack.NewStatusFilter(filterStatusStr)
+		if filterStatus.Is(stack.Unrecognized) {
+			w.WriteHeader(http.StatusBadRequest)
+			writeErr(w, errors.E("invalid status: %s", filterStatusStr))
+			return
+		}
 	}
 
 	var andFilters []func(st cloudstore.Stack) bool

--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -975,7 +975,6 @@ func (c *cli) listStacks(mgr *stack.Manager, isChanged bool, status cloudstack.F
 				stacks = append(stacks, stack)
 			}
 		}
-
 		report.Stacks = stacks
 	}
 
@@ -1293,8 +1292,8 @@ func parseStatusFilter(strStatus string) cloudstack.FilterStatus {
 	status := cloudstack.NoFilter
 	if strStatus != "" {
 		status = cloudstack.NewStatusFilter(strStatus)
-		if status != cloudstack.UnhealthyFilter {
-			fatal(errors.E("only %s filter allowed", cloudstack.UnhealthyFilter))
+		if status.Is(cloudstack.Unrecognized) {
+			fatal(errors.E("unrecognized stack filter: %s", strStatus))
 		}
 	}
 	return status


### PR DESCRIPTION
## Reasons For this Change

It adds more status filters for the `--experimental-status` flag of both `terramate list` and `terramate experimental trigger`.