### PR TITLE
Add run-script subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 - Add `terramate experimental script list` to list scripts visible in current directory.
 - Add `terramate experimental script tree` to show a tree view of scripts visible in current directory.
 - Add `terramate experimental script info <scriptname>` to show details about a script.
+- Add `terramate experimental script run <scriptname>` to run a script in all relevant stacks.
 
 ### Fixed
 

--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -229,6 +229,11 @@ type cliSpec struct {
 			Info struct {
 				Labels []string `arg:"" name:"labels" passthrough:"" help:"Name of the script"`
 			} `cmd:"" help:"Show detailed information about a script"`
+			Run struct {
+				NoRecursive bool     `default:"false" help:"Do not recurse into child stacks"`
+				DryRun      bool     `default:"false" help:"Plan the execution but do not execute it"`
+				Labels      []string `arg:"" name:"labels" passthrough:"" help:"Script to execute"`
+			} `cmd:"" help:"Run script in stacks"`
 		} `cmd:"" help:"Terramate Script commands"`
 	} `cmd:"" help:"Experimental features (may change or be removed in the future)"`
 }
@@ -589,6 +594,11 @@ func (c *cli) run() {
 		c.printScriptTree()
 	case "experimental script info <labels>":
 		c.printScriptInfo()
+	case "experimental script run":
+		log.Fatal().Msg("no script specified")
+	case "experimental script run <labels>":
+		c.setupGit()
+		c.runScript()
 	default:
 		log.Fatal().Msg("unexpected command sequence")
 	}

