### PR TITLE
chore(tmc): case-insensitive organization name.

### DIFF
--- a/cmd/terramate/cli/cloud.go
+++ b/cmd/terramate/cli/cloud.go
@@ -148,7 +148,7 @@ func (c *cli) setupCloudConfig() error {
 	if useOrgName != "" {
 		var useOrgUUID cloud.UUID
 		for _, org := range orgs {
-			if org.Name == useOrgName {
+			if strings.EqualFold(org.Name, useOrgName) {
 				if org.Status != "active" && org.Status != "trusted" {
 					logger.Error().
 						Msgf("You are not yet an active member of organization %s. Please accept the invitation first.", useOrgName)


### PR DESCRIPTION
## What this PR does / why we need it:

A _Terramate Cloud_ organization name is case-insensitive.

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
no
```
