### PR TITLE
feat(generate): add stack_filter block

### DIFF
--- a/docs/cli/code-generation/generate-hcl.md
+++ b/docs/cli/code-generation/generate-hcl.md
@@ -309,6 +309,53 @@ Blocks defined at different levels with the same label aren't allowed, resulting
 in failure for the overall code generation process.
 
 
+## Filter-based Code Generation
+
+To only generate HCL code for stacks matching specific criteria, a `stack_filter`
+block can be added within a `generate_hcl` block.
+
+The following filter attributes for path filtering are supported:
+
+* `project_paths`: Match any of the given stack paths relative to the project root.
+* `repository_paths`: Match any of the given stack paths relative to the repository root.
+
+Stack paths support glob-style wildcards:
+* `*` matches any sequence of characters until the next directory separator (`/`).
+* `**` matches any sequence of characters.
+
+Unless a path starts with `*` or `/`, it is implicitly prefixed with `**/`.
+
+If multiple attributes are set per `stack_filter`, _all_ of them must match.
+
+If multiple `stack_filter` blocks are added, at least one must match.
+
+Here's an example:
+
+```hcl
+generate_hcl "file" {
+  stack_filter {
+    project_paths = ["networking/**"]
+  }
+  content {
+    resource "networking_resource" "name" {
+        # ...
+    }
+  }
+}
+```
+This generates a file containing a networking resource only for stacks located within a
+directory named `networking`. The implicitly added prefix `**/` means that this directory
+can be located anywhere in our project. The suffix `/**` means that the stack can be in
+any nested sub-directory of a `networking` directory.
+
+If we change the attribute to `project_paths = ["/networking/*"]`,
+it only matches stacks that are directly in a `networking` directory located at
+the project root level.
+
+If more complex logic is required to decide if a file should be generated,
+see the `condition` attribute described in the next section.
+
+
 ## Conditional Code Generation
 
 Conditional code generation is achieved by the use of the `condition` attribute.

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/fatih/color v1.16.0
 	github.com/go-git/go-git/v5 v5.9.0
 	github.com/go-test/deep v1.1.0
+	github.com/gobwas/glob v0.2.3
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/google/go-cmp v0.5.9
 	github.com/hashicorp/go-version v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -188,6 +188,8 @@ github.com/go-test/deep v1.0.1/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3a
 github.com/go-test/deep v1.0.3/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/go-test/deep v1.1.0 h1:WOcxcdHcvdgThNXjw0t76K42FXTU7HpNQWHpA2HHNlg=
 github.com/go-test/deep v1.1.0/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
+github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
+github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gofrs/uuid v3.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gofrs/uuid v3.3.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=

--- a/hcl/hcl_test.go
+++ b/hcl/hcl_test.go
@@ -924,6 +924,51 @@ func TestHCLParserMultipleErrors(t *testing.T) {
 	}
 }
 
+func TestHCLParserGenerateStackFilters(t *testing.T) {
+	for _, tc := range []testcase{
+		{
+			name: "invalid project_paths list",
+			input: []cfgfile{
+				{
+					filename: "gen.tm",
+					body: `
+						generate_hcl "test.tf" {
+							stack_filter { project_paths = "*" }
+							content { foo = "bar" }
+						}
+					`,
+				},
+			},
+			want: want{
+				errs: []error{
+					errors.E(hcl.ErrTerramateSchema),
+				},
+			},
+		},
+		{
+			name: "invalid project_paths list element",
+			input: []cfgfile{
+				{
+					filename: "gen.tm",
+					body: `
+						generate_hcl "test.tf" {
+							stack_filter { project_paths = ["blah", 1] }
+							content { foo = "bar" }
+						}
+					`,
+				},
+			},
+			want: want{
+				errs: []error{
+					errors.E(hcl.ErrTerramateSchema),
+				},
+			},
+		},
+	} {
+		testParser(t, tc)
+	}
+}
+
 func TestHCLParserTerramateBlocksMerging(t *testing.T) {
 	tcases := []testcase{
 		{

--- a/test/hclwrite/hclutils/utils.go
+++ b/test/hclwrite/hclutils/utils.go
@@ -4,6 +4,7 @@
 package hclutils
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/terramate-io/terramate/test/hclwrite"
@@ -74,6 +75,23 @@ func GenerateFile(builders ...hclwrite.BlockBuilder) *hclwrite.Block {
 // Content is a helper for a "content" block.
 func Content(builders ...hclwrite.BlockBuilder) *hclwrite.Block {
 	return Block("content", builders...)
+}
+
+// StackFilter is a helper for a "stack_filter" block.
+func StackFilter(builders ...hclwrite.BlockBuilder) *hclwrite.Block {
+	return Block("stack_filter", builders...)
+}
+
+// ProjectPaths is a helper for adding a "project_paths" attribute.
+func ProjectPaths(paths ...string) hclwrite.BlockBuilder {
+	expr := `["` + strings.Join(paths, `","`) + `"]`
+	return hclwrite.Expression("project_paths", expr)
+}
+
+// RepositoryPaths is a helper for adding a "project_paths" attribute.
+func RepositoryPaths(paths ...string) hclwrite.BlockBuilder {
+	expr := `["` + strings.Join(paths, `","`) + `"]`
+	return hclwrite.Expression("repository_paths", expr)
 }
 
 // Lets is a helper for a "lets" block.


### PR DESCRIPTION
## What this PR does / why we need it:

A new `stack_filter` block type is supported in `generate_hcl` blocks. This allows for improved path-based conditional generation. It can significantly improve performance when using path-based rules with lots of stacks.

## Which issue(s) this PR fixes:

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
A new block type is added to the configuration schema.
```
