### PR TITLE
Add link to Terramate Cloud to Top Navigation in docs

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -121,7 +121,8 @@ export default defineConfig({
         text: 'Releases',
         link: 'https://github.com/terramate-io/terramate/releases',
       },
-      { text: '💻 Playground', link: 'https://play.terramate.io/' },
+      { text: 'Playground', link: 'https://play.terramate.io/' },
+      { text: 'Terramate Cloud', link: 'https://terramate.io/' },
     ],
 
     sidebar: {


### PR DESCRIPTION
# Reason for This Change

Currently users that are looking at the documentation website have no chance to navigate to our cloud offering.

## Description of Changes

This adds a direct link to terramate.io/ to the top navigation
