### PR TITLE
chore(scripts): add debug commands for scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 
 - Add `terramate.config.experiments` configuration to enable experimental features.
 - Add support for statuses `ok, failed, drifted and healthy` to the `--experimental-status` flag.
+- Add experimental `script` configuration block.
+- Add `terramate experimental script list` to list scripts visible in current directory.
+- Add `terramate experimental script tree` to show a tree view of scripts visible in current directory.
+- Add `terramate experimental script info <scriptname>` to show details about a script.
 
 ### Fixed
 

--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -222,6 +222,14 @@ type cliSpec struct {
 				} `cmd:"" help:"show drifts"`
 			} `cmd:"" help:"manage cloud drifts"`
 		} `cmd:"" help:"Terramate Cloud commands"`
+
+		Script struct {
+			List struct{} `cmd:"" help:"Show a list of all scripts in the current directory"`
+			Tree struct{} `cmd:"" help:"Show a tree of all scripts in the current directory"`
+			Info struct {
+				Labels []string `arg:"" name:"labels" passthrough:"" help:"Name of the script"`
+			} `cmd:"" help:"Show detailed information about a script"`
+		} `cmd:"" help:"Terramate Script commands"`
 	} `cmd:"" help:"Experimental features (may change or be removed in the future)"`
 }
 
@@ -575,6 +583,12 @@ func (c *cli) run() {
 		c.cloudInfo()
 	case "experimental cloud drift show":
 		c.cloudDriftShow()
+	case "experimental script list":
+		c.printScriptList()
+	case "experimental script tree":
+		c.printScriptTree()
+	case "experimental script info <labels>":
+		c.printScriptInfo()
 	default:
 		log.Fatal().Msg("unexpected command sequence")
 	}

