### PR TITLE
chore: consistently uses int64 for TMC ids.

### DIFF
--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -15,13 +15,13 @@ import (
 	"net/http/httputil"
 	"os"
 	"path"
-	"strconv"
 
 	hversion "github.com/apparentlymart/go-versions/versions"
 	"github.com/rs/zerolog"
 	"github.com/terramate-io/terramate"
 	"github.com/terramate-io/terramate/cloud/stack"
 	"github.com/terramate-io/terramate/errors"
+	"github.com/terramate-io/terramate/strconv"
 	"github.com/terramate-io/terramate/versions"
 )
 
@@ -144,15 +144,15 @@ func (c *Client) GetStack(ctx context.Context, orgUUID UUID, repo, metaID string
 }
 
 // StackDrifts returns the drifts of the given stack.
-func (c *Client) StackDrifts(ctx context.Context, orgUUID UUID, stackID int, page, perPage int) (DriftsStackPayloadResponse, error) {
-	path := path.Join(StacksPath, string(orgUUID), strconv.Itoa(stackID), "drifts")
+func (c *Client) StackDrifts(ctx context.Context, orgUUID UUID, stackID int64, page, perPage int) (DriftsStackPayloadResponse, error) {
+	path := path.Join(StacksPath, string(orgUUID), strconv.Itoa64(stackID), "drifts")
 	path += fmt.Sprintf("?page=%d&per_page=%d", page, perPage)
 	return Get[DriftsStackPayloadResponse](ctx, c, path)
 }
 
 // DriftDetails retrieves details of the given driftID.
-func (c *Client) DriftDetails(ctx context.Context, orgUUID UUID, stackID int, driftID int) (Drift, error) {
-	path := path.Join(DriftsPath, string(orgUUID), strconv.Itoa(stackID), strconv.Itoa(driftID))
+func (c *Client) DriftDetails(ctx context.Context, orgUUID UUID, stackID, driftID int64) (Drift, error) {
+	path := path.Join(DriftsPath, string(orgUUID), strconv.Itoa64(stackID), strconv.Itoa64(driftID))
 	return Get[Drift](ctx, c, path)
 }
 
@@ -207,7 +207,7 @@ func (c *Client) CreateStackDrift(
 func (c *Client) SyncDeploymentLogs(
 	ctx context.Context,
 	orgUUID UUID,
-	stackID int,
+	stackID int64,
 	deploymentUUID UUID,
 	logs DeploymentLogs,
 ) error {
@@ -218,7 +218,7 @@ func (c *Client) SyncDeploymentLogs(
 	// Endpoint:/v1/stacks/{org_uuid}/{stack_id}/deployments/{deployment_uuid}/logs
 	_, err = Post[EmptyResponse](
 		ctx, c, logs,
-		StacksPath, string(orgUUID), strconv.Itoa(stackID), "deployments", string(deploymentUUID), "logs",
+		StacksPath, string(orgUUID), strconv.Itoa64(stackID), "deployments", string(deploymentUUID), "logs",
 	)
 	return err
 }

--- a/cloud/testserver/deployments.go
+++ b/cloud/testserver/deployments.go
@@ -80,7 +80,7 @@ func PostDeployment(store *cloudstore.Data, w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	var stackIDs []int
+	var stackIDs []int64
 	res := cloud.DeploymentStacksResponse{}
 	for _, s := range rPayload.Stacks {
 		state := cloudstore.NewState()

--- a/cloud/testserver/drifts.go
+++ b/cloud/testserver/drifts.go
@@ -8,25 +8,25 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strconv"
 
 	"github.com/julienschmidt/httprouter"
 	"github.com/terramate-io/terramate/cloud"
 	"github.com/terramate-io/terramate/cloud/testserver/cloudstore"
 	"github.com/terramate-io/terramate/errors"
+	"github.com/terramate-io/terramate/strconv"
 )
 
 // GetDrift implements the /v1/drifts/:orguuid/:stackid/:driftid endpoint.
 func GetDrift(store *cloudstore.Data, w http.ResponseWriter, _ *http.Request, params httprouter.Params) {
 	orguuid := cloud.UUID(params.ByName("orguuid"))
-	stackid, err := strconv.Atoi(params.ByName("stackid"))
+	stackid, err := strconv.Atoi64(params.ByName("stackid"))
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		writeErr(w, errors.E(err, "invalid stackid"))
 		return
 	}
 
-	driftid, err := strconv.Atoi(params.ByName("driftid"))
+	driftid, err := strconv.Atoi64(params.ByName("driftid"))
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		writeErr(w, errors.E(err, "invalid driftid"))

--- a/cloud/testserver/stacks.go
+++ b/cloud/testserver/stacks.go
@@ -9,7 +9,7 @@ import (
 	"io"
 	"net/http"
 	"sort"
-	"strconv"
+
 	"time"
 
 	"github.com/julienschmidt/httprouter"
@@ -19,6 +19,7 @@ import (
 	"github.com/terramate-io/terramate/cloud/stack"
 	"github.com/terramate-io/terramate/cloud/testserver/cloudstore"
 	"github.com/terramate-io/terramate/errors"
+	"github.com/terramate-io/terramate/strconv"
 )
 
 func stateTable() map[drift.Status]map[deployment.Status]stack.Status {
@@ -116,7 +117,7 @@ func GetStacks(store *cloudstore.Data, w http.ResponseWriter, r *http.Request, p
 
 		if filter(st) {
 			resp.Stacks = append(resp.Stacks, cloud.StackResponse{
-				ID:               id,
+				ID:               int64(id),
 				Stack:            st.Stack,
 				Status:           st.State.Status,
 				DeploymentStatus: st.State.DeploymentStatus,
@@ -177,7 +178,7 @@ func GetDeploymentLogs(store *cloudstore.Data, w http.ResponseWriter, _ *http.Re
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
-	stackid, err := strconv.Atoi(stackIDStr)
+	stackid, err := strconv.Atoi64(stackIDStr)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		writeErr(w, err)
@@ -190,7 +191,7 @@ func GetDeploymentLogs(store *cloudstore.Data, w http.ResponseWriter, _ *http.Re
 		return
 	}
 	stacks := org.Stacks
-	if stackid < 0 || stackid >= len(stacks) {
+	if stackid < 0 || stackid >= int64(len(stacks)) {
 		w.WriteHeader(http.StatusNotFound)
 		writeErr(w, errors.E("stack not found"))
 		return
@@ -233,13 +234,13 @@ func GetDeploymentLogsEvents(store *cloudstore.Data, w http.ResponseWriter, _ *h
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
-	stackid, err := strconv.Atoi(stackIDStr)
+	stackid, err := strconv.Atoi64(stackIDStr)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		writeErr(w, err)
 	}
 	stacks := org.Stacks
-	if stackid < 0 || stackid >= len(stacks) {
+	if stackid < 0 || stackid >= int64(len(stacks)) {
 		w.WriteHeader(http.StatusNotFound)
 		writeErr(w, errors.E("stack not found"))
 		return
@@ -277,7 +278,7 @@ func PostDeploymentLogs(store *cloudstore.Data, w http.ResponseWriter, r *http.R
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
-	stackid, err := strconv.Atoi(stackIDStr)
+	stackid, err := strconv.Atoi64(stackIDStr)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		writeErr(w, err)
@@ -292,7 +293,7 @@ func PostDeploymentLogs(store *cloudstore.Data, w http.ResponseWriter, r *http.R
 	}
 
 	stacks := org.Stacks
-	if stackid < 0 || stackid >= len(stacks) {
+	if stackid < 0 || stackid >= int64(len(stacks)) {
 		w.WriteHeader(http.StatusNotFound)
 		writeErr(w, errors.E("stack not found"))
 		return
@@ -327,7 +328,7 @@ func PostDeploymentLogs(store *cloudstore.Data, w http.ResponseWriter, r *http.R
 // GetStackDrifts implements the /v1/stacks/:orguuid/:stackid/drifts endpoint.
 func GetStackDrifts(store *cloudstore.Data, w http.ResponseWriter, _ *http.Request, params httprouter.Params) {
 	orguuid := cloud.UUID(params.ByName("orguuid"))
-	stackid, err := strconv.Atoi(params.ByName("stackid"))
+	stackid, err := strconv.Atoi64(params.ByName("stackid"))
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		writeErr(w, errors.E(err, "invalid stackid"))

--- a/cloud/types.go
+++ b/cloud/types.go
@@ -40,7 +40,7 @@ type (
 
 	// MemberOrganization represents the organization associated with the member.
 	MemberOrganization struct {
-		MemberID    int    `json:"member_id,omitempty"`
+		MemberID    int64  `json:"member_id,omitempty"`
 		Name        string `json:"org_name"`
 		DisplayName string `json:"org_display_name"`
 		Domain      string `json:"org_domain"`
@@ -51,7 +51,7 @@ type (
 
 	// StackResponse represents a stack in the Terramate Cloud.
 	StackResponse struct {
-		ID int `json:"stack_id"`
+		ID int64 `json:"stack_id"`
 		Stack
 		Status           stack.Status      `json:"status"`
 		DeploymentStatus deployment.Status `json:"deployment_status"`
@@ -99,7 +99,7 @@ type (
 
 	// DeploymentStackResponse represents the deployment creation response item.
 	DeploymentStackResponse struct {
-		StackID     int               `json:"stack_id"`
+		StackID     int64             `json:"stack_id"`
 		StackMetaID string            `json:"meta_id"`
 		Status      deployment.Status `json:"status"`
 	}
@@ -120,7 +120,7 @@ type (
 
 	// Drift represents the drift information for a given stack.
 	Drift struct {
-		ID       int                 `json:"id"`
+		ID       int64               `json:"id"`
 		Status   drift.Status        `json:"status"`
 		Details  *DriftDetails       `json:"drift_details,omitempty"`
 		Metadata *DeploymentMetadata `json:"metadata,omitempty"`
@@ -229,7 +229,7 @@ type (
 
 	// UpdateDeploymentStack is the request payload item for updating the deployment status.
 	UpdateDeploymentStack struct {
-		StackID int               `json:"stack_id"`
+		StackID int64             `json:"stack_id"`
 		Status  deployment.Status `json:"status"`
 	}
 

--- a/cmd/terramate/cli/cloud.go
+++ b/cmd/terramate/cli/cloud.go
@@ -42,7 +42,7 @@ type cloudConfig struct {
 		runUUID cloud.UUID
 		orgUUID cloud.UUID
 
-		meta2id       map[string]int
+		meta2id       map[string]int64
 		reviewRequest *cloud.DeploymentReviewRequest
 		metadata      *cloud.DeploymentMetadata
 	}
@@ -107,7 +107,7 @@ func (c *cli) checkCloudSync() {
 	}
 
 	if c.parsedArgs.Run.CloudSyncDeployment {
-		c.cloud.run.meta2id = make(map[string]int)
+		c.cloud.run.meta2id = make(map[string]int64)
 		uuid, err := generateRunID()
 		c.handleCriticalError(err)
 		c.cloud.run.runUUID = cloud.UUID(uuid)

--- a/strconv/doc.go
+++ b/strconv/doc.go
@@ -1,0 +1,6 @@
+// Copyright 2023 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+// Package strconv provides helper functions for the Go standard
+// strconv package.
+package strconv

--- a/strconv/format.go
+++ b/strconv/format.go
@@ -1,0 +1,14 @@
+// Copyright 2023 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+package strconv
+
+import "strconv"
+
+// Itoa64 returns the string representation of the provided int64 using base 10.
+func Itoa64(i int64) string { return strconv.FormatInt(i, 10) }
+
+// Atoi64 returns the int64 represented in the given string.
+func Atoi64(a string) (int64, error) {
+	return strconv.ParseInt(a, 10, 64)
+}

--- a/test/cloud/client.go
+++ b/test/cloud/client.go
@@ -5,12 +5,13 @@ package cloud
 
 import (
 	"context"
-	"strconv"
+
 	"testing"
 	"time"
 
 	"github.com/madlambda/spells/assert"
 	"github.com/terramate-io/terramate/cloud"
+	"github.com/terramate-io/terramate/strconv"
 )
 
 const defaultTestTimeout = 1 * time.Second
@@ -26,7 +27,7 @@ func PutStack(t *testing.T, addr string, orgUUID cloud.UUID, st cloud.StackRespo
 		BaseURL:    "http://" + addr,
 		Credential: &credential{},
 	}
-	_, err := cloud.Put[cloud.EmptyResponse](ctx, client, st, cloud.StacksPath, string(orgUUID), strconv.Itoa(st.ID))
+	_, err := cloud.Put[cloud.EmptyResponse](ctx, client, st, cloud.StacksPath, string(orgUUID), strconv.Itoa64(st.ID))
 	assert.NoError(t, err)
 }
 


### PR DESCRIPTION
## What this PR does / why we need it:

Some TMC endpoints have fields declared as `int64` integers (at least in theory because JSON can only store a maximum 2^53 integer value without loss) but CLI was unmarshaling into `int` (32 bits wide depending on the arch). The real motivation for this change is sticking to a size and using it for all ID-like fields. The new Pagination feature also has new fields defined as `int64`.
This is not a real problem at the moment but strictly following the OpenAPI spec is a good practice and some payloads are defined as `int64`. 
Additionally, by using int64 we are more future-proof in the case IDs are changed to not be serial anymore (unlikely, but who knows).

## Which issue(s) this PR fixes:

## Special notes for your reviewer:

The #1304 had those changes because implementing pagination in the testserver led to the case of computing if a provided `stack_id` was inside a int64 range (because pagination.total and pagination.page were int64), not a big problem just doing a conversion but I felt like this should be better handled.
Additionally, the weird case of using `strconv.Atoi()` for some IDs (like `stack_id`) and then `Atoi64()` helper for the pagination `total` and other fields.

## Does this PR introduce a user-facing change?
```
no
```