--- a/cmd/terramate/cli/run_script.go
+++ b/cmd/terramate/cli/run_script.go
@@ -1,0 +1,163 @@
+// Copyright 2023 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+package cli
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"os/exec"
+
+	"github.com/fatih/color"
+	"github.com/rs/zerolog/log"
+	"github.com/terramate-io/terramate/config"
+	"github.com/terramate-io/terramate/errors"
+	"github.com/terramate-io/terramate/globals"
+	"github.com/terramate-io/terramate/hcl/eval"
+	prj "github.com/terramate-io/terramate/project"
+	"github.com/terramate-io/terramate/run"
+	"github.com/terramate-io/terramate/stdlib"
+)
+
+func (c *cli) runScript() {
+	logger := log.With().
+		Str("action", "cli.runScript()").
+		Str("workingDir", c.wd()).
+		Logger()
+
+	c.gitSafeguardDefaultBranchIsReachable()
+	c.checkOutdatedGeneratedCode()
+
+	var stacks config.List[*config.SortableStack]
+	if c.parsedArgs.Experimental.Script.Run.NoRecursive {
+		st, found, err := config.TryLoadStack(c.cfg(), prj.PrjAbsPath(c.rootdir(), c.wd()))
+		if err != nil {
+			logger.Fatal().Err(err).Msg("failed to load stack in current directory")
+		}
+
+		if !found {
+			logger.Fatal().Msg("--no-recursive provided but no stack found in the current directory")
+		}
+
+		stacks = append(stacks, st.Sortable())
+	} else {
+		var err error
+		stacks, err = c.computeSelectedStacks(true)
+		if err != nil {
+			logger.Fatal().Err(err).Msg("failed to compute selected stacks")
+		}
+	}
+
+	// search for the script and prepare a list of script/stack entries
+	m := newScriptsMatcher(c.parsedArgs.Experimental.Script.Run.Labels)
+	m.Search(c.cfg(), stacks)
+
+	if len(m.Results) == 0 {
+		c.output.MsgStdErr(color.RedString("script not found: ") +
+			strings.Join(c.parsedArgs.Experimental.Script.Run.Labels, " "))
+		os.Exit(1)
+	}
+
+	if c.parsedArgs.Experimental.Script.Run.DryRun {
+		c.output.MsgStdErr("This is a dry run, commands will not be executed.")
+	}
+
+	for _, result := range m.Results {
+		if len(result.Stacks) == 0 {
+			continue
+		}
+
+		c.output.MsgStdErr("Found %s defined at %s having %s job(s)",
+			color.GreenString(result.ScriptCfg.Name()),
+			color.BlueString(result.ScriptCfg.Range.String()),
+			color.BlueString(fmt.Sprintf("%d", len(result.ScriptCfg.Jobs))),
+		)
+
+		for _, st := range result.Stacks {
+			ectx, err := scriptEvalContext(c.cfg(), st.Stack)
+			if err != nil {
+				logger.Fatal().Err(err).Msg("failed to get context")
+			}
+
+			evalScript, err := config.EvalScript(ectx, *result.ScriptCfg)
+			if err != nil {
+				logger.Fatal().Err(err).Msg("failed to eval script")
+			}
+
+			for jobNum, j := range evalScript.Jobs {
+				c.output.MsgStdOut("")
+				for cmdNum, cmd := range j.Commands() {
+					printCommand(c.stderr, cmd, st.Dir().String(), jobNum, cmdNum)
+
+					env, err := run.LoadEnv(c.cfg(), st.Stack)
+					if err != nil {
+						logger.Fatal().Err(err).Msg("failed to load env")
+					}
+
+					if err := c.executeCommand(cmd, st.Dir().HostPath(c.rootdir()), newEnvironFrom(env)); err != nil {
+						logger.Fatal().Err(err).Msg("unable to execute command")
+					}
+				}
+			}
+		}
+	}
+}
+
+func (c *cli) executeCommand(cmd []string, wd string, env []string) error {
+	if c.parsedArgs.Experimental.Script.Run.DryRun {
+		return nil
+	}
+
+	newCmd, err := makeCommand(cmd, wd, env, c.stdout, c.stderr)
+	if err != nil {
+		return errors.E(err, "failed to prepare command")
+	}
+
+	if err := newCmd.Run(); err != nil {
+		return errors.E(err, "failed to execute command")
+	}
+
+	return nil
+}
+
+func makeCommand(command []string, dir string, env []string, stdout, stderr io.Writer) (*exec.Cmd, error) {
+	cmdPath, err := run.LookPath(command[0], env)
+	if err != nil {
+		return nil, errors.E(err, "%s: command not found", command[0])
+	}
+
+	runCmd := exec.Command(cmdPath, command[1:]...)
+	runCmd.Dir = dir
+	runCmd.Env = env
+	runCmd.Stdout = stdout
+	runCmd.Stderr = stderr
+
+	return runCmd, nil
+}
+
+// printCommand pretty prints the cmd and attaches a "prompt" style prefix to it
+// for example:
+// /somestack (job:0.0)> echo hello
+func printCommand(w io.Writer, cmd []string, wd string, jobNum, cmdNum int) {
+	prompt := color.GreenString(fmt.Sprintf("%s (job:%d.%d)>", wd, jobNum, cmdNum))
+	fmt.Fprintln(w, prompt, color.YellowString(strings.Join(cmd, " ")))
+}
+
+func scriptEvalContext(root *config.Root, st *config.Stack) (*eval.Context, error) {
+	globalsReport := globals.ForStack(root, st)
+	if err := globalsReport.AsError(); err != nil {
+		return nil, err
+	}
+
+	evalctx := eval.NewContext(stdlib.Functions(st.HostDir(root)))
+	runtime := root.Runtime()
+	runtime.Merge(st.RuntimeValues(root))
+	evalctx.SetNamespace("terramate", runtime)
+	evalctx.SetNamespace("global", globalsReport.Globals.AsValueMap())
+	evalctx.SetEnv(os.Environ())
+
+	return evalctx, nil
+}