--- a/cmd/terramate/cli/script_info.go
+++ b/cmd/terramate/cli/script_info.go
@@ -1,0 +1,160 @@
+// Copyright 2023 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+package cli
+
+import (
+	"sort"
+
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/terramate-io/terramate/config"
+	"github.com/terramate-io/terramate/hcl"
+	"github.com/terramate-io/terramate/hcl/ast"
+	"golang.org/x/exp/maps"
+	"golang.org/x/exp/slices"
+)
+
+func (c *cli) printScriptInfo() {
+	labels := c.parsedArgs.Experimental.Script.Info.Labels
+
+	stacks, err := c.computeSelectedStacks(false)
+	if err != nil {
+		fatal(err, "computing selected stacks")
+	}
+
+	m := newScriptsMatcher(labels)
+	m.Search(c.cfg(), stacks)
+
+	for _, x := range m.Results {
+		c.output.MsgStdOut("Definition: %v", x.ScriptCfg.Range)
+		c.output.MsgStdOut("Description: %v", formatScriptDescription(x.ScriptCfg))
+
+		if len(x.Stacks) > 0 {
+			c.output.MsgStdOut("Stacks:")
+			for _, st := range x.Stacks {
+				c.output.MsgStdOut("  %v", st.Dir())
+			}
+		} else {
+			c.output.MsgStdOut("Stacks: (none)")
+		}
+
+		c.output.MsgStdOut("Jobs:")
+		for _, job := range x.ScriptCfg.Jobs {
+			for cmdIdx, cmd := range formatScriptJob(job) {
+				if cmdIdx == 0 {
+					c.output.MsgStdOut("  * %v", cmd)
+				} else {
+					c.output.MsgStdOut("    %v", cmd)
+				}
+			}
+		}
+
+		c.output.MsgStdOut("")
+	}
+}
+
+type scriptInfoEntry struct {
+	ScriptCfg *hcl.Script
+	Stacks    config.List[*config.SortableStack]
+}
+
+type scriptsMatcher struct {
+	labels []string
+
+	Results []*scriptInfoEntry
+}
+
+func newScriptsMatcher(labels []string) *scriptsMatcher {
+	return &scriptsMatcher{
+		labels:  labels,
+		Results: nil,
+	}
+}
+
+func (m *scriptsMatcher) Search(cfg *config.Root, stacks config.List[*config.SortableStack]) {
+	rootScope := make(config.List[*config.SortableStack], len(stacks))
+	copy(rootScope, stacks)
+
+	m.searchRecursive(cfg.Tree(), &rootScope)
+}
+
+func tryGetScriptByName(cfg *config.Tree, labels []string) *hcl.Script {
+	for _, s := range cfg.Node.Scripts {
+		if slices.Equal(s.Labels, labels) {
+			return s
+		}
+	}
+	return nil
+}
+
+func sortedKeys[V any](m map[string]V) []string {
+	ks := maps.Keys(m)
+	sort.Strings(ks)
+	return ks
+}
+
+func (m *scriptsMatcher) searchRecursive(cfg *config.Tree, scope *config.List[*config.SortableStack]) {
+	scriptCfg := tryGetScriptByName(cfg, m.labels)
+	if scriptCfg != nil {
+		m.addResult(cfg, scriptCfg, scope)
+	} else {
+		for _, k := range sortedKeys(cfg.Children) {
+			m.searchRecursive(cfg.Children[k], scope)
+		}
+	}
+}
+
+func (m *scriptsMatcher) addResult(cfg *config.Tree, scriptCfg *hcl.Script, scope *config.List[*config.SortableStack]) {
+	outerScope := config.List[*config.SortableStack]{}
+	innerScope := config.List[*config.SortableStack]{}
+
+	cfgdir := cfg.Dir()
+	for _, st := range *scope {
+		stackdir := st.Dir()
+
+		if stackdir.HasDirPrefix(cfgdir.String()) {
+			innerScope = append(innerScope, st)
+		} else {
+			outerScope = append(outerScope, st)
+		}
+	}
+
+	// Modify the current scope
+	*scope = outerScope
+
+	newEntry := &scriptInfoEntry{
+		ScriptCfg: scriptCfg,
+		// This may be updated at a deeper level as we move stacks to children
+		Stacks: innerScope,
+	}
+	m.Results = append(m.Results, newEntry)
+
+	for _, k := range sortedKeys(cfg.Children) {
+		m.searchRecursive(cfg.Children[k], &newEntry.Stacks)
+	}
+}
+
+func formatScriptDescription(cfg *hcl.Script) string {
+	return string(ast.TokensForExpression(cfg.Description.Expr).Bytes())
+}
+
+func formatScriptJob(job *hcl.ScriptJob) []string {
+	if job.Commands != nil {
+		switch e := job.Commands.Expr.(type) {
+		case *hclsyntax.TupleConsExpr:
+			commands := []string{}
+			for _, cmd := range e.Exprs {
+				commands = append(commands, string(ast.TokensForExpression(cmd).Bytes()))
+			}
+			return commands
+
+		default:
+			return []string{string(ast.TokensForExpression(e).Bytes())}
+		}
+
+	} else if job.Command != nil {
+		return []string{string(ast.TokensForExpression(job.Command.Expr).Bytes())}
+	}
+
+	return []string{}
+}

