### PR TITLE
Fix links in sidebar to built in functions

### DIFF
--- a/docs/functions/index.md
+++ b/docs/functions/index.md
@@ -8,7 +8,7 @@ prev:
 
 next:
   text: 'tm_ternary'
-  link: '/functions/tm_ternary'
+  link: '/functions/terramate-builtin/tm_ternary'
 ---
 
 # Terramate Functions

--- a/docs/functions/terramate-builtin/tm_hcl_expression.md
+++ b/docs/functions/terramate-builtin/tm_hcl_expression.md
@@ -4,11 +4,11 @@ description: This function is capable of generating HCL expressions from a strin
 
 prev:
   text: 'tm_ternary'
-  link: '/functions/tm_ternary.md'
+  link: '/functions/terramate-builtin/tm_ternary'
 
 next:
   text: 'tm_version_match'
-  link: 'functions/tm_version_match.md'
+  link: 'functions/terramate-builtin/tm_version_match.md'
 ---
 
 # `tm_hcl_expression` Function

--- a/docs/functions/terramate-builtin/tm_ternary.md
+++ b/docs/functions/terramate-builtin/tm_ternary.md
@@ -11,7 +11,7 @@ prev:
 
 next:
   text: 'tm_hcl_expression'
-  link: 'functions/tm_hcl_expression.md'
+  link: 'functions/terramate-builtin/tm_hcl_expression.md'
 ---
 
 # `tm_ternary` Function

--- a/docs/functions/terramate-builtin/tm_vendor.md
+++ b/docs/functions/terramate-builtin/tm_vendor.md
@@ -5,7 +5,7 @@ description: |
 
 prev:
   text: 'tm_version_match'
-  link: '/functions/tm_version_match.md'
+  link: '/functions/terramate-builtin/tm_version_match.md'
 ---
 
 # `tm_vendor` Function

--- a/docs/functions/terramate-builtin/tm_version_match.md
+++ b/docs/functions/terramate-builtin/tm_version_match.md
@@ -5,11 +5,11 @@ description: |
 
 next:
   text: 'tm_vendor'
-  link: '/functions/tm_vendor.md'
+  link: '/functions/terramate-builtin/tm_vendor.md'
 
 prev:
   text: 'tm_hcl_expression'
-  link: '/functions/tm_hcl_expression.md'
+  link: '/functions/terramate-builtin/tm_hcl_expression.md'
 ---
 
 ## `tm_version_match` Function


### PR DESCRIPTION
# Reason for This Change

Previously, some of the links in the sidebar of our documentation were broken.

## Description of Changes

This PR corrects the links by adding the missing directory to the URLs.
