### PR TITLE
fix(scripts): dir prefix check works with root dir

### DIFF
--- a/cmd/terramate/e2etests/core/script_info_test.go
+++ b/cmd/terramate/e2etests/core/script_info_test.go
@@ -52,7 +52,12 @@ func TestScriptInfo(t *testing.T) {
 			stackstr = " (none)"
 		}
 
-		return fmt.Sprintf(`Definition: /%s/script.tm:%s
+		defstr := fmt.Sprintf("%s/script.tm:%s", path, loc)
+		if path != "" {
+			defstr = "/" + defstr
+		}
+
+		return fmt.Sprintf(`Definition: %s
 Description: "%s at /%s"
 Stacks:%s
 Jobs:
@@ -60,9 +65,10 @@ Jobs:
     ["echo","1b"]
   * ["echo","2"]
 
-`, path, loc, name, path, stackstr)
+`, defstr, name, path, stackstr)
 	}
 
+	addStackWithScripts("", []string{"root"})
 	addStackWithScripts("stacks/a", []string{"deploy", "other"})
 	addStackWithScripts("stacks/a/a1", []string{"other2"})
 	addStackWithScripts("stacks/a/a1/a2", []string{"deploy"})
@@ -95,6 +101,20 @@ Jobs:
 			dir:    "",
 			want: RunExpected{
 				Stdout: "",
+			},
+		},
+		{
+			script: "root",
+			dir:    "",
+			want: RunExpected{
+				Stdout: mkExpected("root", "", "1,1-12,5", []string{
+					"/",
+					"/stacks/a",
+					"/stacks/a/a1",
+					"/stacks/a/a1/a2",
+					"/stacks/b",
+					"/stacks/bb",
+				}),
 			},
 		},
 		{

--- a/project/project.go
+++ b/project/project.go
@@ -65,8 +65,10 @@ func (p Path) HasPrefix(s string) bool {
 }
 
 // HasDirPrefix tests whether p begins with a directory prefix s.
-// s must not end with a trailing "/".
 func (p Path) HasDirPrefix(s string) bool {
+	if s == "/" {
+		return strings.HasPrefix(p.String(), "/")
+	}
 	return s == p.String() || strings.HasPrefix(p.String(), s+"/")
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/terramate-io/terramate/blob/main/CONTRIBUTING.md
2. If the PR is unfinished, mark it as draft: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request
3. Please update the PR title using the Conventional Commits convention: https://www.conventionalcommits.org/en/v1.0.0/
    Example: feat: add support for XYZ.
-->

## What this PR does / why we need it:

The `HasDirPrefix` function used for scripts matching doesn't handle checking for the `/` prefix properly. This PR fixes it and adds a test case for it.

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
<!--
If no, just write "no" in the block below.
If yes, please explain the change and update documentation and the CHANGELOG.md file accordingly.
-->
```
no
```