--- a/cmd/terramate/cli/script_list.go
+++ b/cmd/terramate/cli/script_list.go
@@ -1,0 +1,93 @@
+// Copyright 2023 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+package cli
+
+import (
+	"github.com/terramate-io/terramate/config"
+	"github.com/terramate-io/terramate/hcl"
+	prj "github.com/terramate-io/terramate/project"
+)
+
+type scriptListEntry struct {
+	ScriptCfg *hcl.Script
+	Dir       string
+	DefCount  int
+}
+
+type scriptListMap map[string]*scriptListEntry
+
+func (c *cli) printScriptList() {
+	srcpath := prj.PrjAbsPath(c.rootdir(), c.wd())
+
+	cfg, found := c.cfg().Lookup(srcpath)
+	if !found {
+		return
+	}
+
+	entries := scriptListMap{}
+
+	addParentScriptListEntries(cfg, entries)
+	addChildScriptListEntries(cfg, entries)
+
+	for _, name := range sortedKeys(entries) {
+		entry := entries[name]
+
+		c.output.MsgStdOut("%v", name)
+		c.output.MsgStdOut("  %v", formatScriptDescription(entry.ScriptCfg))
+
+		c.output.MsgStdOut("  Defined at %v", entry.Dir)
+
+		if entry.DefCount > 1 {
+			c.output.MsgStdOut("    (+%v more)", entry.DefCount-1)
+		}
+
+		c.output.MsgStdOut("")
+	}
+}
+
+func addParentScriptListEntries(cfg *config.Tree, entries scriptListMap) {
+	for _, sc := range cfg.Node.Scripts {
+		scriptname := sc.Name()
+		defcount := 1
+		olddef := entries[scriptname]
+		if olddef != nil {
+			defcount = olddef.DefCount + 1
+		}
+
+		// Towards parents we replace child definitions
+		entries[scriptname] = &scriptListEntry{
+			ScriptCfg: sc,
+			Dir:       cfg.Dir().String(),
+			DefCount:  defcount,
+		}
+	}
+
+	if cfg.Parent != nil {
+		addParentScriptListEntries(cfg.Parent, entries)
+	}
+}
+
+func addChildScriptListEntries(cfg *config.Tree, entries scriptListMap) {
+	for _, k := range sortedKeys(cfg.Children) {
+		childCfg := cfg.Children[k]
+		for _, sc := range childCfg.Node.Scripts {
+			scriptname := sc.Name()
+
+			olddef := entries[scriptname]
+			if olddef != nil {
+				// Towards children we keep parent definitions
+				olddef.DefCount++
+				continue
+			}
+
+			entries[scriptname] = &scriptListEntry{
+				ScriptCfg: sc,
+				Dir:       childCfg.Dir().String(),
+				DefCount:  1,
+			}
+		}
+
+		addChildScriptListEntries(childCfg, entries)
+	}
+}

