### PR TITLE
chore(perf): optimises tm_ternary by disabling type checking.

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -28,7 +28,7 @@ jobs:
         id: benchmark
         run: |
           echo "result<<EOF" >> $GITHUB_OUTPUT
-          echo "$(make bench/check new=${{ github.event.pull_request.head.sha }})" >> $GITHUB_OUTPUT
+          echo "$(make bench/check new=${{ github.event.pull_request.head.sha }} old=${{ github.event.pull_request.base.ref }})" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
       
       - uses: marocchino/sticky-pull-request-comment@v2

--- a/makefiles/common.mk
+++ b/makefiles/common.mk
@@ -116,7 +116,7 @@ bench/check: allocdelta="+20%"
 bench/check: timedelta="+20%"
 bench/check: name=github.com/terramate-io/terramate
 bench/check: pkg?=./...
-bench/check: old=main
+bench/check: old?=main
 bench/check: new?=$(shell git rev-parse HEAD)
 bench/check:
 	@$(BENCH_CHECK) -mod $(name) -pkg $(pkg) -go-test-flags "-benchmem,-count=20,-run=Bench" \

--- a/stdlib/ternary.go
+++ b/stdlib/ternary.go
@@ -33,13 +33,7 @@ func TernaryFunc() function.Function {
 				Type: customdecode.ExpressionClosureType,
 			},
 		},
-		Type: func(args []cty.Value) (cty.Type, error) {
-			v, err := ternary(args[0], args[1], args[2])
-			if err != nil {
-				return cty.NilType, err
-			}
-			return v.Type(), nil
-		},
+		Type: function.StaticReturnType(cty.DynamicPseudoType),
 		Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
 			return ternary(args[0], args[1], args[2])
 		},


### PR DESCRIPTION
## What this PR does / why we need it:

It optimises the `tm_ternary()` funcall by declaring the function return type as a static `cty.DynamicPseudoType`. This is safe because Terramate doesn't do any schema validation using Hashicorp evaluator.

Benchmark result (extracted from the comment below):

```
metric: time/op
TmTernary-4: old 3.48µs ± 1%: new 2.59µs ± 1%: delta: -25.33%

metric: alloc/op
TmTernary-4: old 1.61kB ± 0%: new 1.11kB ± 0%: delta: -30.85%

metric: allocs/op
TmTernary-4: old 40.0 ± 0%: new 26.0 ± 0%: delta: -35.00%
```

## Which issue(s) this PR fixes:

## Special notes for your reviewer:

- The `make bench/check` target was changed to support configuring the `old` ref.
- The benchmark.yml workflow was changed to use the github base ref so we can compare benchmark between PRs as well.

## Does this PR introduce a user-facing change?
```
no
```