--- a/cmd/terramate/e2etests/core/run_script_test.go
+++ b/cmd/terramate/e2etests/core/run_script_test.go
@@ -1,0 +1,335 @@
+// Copyright 2023 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+package core_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	. "github.com/terramate-io/terramate/cmd/terramate/e2etests/internal/runner"
+
+	"github.com/terramate-io/terramate/test/sandbox"
+)
+
+func TestRunScript(t *testing.T) {
+	t.Parallel()
+
+	type testcase struct {
+		name       string
+		layout     []string
+		runScript  []string
+		workingDir string
+		want       RunExpected
+	}
+
+	terramateConfig :=
+		`f:terramate.tm:
+	  terramate {
+		config {
+		  experiments = ["scripts"]
+		}
+	  }`
+
+	for _, tc := range []testcase{
+		{
+			name: "script defined in stack should run successfully",
+			layout: []string{
+				terramateConfig,
+				"s:stack-a",
+				`f:stack-a/globals.tm:
+				globals {
+				  message = "some message"
+				}`,
+				`f:stack-a/script.tm:
+				script "somescript" {
+				  description = "some description"
+				  job {
+					command = ["echo", "hello"]
+				  }
+				  job {
+					command = ["echo", "${global.message}"]
+				  }
+				}`,
+				"s:stack-b",
+			},
+			runScript: []string{"somescript"},
+			want: RunExpected{
+				StderrRegexes: []string{
+					"Found somescript defined at /stack-a/script.tm:.* having 2 job\\(s\\)",
+					"/stack-a \\(job:0.0\\)> echo hello",
+					"/stack-a \\(job:1.0\\)> echo some message",
+				},
+				StdoutRegexes: []string{
+					"hello",
+					"some message",
+				},
+			},
+		},
+		{
+			name: "unknown script should return exit code",
+			layout: []string{
+				terramateConfig,
+				"s:stack-a",
+				`f:stack-a/globals.tm:
+				globals {
+				  message = "some message"
+				}`,
+				`f:stack-a/script.tm:
+				script "somescript" {
+				  description = "some description"
+				  job {
+					command = ["echo", "hello"]
+				  }
+				  job {
+					command = ["echo", "${global.message}"]
+				  }
+				}`,
+				"s:stack-b",
+			},
+			runScript: []string{"someunknownscript"},
+			want: RunExpected{
+				Stderr: "script not found: someunknownscript\n",
+				Status: 1,
+			},
+		},
+		{
+			name: "script defined in stack should run also in child stacks",
+			layout: []string{
+				terramateConfig,
+				"s:stack-a",
+				"s:stack-a/child",
+				`f:stack-a/globals.tm:
+				globals {
+				  message = "some message"
+				}`,
+				`f:stack-a/script.tm:
+				script "somescript" {
+				  description = "some description"
+				  job {
+					command = ["echo", "${global.message}"]
+				  }
+				}`,
+				"s:stack-b",
+			},
+			runScript: []string{"somescript"},
+			want: RunExpected{
+				StderrRegexes: []string{
+					"Found somescript defined at /stack-a/script.tm:.* having 1 job\\(s\\)",
+					"/stack-a \\(job:0.0\\)> echo some message",
+					"/stack-a/child \\(job:0.0\\)> echo some message",
+				},
+				StdoutRegexes: []string{
+					"some message",
+				},
+			},
+		},
+		{
+			name: "run-script --tags should only run on the relevant stacks",
+			layout: []string{
+				terramateConfig,
+				`s:stack-a:tags=["terraform"]`,
+				`s:stack-a/child:tags=["kubernetes"]`,
+				`f:stack-a/globals.tm:
+				globals {
+				  message = "some message"
+				}`,
+				`f:stack-a/script.tm:
+				script "somescript" {
+				  description = "some description"
+				  job {
+					command = ["echo", "${global.message}"]
+				  }
+				}`,
+				"s:stack-b",
+			},
+			runScript: []string{"--tags=kubernetes", "somescript"},
+			want: RunExpected{
+				Stdout: `some message`,
+				Stderr: "Found somescript defined at /stack-a/script.tm:2,5-7,6 having 1 job(s)\n" +
+					"/stack-a/child (job:0.0)> echo some message\n",
+				FlattenStdout: true,
+			},
+		},
+		{
+			name: "run-script --no-tags should only run on the relevant stacks",
+			layout: []string{
+				terramateConfig,
+				`s:stack-a:tags=["terraform"]`,
+				`s:stack-a/child:tags=["kubernetes"]`,
+				`f:stack-a/globals.tm:
+				globals {
+				  message = "some message"
+				}`,
+				`f:stack-a/script.tm:
+				script "somescript" {
+				  description = "some description"
+				  job {
+					command = ["echo", "${global.message}"]
+				  }
+				}`,
+				"s:stack-b",
+			},
+			runScript: []string{"--no-tags=terraform", "somescript"},
+			want: RunExpected{
+				Stdout: `some message`,
+				Stderr: "Found somescript defined at /stack-a/script.tm:2,5-7,6 having 1 job(s)\n" +
+					"/stack-a/child (job:0.0)> echo some message\n",
+				FlattenStdout: true,
+			},
+		},
+		{
+			name:       "run-script --no-recursive should only run on the relevant stacks",
+			workingDir: "stack-a",
+			layout: []string{
+				terramateConfig,
+				`s:stack-a:tags=["terraform"]`,
+				`s:stack-a/child:tags=["kubernetes"]`,
+				`f:stack-a/globals.tm:
+				globals {
+				  message = "some message"
+				}`,
+				`f:stack-a/script.tm:
+				script "somescript" {
+				  description = "some description"
+				  job {
+					command = ["echo", "${global.message}"]
+				  }
+				}`,
+				"s:stack-b",
+			},
+			runScript: []string{"--no-recursive", "somescript"},
+			want: RunExpected{
+				Stdout: `some message`,
+				Stderr: "Found somescript defined at /stack-a/script.tm:2,5-7,6 having 1 job(s)\n" +
+					"/stack-a (job:0.0)> echo some message\n",
+				FlattenStdout: true,
+			},
+		},
+		{
+			name:       "run-script --dry-run should not execute commands",
+			workingDir: "stack-a",
+			layout: []string{
+				terramateConfig,
+				`s:stack-a:tags=["terraform"]`,
+				`f:stack-a/globals.tm:
+				globals {
+				  message = "some message"
+				}`,
+				`f:stack-a/script.tm:
+				script "somescript" {
+				  description = "some description"
+				  job {
+					command = ["echo", "${global.message}"]
+				  }
+				}`,
+				"s:stack-b",
+			},
+			runScript: []string{"--dry-run", "somescript"},
+			want: RunExpected{
+				Stdout: "\n",
+				Stderr: "This is a dry run, commands will not be executed.\n" +
+					"Found somescript defined at /stack-a/script.tm:2,5-7,6 having 1 job(s)\n" +
+					"/stack-a (job:0.0)> echo some message\n",
+			},
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			sandboxes := []sandbox.S{
+				sandbox.New(t),
+			}
+
+			for _, s := range sandboxes {
+				s := s
+				t.Run("run on sandbox", func(t *testing.T) {
+					t.Parallel()
+					s.BuildTree(tc.layout)
+
+					wd := s.RootDir()
+					if tc.workingDir != "" {
+						wd = filepath.Join(wd, tc.workingDir)
+					}
+
+					// required because `terramate run-script` requires a clean repo.
+					git := s.Git()
+					git.CommitAll("everything")
+
+					cli := NewCLI(t, wd)
+					AssertRunResult(t, cli.RunScript(tc.runScript...), tc.want)
+				})
+			}
+		})
+	}
+}
+
+func TestRunScriptOnChangedStacks(t *testing.T) {
+	t.Parallel()
+
+	const (
+		mainTfFileName  = "main.tf"
+		mainTfContents  = "# change is the eternal truth of the universe"
+		terramateConfig = `f:terramate.tm:
+		  terramate {
+			config {
+			  experiments = ["scripts"]
+			}
+		  }`
+	)
+
+	s := sandbox.New(t)
+
+	// stack must run after stack2 but stack2 didn't change.
+	s.BuildTree([]string{
+		terramateConfig,
+		`s:stack`,
+		`f:stack/globals.tm:
+		globals {
+		  message = "some message"
+		}`,
+		`f:stack/script.tm:
+		  script "somescript" {
+			description = "some description"
+			job {
+			  command = ["echo", "hello ${terramate.stack.name}"]
+			}
+		  }
+		`,
+		"s:stack/child",
+	})
+
+	cli := NewCLI(t, s.RootDir())
+	git := s.Git()
+
+	// after all files have been committed
+	git.CommitAll("first commit")
+	git.Push("main")
+
+	// run-script should execute the script on both stacks
+	AssertRunResult(t, cli.RunScript("--changed", "somescript"), RunExpected{
+		Stdout: "\n" +
+			"hello stack\n\n" +
+			"hello child\n",
+		Stderr: "Found somescript defined at /stack/script.tm:2,5-7,6 having 1 job(s)\n" +
+			"/stack (job:0.0)> echo hello stack\n" +
+			"/stack/child (job:0.0)> echo hello child\n",
+	})
+
+	// when a stack is changed and committed
+	stack := s.DirEntry("stack")
+	stackMainTf := stack.CreateFile(mainTfFileName, "# some code")
+	stackMainTf.Write(mainTfContents)
+	git.CommitAll("second commit")
+	git.Push("main")
+
+	// run-script --changed should execute the script only on that stack
+	AssertRunResult(t, cli.RunScript("--changed", "somescript"),
+		RunExpected{
+			Stdout: "\n" +
+				"hello stack\n",
+			Stderr: "Found somescript defined at /stack/script.tm:2,5-7,6 having 1 job(s)\n" +
+				"/stack (job:0.0)> echo hello stack\n",
+		})
+
+}

