### PR TITLE
chore(perf): add benchmark for tm_ternary().

### DIFF
--- a/stdlib/funcs_bench_test.go
+++ b/stdlib/funcs_bench_test.go
@@ -1,0 +1,29 @@
+// Copyright 2023 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+package stdlib_test
+
+import (
+	"testing"
+
+	"github.com/madlambda/spells/assert"
+	"github.com/terramate-io/terramate/hcl/ast"
+	"github.com/terramate-io/terramate/hcl/eval"
+	"github.com/terramate-io/terramate/stdlib"
+	"github.com/terramate-io/terramate/test"
+)
+
+func BenchmarkTmTernary(b *testing.B) {
+	b.StopTimer()
+	evalctx := eval.NewContext(stdlib.Functions(test.TempDir(b)))
+	expr, err := ast.ParseExpression(`tm_ternary(false, tm_unknown_function(), "result")`, `bench-test`)
+	assert.NoError(b, err)
+	b.StartTimer()
+	for n := 0; n < b.N; n++ {
+		v, err := evalctx.Eval(expr)
+		assert.NoError(b, err)
+		if got := v.AsString(); got != "result" {
+			b.Fatalf("unexpected value: %s", got)
+		}
+	}
+}


### PR DESCRIPTION
## What this PR does / why we need it:

Adds benchmark for the current implementation of `tm_ternary()`.
It needs to be introduced in separate PR so we can use [benchcheck](https://pkg.go.dev/github.com/madlambda/benchcheck) to compare the performance of `main` versus other branches.

## Which issue(s) this PR fixes:
none

## Special notes for your reviewer:

- An upcoming PR will improve `tm_ternary()` performance by indirectly disabling type checking.

## Does this PR introduce a user-facing change?
```
no
```
