### PR TITLE
docs: add a new section for editor plugins

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -263,6 +263,13 @@ export default defineConfig({
             { text: 'version', link: '/cli/cmdline/version' },
           ],
         },
+        {
+          text: '💻 Editor Plugins',
+          collapsed: false,
+          items: [
+            { text: 'Overview', link: '/cli/editor-plugins/index' },
+          ],
+        },
         // {
         //   text: 'Misc',
         //   collapsed: false,

--- a/docs/cli/editor-plugins/index.md
+++ b/docs/cli/editor-plugins/index.md
@@ -1,0 +1,22 @@
+---
+title: Editor Plugins
+description: Learn how to use the terramate plugins for various text editors.
+
+prev:
+  text: 'Commands (CLI)'
+  link: '/cli/cmdline/'
+
+next:
+  text: 'Guides & Examples'
+  link: '/cli/guides/'
+---
+
+# Editor Plugins
+
+Terramate provides the following plugins to enhance the editing experience:
+
+* [vscode-terramate](https://github.com/terramate-io/vscode-terramate)
+* [vim-terramate](https://github.com/terramate-io/vim-terramate)
+
+These plugins utilize the Terramate Language Server to provide diagnostics about
+the terramate configuration.


### PR DESCRIPTION


## What this PR does / why we need it:

This PR adds a new section to the public documentation: 'Editor Plugins'. This section makes it easy for documentation readers to discover the {vscode,vim}-terramate extensions.

## Which issue(s) this PR fixes:

none

## Special notes for your reviewer:

* I kept the documentation text short intentionally so that users are encouraged to navigate to the respective plugin README to find installation instructions / features etc.  

## Does this PR introduce a user-facing change?

Yes, the [user-facing documentation](https://terramate.io/docs/cli) will be updated.