--- a/cmd/terramate/e2etests/internal/runner/runner.go
+++ b/cmd/terramate/e2etests/internal/runner/runner.go
@@ -244,6 +244,11 @@ func (tm CLI) Run(args ...string) RunResult {
 	}
 }
 
+// RunScript is a helper for executing `terramate run-script`.
+func (tm CLI) RunScript(args ...string) RunResult {
+	return tm.Run(append([]string{"experimental", "script", "run"}, args...)...)
+}
+
 // StacksRunOrder is a helper for executing `terramate experimental run-order`.
 func (tm CLI) StacksRunOrder(args ...string) RunResult {
 	return tm.Run(append([]string{"experimental", "run-order"}, args...)...)


### PR DESCRIPTION
## What this PR does / why we need it:

In order to execute commands specified in `script` blocks, a new subcommand `run-script` is needed.

#### Examples

```
terramate experimental run-script myscript1
```


```
terramate experimental run-script --dry-run myscript1
```

```
terramate experimental run-script --changed myscript1
```

```
terramate experimental run-script --no-recursive myscript1
```

```
terramate experimental run-script --tags=sometag myscript1
```

```
terramate experimental run-script --no-tags=sometag myscript1
```

## Which issue(s) this PR fixes:
none

## Special notes for your reviewer:
* ~the scriptsMatcher/search functionality was cherrypicked from https://github.com/terramate-io/terramate/pull/1275 (I will rebase onto that PR's branch once its ready)~
* I used plain strings instead of the `hclwrite.BlockBuilder` because I couldnt find a way to use variable interpolation in test strings (e.g. `${global.abc*}` or `${terramate.stack.name}`). I am happy with this approach but if there is a better alternative to that please let me know.
* the run-script command uses the already existing `terramate.config.run.env` for configuring env variables. This is nice for keeping the configuration dry, but it also couples the configuration for run/run-script. I am not sure which option is better and would like to have your thoughts. 
* To keep the scope of this PR small, I will implement signal handling for the commands in a separate PR.


## Does this PR introduce a user-facing change?

Yes, a new subcommand `run-script` was added.

# Reason for This Change

`run-script` subcommand will allow users to execute `script {}` blocks in the relevant stacks. 

## Description of Changes

- [x] `run-script` command that executes a script on all of the relevant stacks
- [x] End-to-end tests for various scenarios
- [x] Merge the scriptsMatcher/Search functionality with list scripts implementation


