### PR TITLE
fix: fail if scripts are redeclared.

### DIFF
--- a/hcl/hcl.go
+++ b/hcl/hcl.go
@@ -1733,6 +1733,14 @@ func (p *TerramateParser) parseTerramateSchema() (Config, error) {
 				continue
 			}
 
+			if other, found := findScript(config.Scripts, block.Labels); found {
+				errs.Append(
+					errors.E(ErrScriptRedeclared, block.DefRange(),
+						"script with labels %v defined at %q", block.Labels, other.Range.String()),
+				)
+				continue
+			}
+
 			scriptCfg, err := p.parseScriptBlock(block)
 			if err != nil {
 				errs.Append(err)

--- a/hcl/hcl_script.go
+++ b/hcl/hcl_script.go
@@ -7,12 +7,14 @@ import (
 	"github.com/terramate-io/terramate/errors"
 	"github.com/terramate-io/terramate/hcl/ast"
 	"github.com/terramate-io/terramate/hcl/info"
+	"golang.org/x/exp/slices"
 )
 
 // Errors returned during the HCL parsing of script block
 const (
 	ErrScriptNoLabels            errors.Kind = "terramate schema error: (script): must provide at least one label"
 	ErrScriptNoDesc              errors.Kind = "terramate schema error: (script): missing description"
+	ErrScriptRedeclared          errors.Kind = "terramate schema error: (script): multiple script blocks with same labels in the same directory"
 	ErrScriptUnrecognizedAttr    errors.Kind = "terramate schema error: (script): unrecognized attribute"
 	ErrScriptUnrecognizedBlock   errors.Kind = "terramate schema error: (script): unrecognized block"
 	ErrScriptNoCmds              errors.Kind = "terramate schema error: (script): missing command or commands"
@@ -110,7 +112,15 @@ func (p *TerramateParser) parseScriptBlock(block *ast.Block) (*Script, error) {
 	}
 
 	return parsedScript, nil
+}
 
+func findScript(scripts []*Script, target []string) (*Script, bool) {
+	for _, script := range scripts {
+		if slices.Equal(script.Labels, target) {
+			return script, true
+		}
+	}
+	return nil, false
 }
 
 func validateScriptJobBlock(block *ast.Block) (*ScriptJob, error) {

--- a/hcl/hcl_script_test.go
+++ b/hcl/hcl_script_test.go
@@ -165,6 +165,44 @@ func TestHCLScript(t *testing.T) {
 			},
 		},
 		{
+			name: "multiple scripts with same labels",
+			input: []cfgfile{
+				{
+					filename: "cfg.tm",
+					body: `
+					  terramate {
+						  config {
+							  experiments = ["scripts"]
+						  }
+					  }
+					`,
+				},
+				{
+					filename: "script.tm",
+					body: `
+					  script "a" "b" {
+						description = "some description"
+						job {
+						  command = ["echo", "hello"]
+						}
+					  }
+					  script "a" "b" {
+						description = "other description"
+						job {
+						  command = ["echo", "other command"]
+						}
+					  }
+					`,
+				},
+			},
+			want: want{
+				errs: []error{
+					errors.E(hcl.ErrScriptRedeclared,
+						Mkrange("script.tm", Start(8, 8, 136), End(8, 22, 150))),
+				},
+			},
+		},
+		{
 			name: "script with a description attr",
 			input: []cfgfile{
 				{


### PR DESCRIPTION
## What this PR does / why we need it:

When multiple `script` blocks are declared with the same set of labels in the same directory, no error is shown. Just the first script found is used, and the others are ignored.

## Which issue(s) this PR fixes:

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
no, because scripts have not been released yet.
```
