### PR TITLE
fix: job command or commands items cannot be empty

### DIFF
--- a/config/script.go
+++ b/config/script.go
@@ -18,6 +18,7 @@ const (
 	ErrScriptInvalidTypeDesc     errors.Kind = "invalid type for script.description"
 	ErrScriptInvalidTypeCommand  errors.Kind = "invalid type for script.command"
 	ErrScriptInvalidTypeCommands errors.Kind = "invalid type for script.commands"
+	ErrScriptEmptyCmds           errors.Kind = "job command or commands evaluated to empty list"
 )
 
 // ScriptJob represents an evaluated job block
@@ -110,6 +111,10 @@ func evalScriptJobCommand(evalctx *eval.Context, expr hhcl.Expression, name stri
 			"%s should be a list(string) type", name)
 	}
 
+	if val.LengthInt() == 0 {
+		return nil, errors.E(ErrScriptEmptyCmds, expr.Range())
+	}
+
 	errs := errors.L()
 	evaluatedCommand := []string{}
 
@@ -146,6 +151,10 @@ func evalScriptJobCommands(evalctx *eval.Context, expr hhcl.Expression, name str
 			"%s should be a list(string) type", name)
 	}
 
+	if val.LengthInt() == 0 {
+		return nil, errors.E(ErrScriptEmptyCmds, expr.Range())
+	}
+
 	errs := errors.L()
 	evaluatedCommands := [][]string{}
 
@@ -159,6 +168,10 @@ func evalScriptJobCommands(evalctx *eval.Context, expr hhcl.Expression, name str
 				"field %s must be a list of list(string) but element %d has type %q",
 				name, index, elem.Type().FriendlyName()))
 			continue
+		}
+
+		if elem.LengthInt() == 0 {
+			return nil, errors.E(ErrScriptEmptyCmds, expr.Range(), "commands item %d is empty", index)
 		}
 
 		evaluatedCommand := []string{}

--- a/config/script_test.go
+++ b/config/script_test.go
@@ -213,6 +213,52 @@ func TestScriptEval(t *testing.T) {
 			wantErr: errors.E(config.ErrScriptInvalidTypeCommands),
 		},
 		{
+			name: "commands evaluating to empty list",
+			script: hcl.Script{
+				Labels: labels,
+				Description: hcl.NewScriptDescription(
+					makeAttribute(t, "description", `"some description"`)),
+				Jobs: []*hcl.ScriptJob{
+					{
+						Commands: makeCommands(t, `[]`),
+					},
+				},
+			},
+			wantErr: errors.E(config.ErrScriptEmptyCmds),
+		},
+		{
+			name: "commands item evaluating to empty list",
+			script: hcl.Script{
+				Labels: labels,
+				Description: hcl.NewScriptDescription(
+					makeAttribute(t, "description", `"some description"`)),
+				Jobs: []*hcl.ScriptJob{
+					{
+						Commands: makeCommands(t, `[
+							["echo", "hello"],
+							[],
+							["echo", "other"]
+						]`),
+					},
+				},
+			},
+			wantErr: errors.E(config.ErrScriptEmptyCmds),
+		},
+		{
+			name: "command evaluating to empty list",
+			script: hcl.Script{
+				Labels: labels,
+				Description: hcl.NewScriptDescription(
+					makeAttribute(t, "description", `"some description"`)),
+				Jobs: []*hcl.ScriptJob{
+					{
+						Command: makeCommand(t, `[]`),
+					},
+				},
+			},
+			wantErr: errors.E(config.ErrScriptEmptyCmds),
+		},
+		{
 			name: "commands attribute with functions and globals",
 			script: hcl.Script{
 				Labels: labels,


### PR DESCRIPTION
## What this PR does / why we need it:

The `experimental run-script` gives the panic below if a job definition has an empty commands list:

```
$ terramate experimental script run a b
Found a b defined at /cmd/cmd.tm:1,1-6,2 having 1 job(s)

/cmd/terramate/e2etests/cloud/interop/testdata/interop-stacks/basic-drift (job:0.0)>
panic: runtime error: index out of range [0] with length 0

goroutine 1 [running]:
github.com/terramate-io/terramate/cmd/terramate/cli.makeCommand({0x1017aa8c0?, 0x1?, 0x14000156888?}, {0x1400026cfc0?, 0x14000021080?}, {0x14000388000?, 0x14000156888?, 0x1010412ec?}, {0x1012c2558?, 0x1400018a008?}, ...)
	/Users/tiagodemoura/src/terramate/cmd/terramate/cli/run_script.go:128 +0x230
github.com/terramate-io/terramate/cmd/terramate/cli.(*cli).executeCommand(0x1400034bed0?, {0x1017aa8c0?, 0x1017aa8c0?, 0x0?}, {0x1400026cfc0?, 0x1400026c481?}, {0x14000388000?, 0x6?, 0x2?})
	/Users/tiagodemoura/src/terramate/cmd/terramate/cli/run_script.go:115 +0x68
github.com/terramate-io/terramate/cmd/terramate/cli.(*cli).runScript(0x14000297500)
	/Users/tiagodemoura/src/terramate/cmd/terramate/cli/run_script.go:101 +0xf2c
github.com/terramate-io/terramate/cmd/terramate/cli.(*cli).run(0x14000297500)
	/Users/tiagodemoura/src/terramate/cmd/terramate/cli/cli.go:601 +0x858
github.com/terramate-io/terramate/cmd/terramate/cli.Exec({0x10104b050, 0x9}, {0x1400018c130, 0x5, 0x5}, {0x1012c2538, 0x1400018a000}, {0x1012c2558, 0x1400018a008}, {0x1012c2558, ...})
	/Users/tiagodemoura/src/terramate/cmd/terramate/cli/cli.go:263 +0xb0
main.main()
	/Users/tiagodemoura/src/terramate/cmd/terramate/main.go:20 +0x94
```

## Which issue(s) this PR fixes:

## Special notes for your reviewer:
The issue manifests in the #1270 PR.

## Does this PR introduce a user-facing change?
```
no because scripts is not released.
```
