### PR TITLE
docs: Update getting-started doc

### DIFF
--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -78,11 +78,10 @@ Nothing to do, generated code is up to date
 
 ## Terramate Code Generation
 
-Let’s make it do something. Append the following to the `mysite/stack.tm.hcl`:
+Let’s make it do something. **Append** the following to the `mysite/stack.tm.hcl`:
 
 ```hcl
 # file: mysite/stack.tm.hcl
-...
 generate_hcl "mysite.tf" {
   content {
     resource "local_file" "mysite" {
@@ -214,7 +213,6 @@ generate_hcl "mysite.tf" {
   content {
     resource "local_file" "mysite" {
       filename = "/tmp/tfmysite/${terramate.stack.path.relative}/index.html"
-...
 ```
 
 To execute Terraform, navigate `"cd"` to `prod/mysite` and `dev/mysite` and run the necessary Terraform commands.


### PR DESCRIPTION
# Reason for This Change

When using the copy-to-clipboard functionality, the `...`  are somehow troublesome, because they will generate:

```bash
ERR HCL syntax error: loading from ~/mysite: An argument or block definition is required here. file=/tmp/terramate_demo/mysite/stack.tm.hcl:7,1-4
```

## Description of Changes

Enpahsis the operation e.g. append and remove unnecessary `…` to avoid HCL syntax error.
