### PR TITLE
chore(tests): fix flaky e2e test.

### DIFF
--- a/cloud/testserver/cloudstore/store.go
+++ b/cloud/testserver/cloudstore/store.go
@@ -37,7 +37,7 @@ type (
 		Members     []Member                   `json:"members"`
 		Stacks      []Stack                    `json:"stacks"`
 		Deployments map[cloud.UUID]*Deployment `json:"deployments"`
-		Drifts      []*Drift                   `json:"drifts"`
+		Drifts      []Drift                    `json:"drifts"`
 	}
 	// Member represents the organization member.
 	Member struct {
@@ -208,15 +208,15 @@ outer:
 }
 
 // GetStackByMetaID returns the given stack.
-func (d *Data) GetStackByMetaID(org Org, id string) (*Stack, int, bool) {
+func (d *Data) GetStackByMetaID(org Org, id string) (Stack, int, bool) {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 	for i, st := range org.Stacks {
 		if st.Stack.MetaID == id {
-			return &st, i, true
+			return st, i, true
 		}
 	}
-	return nil, 0, false
+	return Stack{}, 0, false
 }
 
 // GetStack by id.
@@ -294,7 +294,7 @@ func (d *Data) GetStackDrifts(orguuid cloud.UUID, stackID int) ([]Drift, error) 
 	for i, drift := range org.Drifts {
 		drift.ID = i // lazy set, then can be unset in HCL
 		if drift.StackMetaID == st.MetaID {
-			drifts = append(drifts, *drift)
+			drifts = append(drifts, drift)
 		}
 	}
 	return drifts, nil
@@ -334,7 +334,7 @@ func (d *Data) InsertDrift(orgID cloud.UUID, drift Drift) (int, error) {
 	}
 	d.mu.Lock()
 	defer d.mu.Unlock()
-	org.Drifts = append(org.Drifts, &drift)
+	org.Drifts = append(org.Drifts, drift)
 	d.Orgs[org.Name] = org
 	return len(org.Drifts) - 1, nil
 }

--- a/cloud/testserver/drifts.go
+++ b/cloud/testserver/drifts.go
@@ -90,7 +90,7 @@ func PostDrift(store *cloudstore.Data, w http.ResponseWriter, r *http.Request, p
 
 	st, _, found := store.GetStackByMetaID(org, payload.Stack.MetaID)
 	if !found {
-		st = &cloudstore.Stack{
+		st = cloudstore.Stack{
 			Stack: payload.Stack,
 			State: cloudstore.NewState(),
 		}
@@ -118,7 +118,7 @@ func PostDrift(store *cloudstore.Data, w http.ResponseWriter, r *http.Request, p
 		return
 	}
 
-	_, err = store.UpsertStack(cloud.UUID(orguuid), *st)
+	_, err = store.UpsertStack(cloud.UUID(orguuid), st)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		writeErr(w, err)


### PR DESCRIPTION
# Reason for This Change

The cloudstore.Data was reused between testcases and then it hit some cases not implemented in the testserver (handling drifts in stacks still pending).

## Description of Changes

The `tc.cloudData` was serialized and then loaded again in each subtest.
