### PR TITLE
fix(generate): dotfiles must not be ignored while detecting existing files.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 ### Fixed
 
 - fix(generate): blocks with context=root were ignored if defined in stacks.
+- fix(generate): dot files were ignored while detecting existent files.
 
 ## 0.4.3
 

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -446,10 +446,6 @@ processSubdirs:
 		}
 
 		for _, entry := range entries {
-			if config.Skip(entry.Name()) {
-				continue
-			}
-
 			if entry.IsDir() {
 				isStack := config.IsStack(root, filepath.Join(absSubdir, entry.Name()))
 				if isStack {

--- a/generate/generate_hcl_test.go
+++ b/generate/generate_hcl_test.go
@@ -1692,7 +1692,7 @@ func TestGenerateHCLCleanupOldFilesIgnoreSymlinks(t *testing.T) {
 	})
 }
 
-func TestGenerateHCLCleanupOldFilesIgnoreDotDirs(t *testing.T) {
+func TestGenerateHCLCleanupOldFilesDONTIgnoreDotDirs(t *testing.T) {
 	t.Parallel()
 
 	s := sandbox.NoGit(t, true)
@@ -1701,7 +1701,12 @@ func TestGenerateHCLCleanupOldFilesIgnoreDotDirs(t *testing.T) {
 	test.WriteFile(t, filepath.Join(s.RootDir(), ".terramate"), "test.tf", genhcl.Header)
 	test.WriteFile(t, filepath.Join(s.RootDir(), ".another"), "test.tf", genhcl.Header)
 
-	assertEqualReports(t, s.Generate(), generate.Report{})
+	assertEqualReports(t, s.Generate(), generate.Report{
+		Successes: []generate.Result{
+			{Dir: project.NewPath("/.another"), Deleted: []string{"test.tf"}},
+			{Dir: project.NewPath("/.terramate"), Deleted: []string{"test.tf"}},
+		},
+	})
 }
 
 func TestGenerateHCLTerramateRootMetadata(t *testing.T) {

--- a/generate/generate_list_test.go
+++ b/generate/generate_list_test.go
@@ -168,13 +168,19 @@ func TestGeneratedFilesListing(t *testing.T) {
 			},
 		},
 		{
-			name: "ignores dot dirs and files",
+			// https://github.com/terramate-io/terramate/issues/1260
+			// dotfiles should not be ignored if not inside a .tmskip
+			name: "regression test: should not ignore dotdirs and dotfiles",
 			layout: []string{
 				genfile(".name.tf"),
 				genfile(".dir/1.tf"),
 				genfile(".dir/2.tf"),
 			},
-			want: []string{},
+			want: []string{
+				".name.tf",
+				".dir/1.tf",
+				".dir/2.tf",
+			},
 		},
 	}
 

--- a/test/sandbox/sandbox.go
+++ b/test/sandbox/sandbox.go
@@ -486,9 +486,9 @@ func (de DirEntry) Chmod(relpath string, mode stdfs.FileMode) {
 // ReadFile will read a file inside this dir entry with the given name.
 // It will fail the test if the file doesn't exist, since it assumes an
 // expectation on the file being there.
-func (de DirEntry) ReadFile(name string) []byte {
+func (de DirEntry) ReadFile(name string) string {
 	de.t.Helper()
-	return test.ReadFile(de.t, de.abspath, name)
+	return string(test.ReadFile(de.t, de.abspath, name))
 }
 
 // RemoveFile will delete a file inside this dir entry with the given name.


### PR DESCRIPTION
## What this PR does / why we need it:

The `generator` was ignoring dot dirs/files while scanning the project for the detection of existing/changed/deleted files.
The issue existed since `v0.1.36` version, introduced in PR [#624](https://github.com/terramate-io/terramate/commit/51221de238bdd06668421f9d5427351d9724ff4a#diff-39a24c8d3907e38beb5e39b5f0a40df7aa73c38449615f140ec3fca502900e86R297).

## Which issue(s) this PR fixes:

Fixes #1260 

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
yes, it fixes a generate bug where dot files were always showing as "created" even if already in the disk.
```
