### PR TITLE
chore(perf): add benchmark to the tm_try() funcall.

### DIFF
--- a/stdlib/funcs_bench_test.go
+++ b/stdlib/funcs_bench_test.go
@@ -27,3 +27,18 @@ func BenchmarkTmTernary(b *testing.B) {
 		}
 	}
 }
+
+func BenchmarkTmTry(b *testing.B) {
+	b.StopTimer()
+	evalctx := eval.NewContext(stdlib.Functions(test.TempDir(b)))
+	expr, err := ast.ParseExpression(`tm_try(tm_unknown_function(), "result")`, `bench-test`)
+	assert.NoError(b, err)
+	b.StartTimer()
+	for n := 0; n < b.N; n++ {
+		v, err := evalctx.Eval(expr)
+		assert.NoError(b, err)
+		if got := v.AsString(); got != "result" {
+			b.Fatalf("unexpected value: %s", got)
+		}
+	}
+}


### PR DESCRIPTION
## What this PR does / why we need it:

Adds benchmark for the `tm_try()` function. This is needed by #1279 

## Which issue(s) this PR fixes:

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
no
```
