### PR TITLE
chore: Add package for printing errors, warnings etc

### DIFF
--- a/printer/doc.go
+++ b/printer/doc.go
@@ -1,0 +1,7 @@
+// Copyright 2023 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+// Package printer defines funtionality for "printing" text to an io.Writer e.g.
+// os.Stdout, os.Stderr etc. with a consistent style for errors, warnings,
+// information etc.
+package printer

--- a/printer/printer.go
+++ b/printer/printer.go
@@ -1,0 +1,79 @@
+// Copyright 2023 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+package printer
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/fatih/color"
+	"github.com/terramate-io/terramate/errors"
+)
+
+var (
+	bold       = color.New(color.Bold).Sprint
+	boldYellow = color.New(color.Bold, color.FgYellow).Sprint
+	boldRed    = color.New(color.Bold, color.FgRed).Sprint
+	boldGreen  = color.New(color.Bold, color.FgGreen).Sprint
+)
+
+// Printer encapuslates an io.Writer
+type Printer struct {
+	w io.Writer
+}
+
+// NewPrinter creates a new Printer with the provider io.Writer e.g.: stdio,
+// stderr, file etc.
+func NewPrinter(w io.Writer) *Printer {
+	return &Printer{w}
+}
+
+// Println prints a message to the io.Writer
+func (p *Printer) Println(msg string) {
+	fmt.Fprintln(p.w, msg)
+}
+
+// Warnln prints a message with a "Warning:" prefix. The prefix is printed in
+// the boldYellow style.
+func (p *Printer) Warnln(title string) {
+	fmt.Fprintln(p.w, boldYellow("Warning:"), bold(title))
+}
+
+// ErrorWithDetailsln prints an error with a title and the underlying error. If
+// the error contains multiple error items, each error is printed with a `->`
+// prefix.
+// e.g.:
+// Error: parsing failed
+// -> somefile.tm:8,3-7: terramate schema error: unrecognized attribute
+// -> somefile.tm:9,4-7: terramate schema error: unrecognized block
+func (p *Printer) ErrorWithDetailsln(title string, err error) {
+	p.Errorln(title)
+
+	for _, item := range toStrings(err) {
+		fmt.Fprintln(p.w, boldRed(">"), item)
+	}
+}
+
+// Errorln prints a message with a "Error:" prefix. The prefix is prinited in
+// the boldRed style.
+func (p *Printer) Errorln(title string) {
+	fmt.Fprintln(p.w, boldRed("Error:"), bold(title))
+}
+
+// Successln prints a message in the boldGreen style
+func (p *Printer) Successln(msg string) {
+	fmt.Fprintln(p.w, boldGreen(msg))
+}
+
+// toStrings converts an error into a list of strings where each string
+// represents an individual error.
+func toStrings(err error) []string {
+	errs := errors.L(err).Errors()
+	list := make([]string, 0, len(errs))
+	for _, errItem := range errs {
+		list = append(list, errItem.Error())
+	}
+
+	return list
+}

--- a/printer/printer_test.go
+++ b/printer/printer_test.go
@@ -1,0 +1,139 @@
+// Copyright 2023 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+package printer
+
+import (
+	stderrors "errors"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/terramate-io/terramate/errors"
+)
+
+func ExampleNewPrinter() {
+	p := NewPrinter(os.Stdout)
+	p.Println("Doing something")
+	p.Warnln("doing something fishy")
+	p.ErrorWithDetailsln(
+		"failed to find fish",
+		stderrors.New("error 1"),
+	)
+	// Output:
+	// Doing something
+	// Warning: doing something fishy
+	// Error: failed to find fish
+	// > error 1
+}
+
+func TestPrinter(t *testing.T) {
+	buf := new(strings.Builder)
+	p := NewPrinter(buf)
+	p.Println("Start to do something")
+	p.Println("doing 1")
+	p.Println("doing 2")
+	p.Warnln("Something is not perfect, but continuing")
+	p.Successln("Finished doing something")
+
+	want := `Start to do something
+doing 1
+doing 2
+Warning: Something is not perfect, but continuing
+Finished doing something
+`
+	if got := buf.String(); got != want {
+		t.Fatalf("want: %s, got: %s\n", want, got)
+	}
+}
+
+func TestPrinterSimple(t *testing.T) {
+	buf := new(strings.Builder)
+	p := NewPrinter(buf)
+	p.Println("Start to do something")
+	p.ErrorWithDetailsln(
+		"Wrong state of things",
+		stderrors.New("details of the error here"))
+
+	want := `Start to do something
+Error: Wrong state of things
+> details of the error here
+`
+	if got := buf.String(); got != want {
+		t.Fatalf("want: %s, got: %s\n", want, got)
+	}
+}
+
+func TestPrinterErrorWithDetails(t *testing.T) {
+	type testcase struct {
+		name string
+		msg  string
+		err  error
+		want string
+	}
+
+	for _, tc := range []testcase{
+		{
+			name: "simple error",
+			msg:  "Wrong state of things",
+			err:  fmt.Errorf("error details"),
+			want: `Error: Wrong state of things
+> error details
+`,
+		},
+		{
+			name: "error with type *errors.Error",
+			msg:  "Wrong state of things",
+			err:  errors.E("some details"),
+			want: `Error: Wrong state of things
+> some details
+`,
+		},
+		{
+			name: "error of type *errors.List",
+			msg:  "Wrong state of things",
+			err: errors.L(
+				errors.E("1. error details"),
+				errors.E("2. error details"),
+			),
+			want: `Error: Wrong state of things
+> 1. error details
+> 2. error details
+`,
+		},
+		{
+			name: "error of type *errors.List with file ranges",
+			msg:  "Parsing failed",
+			err: errors.L(
+				errors.E(errors.Kind("schema error"), hcl.Range{
+					Filename: "test.tm",
+					Start:    hcl.Pos{Line: 1, Column: 5, Byte: 3},
+					End:      hcl.Pos{Line: 1, Column: 10, Byte: 13},
+				}, "unexpected attribute"),
+				errors.E(errors.Kind("schema error"), hcl.Range{
+					Filename: "test.tm",
+					Start:    hcl.Pos{Line: 2, Column: 5, Byte: 3},
+					End:      hcl.Pos{Line: 2, Column: 10, Byte: 13},
+				}, "unexpected block"),
+			),
+			want: `Error: Parsing failed
+> test.tm:1,5-10: schema error: unexpected attribute
+> test.tm:2,5-10: schema error: unexpected block
+`,
+		},
+	} {
+
+		t.Run(tc.name, func(t *testing.T) {
+			buf := new(strings.Builder)
+			p := NewPrinter(buf)
+			p.ErrorWithDetailsln(tc.msg, tc.err)
+
+			got := buf.String()
+			if tc.want != got {
+				t.Errorf("unexpected result, want: %s, got %s", tc.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION

## What this PR does / why we need it:

This PR adds a new abstraction for printing errors, warnings, and information that is more human readable than the existing logging statements. 
* Create a new package "printer"
* Add type Printer + convenience methods to print Errors, Warnings, Success, Information etc. in a consistent style

## Which issue(s) this PR fixes:

## Special notes for your reviewer:

A [subsequent PR](https://github.com/terramate-io/terramate/pull/1323) uses the `printer` package to improve error messages emitted by `terramate run`.


## Does this PR introduce a user-facing change?
no
