### PR TITLE
fix(parser): malformed error message.

### DIFF
--- a/hcl/hcl.go
+++ b/hcl/hcl.go
@@ -1162,7 +1162,7 @@ func assignSet(attr *hcl.Attribute, target *[]string, val cty.Value) error {
 		if _, ok := values[str]; ok {
 			errs.Append(errors.E(ErrTerramateSchema, attr.Expr.Range(),
 				"duplicated entry %q in the index %d of field %q of type set(string)",
-				str, attr.Name))
+				str, index, attr.Name))
 
 			continue
 		}


### PR DESCRIPTION
## What this PR does / why we need it:

The error for duplicated set(string) entries was malformed:

```
✗ ./bin/terramate list
2023-12-13T13:29:02Z ERR terramate schema error: duplicated entry "scripts" in the index %!d(string=experiments) of field %!q(MISSING) of type set(string) file=/Users/tiagodemoura/src/terramate/terramate.tm:23,19-41
20
```

## Which issue(s) this PR fixes:

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
no, because script feature is not released yet.
```