--- a/cmd/terramate/cli/script_tree.go
+++ b/cmd/terramate/cli/script_tree.go
@@ -1,0 +1,170 @@
+// Copyright 2023 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+package cli
+
+import (
+	"fmt"
+	"io"
+	"path"
+	"sort"
+	"strings"
+
+	"github.com/fatih/color"
+	"github.com/terramate-io/terramate/config"
+	"github.com/terramate-io/terramate/hcl"
+	prj "github.com/terramate-io/terramate/project"
+	"golang.org/x/exp/slices"
+)
+
+func (c *cli) printScriptTree() {
+	srcpath := prj.PrjAbsPath(c.rootdir(), c.wd())
+
+	cfg, found := c.cfg().Lookup(srcpath)
+	if !found {
+		return
+	}
+
+	rootNode, topNode := addParentScriptTreeNodes(cfg, nil, true)
+	addChildScriptTreeNodes(cfg, topNode)
+
+	var sb strings.Builder
+	rootNode.format(&sb, "", nil)
+	c.output.MsgStdOut(sb.String())
+}
+
+type scriptsTreeNode struct {
+	DirName  string
+	IsStack  bool
+	Scripts  []*hcl.Script
+	Children []*scriptsTreeNode
+	Parent   *scriptsTreeNode
+	Visible  bool
+}
+
+func (node *scriptsTreeNode) format(w io.Writer, prefix string, parentScripts []string) {
+	stackColor := color.New(color.FgGreen).SprintFunc()
+	scriptColor := color.New(color.FgYellow).SprintFunc()
+	parentScriptColor := color.New(color.Faint).SprintFunc()
+
+	var text string
+	if node.DirName != "" {
+		text += node.DirName
+	} else {
+		text += "/"
+	}
+
+	if node.IsStack {
+		fmt.Fprintln(w, "#"+stackColor(text))
+	} else {
+		fmt.Fprintln(w, text)
+	}
+
+	visibleChildren := make([]*scriptsTreeNode, 0, len(node.Children))
+	for _, child := range node.Children {
+		if child.Visible {
+			visibleChildren = append(visibleChildren, child)
+		}
+	}
+
+	blockPrefix := prefix
+	if len(visibleChildren) > 0 {
+		blockPrefix += "│ "
+	} else {
+		blockPrefix += "  "
+	}
+
+	for _, sc := range node.Scripts {
+		desc := formatScriptDescription(sc)
+		fmt.Fprintln(w, blockPrefix+"* "+scriptColor(sc.Name()+": "+desc))
+	}
+
+	if node.IsStack {
+		for _, p := range parentScripts {
+			found := slices.ContainsFunc(node.Scripts,
+				func(a *hcl.Script) bool {
+					return a.Name() == p
+				})
+			if !found {
+				fmt.Fprintln(w, blockPrefix+parentScriptColor("~ "+p))
+			}
+		}
+	}
+
+	for _, e := range node.Scripts {
+		if !slices.Contains(parentScripts, e.Name()) {
+			parentScripts = append(parentScripts, e.Name())
+		}
+	}
+
+	sort.Strings(parentScripts)
+
+	for i, child := range visibleChildren {
+		if i == len(visibleChildren)-1 {
+			fmt.Fprint(w, prefix+"└── ")
+			child.format(w, prefix+"    ", parentScripts)
+		} else {
+			fmt.Fprint(w, prefix+"├── ")
+			child.format(w, prefix+"│   ", parentScripts)
+		}
+	}
+}
+
+func addParentScriptTreeNodes(cfg *config.Tree, cur *scriptsTreeNode, selected bool) (root *scriptsTreeNode, top *scriptsTreeNode) {
+	_, dirname := path.Split(cfg.Dir().String())
+	if dirname == "" {
+		dirname = "/"
+	}
+
+	thisNode := &scriptsTreeNode{
+		DirName: dirname,
+		IsStack: selected && cfg.IsStack(),
+		Visible: true,
+	}
+
+	thisNode.Scripts = append(thisNode.Scripts, cfg.Node.Scripts...)
+
+	if cur != nil {
+		thisNode.Children = []*scriptsTreeNode{cur}
+		cur.Parent = thisNode
+	}
+
+	if cfg.Parent != nil {
+		rootNode, _ := addParentScriptTreeNodes(cfg.Parent, thisNode, false)
+		return rootNode, thisNode
+	}
+
+	return thisNode, thisNode
+}
+
+func addChildScriptTreeNodes(cfg *config.Tree, cur *scriptsTreeNode) {
+	for _, k := range sortedKeys(cfg.Children) {
+		childCfg := cfg.Children[k]
+		_, dirname := path.Split(childCfg.Dir().String())
+		if dirname == "" {
+			dirname = "/"
+		}
+
+		isStack := childCfg.IsStack()
+
+		if isStack {
+			p := cur
+			for p != nil && !p.Visible {
+				p.Visible = true
+				p = p.Parent
+			}
+		}
+
+		childNode := &scriptsTreeNode{
+			DirName: dirname,
+			IsStack: isStack,
+			Visible: isStack,
+			Parent:  cur,
+		}
+
+		childNode.Scripts = append(childNode.Scripts, childCfg.Node.Scripts...)
+		cur.Children = append(cur.Children, childNode)
+
+		addChildScriptTreeNodes(childCfg, childNode)
+	}
+}

