### PR TITLE
feat: fmt of individual files and stdin.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 ### Added
 
 - Add `terramate.config.generate.hcl_magic_header_comment_style` option for setting the generated comment style.
+- Add support for formatting specific files and stdin (`terramate fmt [file...]` or `terramate fmt -`).
 
 ## 0.4.5
 

--- a/cmd/terramate/e2etests/internal/runner/runner.go
+++ b/cmd/terramate/e2etests/internal/runner/runner.go
@@ -244,6 +244,23 @@ func (tm CLI) Run(args ...string) RunResult {
 	}
 }
 
+// RunWithStdin runs the CLI but uses the provided string as stdin.
+func (tm CLI) RunWithStdin(stdin string, args ...string) RunResult {
+	t := tm.t
+	t.Helper()
+
+	cmd := tm.NewCmd(args...)
+	cmd.Stdin.b.WriteString(stdin)
+	_ = cmd.Run()
+
+	return RunResult{
+		Cmd:    strings.Join(args, " "),
+		Stdout: cmd.Stdout.String(),
+		Stderr: cmd.Stderr.String(),
+		Status: cmd.ExitCode(),
+	}
+}
+
 // RunScript is a helper for executing `terramate run-script`.
 func (tm CLI) RunScript(args ...string) RunResult {
 	return tm.Run(append([]string{"script", "run"}, args...)...)

--- a/hcl/fmt/fmt.go
+++ b/hcl/fmt/fmt.go
@@ -20,6 +20,9 @@ import (
 // ErrHCLSyntax is the error kind for syntax errors.
 const ErrHCLSyntax errors.Kind = "HCL syntax error"
 
+// ErrReadFile is the error kind for any error related to reading the file content.
+const ErrReadFile errors.Kind = "failed to read file"
+
 // FormatResult represents the result of a formatting operation.
 type FormatResult struct {
 	path      string
@@ -68,39 +71,17 @@ func FormatTree(dir string) ([]FormatResult, error) {
 	}
 	sort.Strings(files)
 
-	results := []FormatResult{}
 	errs := errors.L()
+	results, err := FormatFiles(dir, files)
 
-	for _, f := range files {
-		path := filepath.Join(dir, f)
-		fileContents, err := os.ReadFile(path)
-		if err != nil {
-			errs.Append(err)
-			continue
-		}
-
-		currentCode := string(fileContents)
-		formatted, err := Format(currentCode, path)
-		if err != nil {
-			errs.Append(err)
-			continue
-		}
-
-		if currentCode == formatted {
-			continue
-		}
-
-		results = append(results, FormatResult{
-			path:      path,
-			formatted: formatted,
-		})
-	}
+	errs.Append(err)
 
 	dirs, err := fs.ListTerramateDirs(dir)
 	if err != nil {
 		errs.Append(err)
 		return nil, errors.E(errFormatTree, errs)
 	}
+
 	sort.Strings(dirs)
 
 	for _, d := range dirs {
@@ -112,6 +93,54 @@ func FormatTree(dir string) ([]FormatResult, error) {
 		results = append(results, subres...)
 	}
 
+	if err := errs.AsError(); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+// FormatFiles will format all the provided Terramate paths.
+// Only Terramate configuration files can be reliably formatted with this function.
+// If HCL files for a different tool is provided, the result is unpredictable.
+//
+// Note: The provided file paths can be absolute or relative. If relative, ensure
+// working directory is corrected adjusted. The special `-` filename is treated as a
+// normal filename, then if it needs to be interpreted as `stdin` this needs to be
+// handled separately by the caller.
+//
+// Files that are already formatted are ignored. If all files are formatted
+// this function returns an empty result.
+//
+// All files will be left untouched. To save the formatted result on disk you
+// can use FormatResult.Save for each FormatResult.
+func FormatFiles(basedir string, files []string) ([]FormatResult, error) {
+	results := []FormatResult{}
+	errs := errors.L()
+
+	for _, file := range files {
+		fname := file
+		if !filepath.IsAbs(file) {
+			fname = filepath.Join(basedir, file)
+		}
+		fileContents, err := os.ReadFile(fname)
+		if err != nil {
+			errs.Append(errors.E(ErrReadFile, err))
+			continue
+		}
+		currentCode := string(fileContents)
+		formatted, err := Format(currentCode, fname)
+		if err != nil {
+			errs.Append(err)
+			continue
+		}
+		if currentCode == formatted {
+			continue
+		}
+		results = append(results, FormatResult{
+			path:      fname,
+			formatted: formatted,
+		})
+	}
 	if err := errs.AsError(); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## What this PR does / why we need it:

Introduces the ability to format individual files or `stdin` with the `terramate fmt` command.

Example:

Individual files:
```
$ terramate fmt terramate.tm stacks/my-stack/stack.tm
```

Stdin:
```
$ terramate fmt -
format this input ^D
$ echo $?
1
```

Format current directory (old behavior):
```
$ terramate fmt
```

## Which issue(s) this PR fixes:

Fixes #1226 

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
yes, new arguments list for `fmt`
```
