### PR TITLE
docs: add explanation of how to enable experimental scripts feature

### DIFF
--- a/docs/cli/cmdline/script/info.md
+++ b/docs/cli/cmdline/script/info.md
@@ -13,7 +13,7 @@ next:
 
 # Script Info
 
-**Note:** This is an experimental command that is likely subject to change in the future.
+**Note:** This is an upcoming experimental feature that is subject to change in the future. To use it now, you must enable the project config option `terramate.config.experiments = ["scripts"]`
 
 The `script info LABEL...` command lists details about all script definitions matching the given LABELs (see [script run](./run) command for details about matching labels). The information provided by `script info` includes:
 

--- a/docs/cli/cmdline/script/list.md
+++ b/docs/cli/cmdline/script/list.md
@@ -13,7 +13,7 @@ next:
 
 # Script List
 
-**Note:** This is an experimental command that is likely subject to change in the future.
+**Note:** This is an upcoming experimental feature that is subject to change in the future. To use it now, you must enable the project config option `terramate.config.experiments = ["scripts"]`
 
 Shows a list of all uniquely-named scripts that can be executed with `script run` in the current directory. If there are multiple definitions with the same name, a parent is selected over a child, or a first sibling over a later sibling (ordered by directory name).
 

--- a/docs/cli/cmdline/script/run.md
+++ b/docs/cli/cmdline/script/run.md
@@ -13,7 +13,7 @@ next:
 
 # Script Run
 
-**Note:** This is an experimental command that is likely subject to change in the future.
+**Note:** This is an upcoming experimental feature that is subject to change in the future. To use it now, you must enable the project config option `terramate.config.experiments = ["scripts"]`
 
 The `script run LABEL...` command will run a Terramate script over a set of stacks. The `LABEL` (one or more) needs to exactly match the labels defined in the `script` block:
 

--- a/docs/cli/cmdline/script/tree.md
+++ b/docs/cli/cmdline/script/tree.md
@@ -13,6 +13,8 @@ next:
 
 # Script Tree
 
+**Note:** This is an upcoming experimental feature that is subject to change in the future. To use it now, you must enable the project config option `terramate.config.experiments = ["scripts"]`
+
 Shows a tree-view of all scripts relative to the current directory (or a specific directory with the -C flag). The tree expands all sub-directories, and the parent path back to the project root, showing script definitions per directory.
 
 ## Usage


### PR DESCRIPTION
## What this PR does / why we need it:
Explains in the docs that you must enable a config option to use the scripts features

## Does this PR introduce a user-facing change?
```
no
```