--- a/cmd/terramate/e2etests/core/script_info_test.go
+++ b/cmd/terramate/e2etests/core/script_info_test.go
@@ -1,0 +1,184 @@
+// Copyright 2023 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+package core_test
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	. "github.com/terramate-io/terramate/cmd/terramate/e2etests/internal/runner"
+
+	"github.com/terramate-io/terramate/test/sandbox"
+)
+
+func TestScriptInfo(t *testing.T) {
+	t.Parallel()
+
+	layout := []string{"d:stacks"}
+
+	addStackWithScripts := func(path string, scripts []string) {
+		layout = append(layout, fmt.Sprintf("s:%s", path))
+
+		var content string
+
+		for _, name := range scripts {
+			content += fmt.Sprintf(`script "%s" {
+				description = "%s at /%s"
+				job {
+					commands = [
+						["echo", "1a"],
+						["echo", "1b"]
+					]
+				}
+				job {
+					command = ["echo", "2"]
+				}
+			}
+			`, name, name, path)
+		}
+
+		layout = append(layout, fmt.Sprintf(`f:%s/script.tm:%s`, path, content))
+	}
+
+	mkExpected := func(name, path, loc string, stacks []string) string {
+		stackstr := ""
+		for _, s := range stacks {
+			stackstr += fmt.Sprintf("\n  %s", s)
+		}
+		if stackstr == "" {
+			stackstr = " (none)"
+		}
+
+		return fmt.Sprintf(`Definition: /%s/script.tm:%s
+Description: "%s at /%s"
+Stacks:%s
+Jobs:
+  * ["echo","1a"]
+    ["echo","1b"]
+  * ["echo","2"]
+
+`, path, loc, name, path, stackstr)
+	}
+
+	addStackWithScripts("stacks/a", []string{"deploy", "other"})
+	addStackWithScripts("stacks/a/a1", []string{"other2"})
+	addStackWithScripts("stacks/a/a1/a2", []string{"deploy"})
+	addStackWithScripts("stacks/b", []string{"deploy", "other"})
+	addStackWithScripts("stacks/bb", []string{"other3"})
+
+	s := sandbox.New(t)
+	s.BuildTree(layout)
+
+	s.RootEntry().CreateConfig(`
+		terramate {
+			config {
+				experiments = ["scripts"]
+			}
+	  	}
+	`)
+
+	git := s.Git()
+	git.CommitAll("everything")
+
+	type testcase struct {
+		script string
+		dir    string
+		want   RunExpected
+	}
+
+	for _, tc := range []testcase{
+		{
+			script: "not_found",
+			dir:    "",
+			want: RunExpected{
+				Stdout: "",
+			},
+		},
+		{
+			script: "deploy",
+			dir:    "",
+			want: RunExpected{
+				Stdout: mkExpected("deploy", "stacks/a", "1,1-12,5", []string{
+					"/stacks/a",
+					"/stacks/a/a1",
+				}) + mkExpected("deploy", "stacks/a/a1/a2", "1,1-12,5", []string{
+					"/stacks/a/a1/a2",
+				}) + mkExpected("deploy", "stacks/b", "1,1-12,5", []string{
+					"/stacks/b",
+				}),
+			},
+		},
+		{
+			script: "deploy",
+			dir:    "stacks/a/a1",
+			want: RunExpected{
+				Stdout: mkExpected("deploy", "stacks/a", "1,1-12,5", []string{
+					"/stacks/a/a1",
+				}) + mkExpected("deploy", "stacks/a/a1/a2", "1,1-12,5", []string{
+					"/stacks/a/a1/a2",
+				}) + mkExpected("deploy", "stacks/b", "1,1-12,5", []string{}),
+			},
+		},
+		{
+			script: "deploy",
+			dir:    "stacks/a/a1/a2",
+			want: RunExpected{
+				Stdout: mkExpected("deploy", "stacks/a", "1,1-12,5", []string{}) +
+					mkExpected("deploy", "stacks/a/a1/a2", "1,1-12,5", []string{
+						"/stacks/a/a1/a2",
+					}) + mkExpected("deploy", "stacks/b", "1,1-12,5", []string{}),
+			},
+		},
+		{
+			script: "deploy",
+			dir:    "stacks/b",
+			want: RunExpected{
+				Stdout: mkExpected("deploy", "stacks/a", "1,1-12,5", []string{}) +
+					mkExpected("deploy", "stacks/a/a1/a2", "1,1-12,5", []string{}) +
+					mkExpected("deploy", "stacks/b", "1,1-12,5", []string{
+						"/stacks/b",
+					}),
+			},
+		},
+		{
+			script: "other2",
+			dir:    "stacks/b",
+			want: RunExpected{
+				Stdout: mkExpected("other2", "stacks/a/a1", "1,1-12,5", []string{}),
+			},
+		},
+		{
+			script: "other3",
+			dir:    "stacks/bb",
+			want: RunExpected{
+				Stdout: mkExpected("other3", "stacks/bb", "1,1-12,5", []string{
+					"/stacks/bb",
+				}),
+			},
+		},
+		{
+			script: "other3",
+			dir:    "stacks/b",
+			want: RunExpected{
+				Stdout: mkExpected("other3", "stacks/bb", "1,1-12,5", []string{}),
+			},
+		},
+	} {
+		tc := tc
+		name := fmt.Sprintf("%v in %v", tc.script, tc.dir)
+		name = strings.ReplaceAll(name, "/", "_")
+		t.Run(name, func(t *testing.T) {
+			wd := s.RootDir()
+			if tc.dir != "" {
+				wd = filepath.Join(wd, tc.dir)
+			}
+
+			cli := NewCLI(t, wd)
+			AssertRunResult(t, cli.Run("experimental", "script", "info", "--", tc.script), tc.want)
+		})
+
+	}
+}

