### PR TITLE
chore: Replace the most annoying frist-time user error message

### DIFF
--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -462,7 +462,17 @@ func newCLI(version string, args []string, stdin io.Reader, stdout, stderr io.Wr
 	}
 
 	if !foundRoot {
-		log.Fatal().Msg("Project root not found. If you invoke Terramate inside a Git repository, Terramate will automatically assume the top level of your repository as the project root. If you use Terramate in a directory that isn't a Git repository, you must configure the project root by creating a terramate.tm.hcl configuration in the directory you wish to be the top-level of your Terramate project. For details please see https://terramate.io/docs/cli/configuration/project-config#project-configuration.")
+		output.MsgStdErr(`Error: Terramate was unable to detect a project root.
+
+Please ensure you run Terramate inside a Git repository or create a new one here by calling 'git init'.
+
+Using Terramate together with Git is the recommended way.
+
+Alternatively you can create a Terramate config to make the current directory the project root.
+
+Please see https://terramate.io/docs/cli/configuration/project-setup for details.
+`)
+		os.Exit(1)
 	}
 
 	err = prj.setDefaults()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/terramate-io/terramate/blob/main/CONTRIBUTING.md
2. If the PR is unfinished, mark it as draft: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request
3. Please update the PR title using the Conventional Commits convention: https://www.conventionalcommits.org/en/v1.0.0/
    Example: feat: add support for XYZ.
-->

## What this PR does / why we need it:

## Which issue(s) this PR fixes:
This is making first time use error message more actionable.

## Special notes for your reviewer:

run `terramate create` outside a Terramate Project.

## Does this PR introduce a user-facing change?
```
$ terramate create out-side-of-project
Error: Terramate was unable to detect a project root.

Please ensure you run Terramate inside a Git repository or create a new one here by calling 'git init'.

Using Terramate together with Git is the recommended way.

Alternatively you can create a Terramate config to make the current directory the project root.

Please see https://terramate.io/docs/cli/configuration/project-setup for details.

```
instead of
```
2023-12-13T15:28:13+01:00 FTL Project root not found. If you invoke Terramate inside a Git repository, Terramate will automatically assume the top level of your repository as the project root. If you use Terramate in a directory that isn't a Git repository, you must configure the project root by creating a terramate.tm.hcl configuration in the directory you wish to be the top-level of your Terramate project. For details please see https://terramate.io/docs/cli/configuration/project-config#project-configuration.
```