--- a/cmd/terramate/e2etests/core/script_list_test.go
+++ b/cmd/terramate/e2etests/core/script_list_test.go
@@ -1,0 +1,150 @@
+// Copyright 2023 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+package core_test
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	. "github.com/terramate-io/terramate/cmd/terramate/e2etests/internal/runner"
+
+	"github.com/terramate-io/terramate/test/sandbox"
+)
+
+func TestScriptList(t *testing.T) {
+	t.Parallel()
+
+	layout := []string{"d:stacks"}
+
+	addStackWithScripts := func(path string, scripts []string) {
+		layout = append(layout,
+			fmt.Sprintf("s:%s", path))
+
+		var content string
+
+		for _, name := range scripts {
+			content += fmt.Sprintf(`script "%s" {
+				description = "%s at /%s"
+				job {
+					command = ["echo", "hello"]
+				}
+			}
+			`, name, name, path)
+		}
+
+		layout = append(layout,
+			fmt.Sprintf(`f:%s/script.tm:%s`, path, content))
+	}
+
+	mkExpected := func(name, path string, count int) string {
+		if count != 0 {
+			return fmt.Sprintf(`%s
+  "%s at /%s"
+  Defined at /%s
+    (+%d more)
+
+`, name, name, path, path, count)
+
+		}
+
+		return fmt.Sprintf(`%s
+  "%s at /%s"
+  Defined at /%s
+
+`, name, name, path, path)
+	}
+
+	addStackWithScripts("stacks/a", []string{"deploy", "obliterate"})
+	addStackWithScripts("stacks/b", []string{"deploy", "crush"})
+	addStackWithScripts("stacks/b/b1", []string{"deploy", "crush"})
+	addStackWithScripts("stacks/b/b1/b2", []string{"deploy", "break"})
+	addStackWithScripts("stacks/c", []string{"deploy"})
+
+	s := sandbox.New(t)
+	s.BuildTree(layout)
+
+	s.RootEntry().CreateConfig(`
+		terramate {
+			config {
+				experiments = ["scripts"]
+			}
+	  	}
+	`)
+
+	git := s.Git()
+	git.CommitAll("everything")
+
+	type testcase struct {
+		dir  string
+		want RunExpected
+	}
+
+	for _, tc := range []testcase{
+		{
+			dir: "",
+			want: RunExpected{
+				Stdout: mkExpected("break", "stacks/b/b1/b2", 0) +
+					mkExpected("crush", "stacks/b", 1) +
+					mkExpected("deploy", "stacks/a", 4) +
+					mkExpected("obliterate", "stacks/a", 0),
+			},
+		},
+		{
+			dir: "stacks",
+			want: RunExpected{
+				Stdout: mkExpected("break", "stacks/b/b1/b2", 0) +
+					mkExpected("crush", "stacks/b", 1) +
+					mkExpected("deploy", "stacks/a", 4) +
+					mkExpected("obliterate", "stacks/a", 0),
+			},
+		},
+		{
+			dir: "stacks/a",
+			want: RunExpected{
+				Stdout: mkExpected("deploy", "stacks/a", 0) +
+					mkExpected("obliterate", "stacks/a", 0),
+			},
+		},
+		{
+			dir: "stacks/b",
+			want: RunExpected{
+				Stdout: mkExpected("break", "stacks/b/b1/b2", 0) +
+					mkExpected("crush", "stacks/b", 1) +
+					mkExpected("deploy", "stacks/b", 2),
+			},
+		},
+		{
+			dir: "stacks/b/b1",
+			want: RunExpected{
+				Stdout: mkExpected("break", "stacks/b/b1/b2", 0) +
+					mkExpected("crush", "stacks/b", 1) +
+					mkExpected("deploy", "stacks/b", 2),
+			},
+		},
+		{
+			dir: "stacks/b/b1/b2",
+			want: RunExpected{
+				Stdout: mkExpected("break", "stacks/b/b1/b2", 0) +
+					mkExpected("crush", "stacks/b", 1) +
+					mkExpected("deploy", "stacks/b", 2),
+			},
+		},
+		{
+			dir: "stacks/c",
+			want: RunExpected{
+				Stdout: mkExpected("deploy", "stacks/c", 0),
+			},
+		},
+	} {
+		tc := tc
+		wd := s.RootDir()
+		if tc.dir != "" {
+			wd = filepath.Join(wd, tc.dir)
+		}
+
+		cli := NewCLI(t, wd)
+		AssertRunResult(t, cli.Run("experimental", "script", "list"), tc.want)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/cli/go-gh/v2 v2.1.0
 	github.com/cli/safeexec v1.0.0
 	github.com/emicklei/dot v0.16.0
+	github.com/fatih/color v1.16.0
 	github.com/go-git/go-git/v5 v5.9.0
 	github.com/go-test/deep v1.1.0
 	github.com/golang-jwt/jwt v3.2.2+incompatible
@@ -41,7 +42,7 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
-	github.com/mattn/go-isatty v0.0.19 // indirect
+	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/segmentio/asm v1.1.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -160,6 +160,8 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/evanphx/json-patch v0.0.0-20190203023257-5858425f7550/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/fatih/color v1.16.0 h1:zmkK9Ngbjj+K0yRhTVONQh1p/HknKYSlNT+vZCzyokM=
+github.com/fatih/color v1.16.0/go.mod h1:fL2Sau1YI5c0pdGEVCbKQbLXB6edEj1ZgiY4NijnWvE=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -392,8 +394,8 @@ github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcME
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
-github.com/mattn/go-isatty v0.0.19 h1:JITubQf0MOLdlGRuRq+jtsDlekdYPia9ZFsB8h/APPA=
-github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
+github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-shellwords v1.0.4/go.mod h1:3xCvwCdWdlDJUrvuMn7Wuy9eWs4pE8vqg+NOMyg4B2o=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=

--- a/hcl/hcl_script.go
+++ b/hcl/hcl_script.go
@@ -4,6 +4,8 @@
 package hcl
 
 import (
+	"strings"
+
 	"github.com/terramate-io/terramate/errors"
 	"github.com/terramate-io/terramate/hcl/ast"
 	"github.com/terramate-io/terramate/hcl/info"
@@ -61,6 +63,24 @@ func NewScriptCommand(attr ast.Attribute) *Command {
 func NewScriptCommands(attr ast.Attribute) *Commands {
 	cmds := Commands(attr)
 	return &cmds
+}
+
+// Name returns the formatted script name
+func (sc *Script) Name() string {
+	var b strings.Builder
+	for i, e := range sc.Labels {
+		if i != 0 {
+			_ = b.WriteByte(' ')
+		}
+		if strings.Contains(e, " ") {
+			_ = b.WriteByte('"')
+			_, _ = b.WriteString(e)
+			_ = b.WriteByte('"')
+		} else {
+			_, _ = b.WriteString(e)
+		}
+	}
+	return b.String()
 }
 
 func (p *TerramateParser) parseScriptBlock(block *ast.Block) (*Script, error) {

--- a/project/project.go
+++ b/project/project.go
@@ -64,6 +64,12 @@ func (p Path) HasPrefix(s string) bool {
 	return strings.HasPrefix(p.String(), s)
 }
 
+// HasDirPrefix tests whether p begins with a directory prefix s.
+// s must not end with a trailing "/".
+func (p Path) HasDirPrefix(s string) bool {
+	return s == p.String() || strings.HasPrefix(p.String(), s+"/")
+}
+
 // Join joins the pathstr path into p. See [path.Join] for the underlying
 // implementation.
 func (p Path) Join(pathstr string) Path {


### PR DESCRIPTION
## What this PR does / why we need it:

Three new experimental commands are added, related to the new scripts feature. For now, they are intended for debugging as they allow inspecting the script hierarchy.

#### script-list

Shows a list of all available scripts in the current directory. If there are multiple definitions, it uses the most parent definition, or the first sibling in case all definitions are on the same level.

Usage:
`terramate experimental script list`

Output:
```
deploy
  some description
  Defined at /
    (+1 more)

stagify
  do something
  Defined at /stacks/stage

validate
  some description
  Defined at /
    (+1 more)
```

#### script info

Shows information about _a specific script_. For each definition, it lists the jobs and affected stacks.

Usage: 
`terramate experimental script info -- validate`

Output:
```
Definition: /scripts.tm.hcl:11,1-24,2
Description: some description
Stacks:
  /stacks/prod
  /stacks/prod/backend
  /stacks/prod/frontend
  /stacks/stage
  /stacks/stage/backend
  /stacks/stage/frontend
Jobs:
  * ["echo","hello"]
    ["echo","bye"]
  * ["nono","nono"]

Definition: /stacks/dev/scripts.tm.hcl:1,1-9,2
Description: overriding validate
Stacks:
  /stacks/dev
Jobs:
  * ["echo","hello"]
    ["echo","bye"]
```

#### script tree

Shows a tree of all available scripts in the current directory and also which stacks are in the current selection scope.

Usage:
`terramate experimental script tree`

Output:
```
/
│ * deploy: some description
│ * validate: some description
└── stacks
    └── stage
        │ # stage
        │ * deploy: overriding deploy
        │ * stagify: do something
        │ ~ validate
        ├── frontend
        │     # frontend
        │     ~ deploy
        │     ~ stagify
        │     ~ validate
        └── backend
              # backend
              ~ deploy
              ~ stagify
              ~ validate
```

## Special notes for your reviewer:

* I did not add any tests for `script tree` since this is really just intended for debugging for now.

## Does this PR introduce a user-facing change?
<!--
If no, write "no" in the block below.
If yes, please explain the change and update documentation and the CHANGELOG.md file accordingly.
-->
No. It adds three new commands, but they are all categorized as experimental.