### PR TITLE
chore: revert "fix(generate): dotfiles must not be ignored."

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,6 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 ### Fixed
 
 - fix(generate): blocks with context=root were ignored if defined in stacks.
-- fix(generate): dot files were ignored while detecting existent files.
 
 ## 0.4.3
 

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -446,6 +446,10 @@ processSubdirs:
 		}
 
 		for _, entry := range entries {
+			if config.Skip(entry.Name()) {
+				continue
+			}
+
 			if entry.IsDir() {
 				isStack := config.IsStack(root, filepath.Join(absSubdir, entry.Name()))
 				if isStack {

--- a/generate/generate_hcl_test.go
+++ b/generate/generate_hcl_test.go
@@ -1692,7 +1692,7 @@ func TestGenerateHCLCleanupOldFilesIgnoreSymlinks(t *testing.T) {
 	})
 }
 
-func TestGenerateHCLCleanupOldFilesDONTIgnoreDotDirs(t *testing.T) {
+func TestGenerateHCLCleanupOldFilesIgnoreDotDirs(t *testing.T) {
 	t.Parallel()
 
 	s := sandbox.NoGit(t, true)
@@ -1701,12 +1701,7 @@ func TestGenerateHCLCleanupOldFilesDONTIgnoreDotDirs(t *testing.T) {
 	test.WriteFile(t, filepath.Join(s.RootDir(), ".terramate"), "test.tf", genhcl.Header)
 	test.WriteFile(t, filepath.Join(s.RootDir(), ".another"), "test.tf", genhcl.Header)
 
-	assertEqualReports(t, s.Generate(), generate.Report{
-		Successes: []generate.Result{
-			{Dir: project.NewPath("/.another"), Deleted: []string{"test.tf"}},
-			{Dir: project.NewPath("/.terramate"), Deleted: []string{"test.tf"}},
-		},
-	})
+	assertEqualReports(t, s.Generate(), generate.Report{})
 }
 
 func TestGenerateHCLTerramateRootMetadata(t *testing.T) {

--- a/generate/generate_list_test.go
+++ b/generate/generate_list_test.go
@@ -168,19 +168,13 @@ func TestGeneratedFilesListing(t *testing.T) {
 			},
 		},
 		{
-			// https://github.com/terramate-io/terramate/issues/1260
-			// dotfiles should not be ignored if not inside a .tmskip
-			name: "regression test: should not ignore dotdirs and dotfiles",
+			name: "ignores dot dirs and files",
 			layout: []string{
 				genfile(".name.tf"),
 				genfile(".dir/1.tf"),
 				genfile(".dir/2.tf"),
 			},
-			want: []string{
-				".name.tf",
-				".dir/1.tf",
-				".dir/2.tf",
-			},
+			want: []string{},
 		},
 	}
 

--- a/generate/generate_test.go
+++ b/generate/generate_test.go
@@ -123,144 +123,6 @@ func TestGenerateIgnore(t *testing.T) {
 				},
 			},
 		},
-		{
-			// https://github.com/terramate-io/terramate/issues/1260
-			// dotfiles should not be ignored if not inside a .tmskip
-			name: "regression test: dot files snould not be skipped when scanning files",
-			layout: []string{
-				"s:stack",
-			},
-			configs: []hclconfig{
-				{
-					path: "/stack",
-					add: GenerateHCL(
-						Labels(".file.hcl"),
-						Content(
-							Str("data", "data"),
-						),
-						Bool("condition", true),
-					),
-				},
-				{
-					path: "/stack",
-					add: GenerateHCL(
-						Labels(".directory/file.hcl"),
-						Content(
-							Str("data", "data"),
-						),
-						Bool("condition", true),
-					),
-				},
-				{
-					path: "/stack",
-					add: GenerateHCL(
-						Labels(".directory/.file.hcl"),
-						Content(
-							Str("data", "data"),
-						),
-						Bool("condition", true),
-					),
-				},
-				{
-					path: "/stack",
-					add: GenerateFile(
-						Labels(".file"),
-						Str("content", "stack context"),
-						Bool("condition", true),
-					),
-				},
-				{
-					path: "/stack",
-					add: GenerateFile(
-						Labels(".directory/.file"),
-						Str("content", "stack context"),
-						Bool("condition", true),
-					),
-				},
-				{
-					path: "/stack",
-					add: GenerateFile(
-						Labels(".directory/file"),
-						Str("content", "stack context"),
-						Bool("condition", true),
-					),
-				},
-				{
-					path: "/stack",
-					add: GenerateFile(
-						Labels("/.root-file"),
-						Expr("context", "root"),
-						Str("content", "root context"),
-						Bool("condition", true),
-					),
-				},
-				{
-					path: "/stack",
-					add: GenerateFile(
-						Labels("/.directory/root-file"),
-						Expr("context", "root"),
-						Str("content", "root context"),
-						Bool("condition", true),
-					),
-				},
-				{
-					path: "/stack",
-					add: GenerateFile(
-						Labels("/.directory/.root-file"),
-						Expr("context", "root"),
-						Str("content", "root context"),
-						Bool("condition", true),
-					),
-				},
-			},
-			want: []generatedFile{
-				{
-					dir: "/",
-					files: map[string]fmt.Stringer{
-						"/.root-file":            stringer("root context"),
-						"/.directory/.root-file": stringer("root context"),
-						"/.directory/root-file":  stringer("root context"),
-					},
-				},
-				{
-					dir: "/stack",
-					files: map[string]fmt.Stringer{
-						".file":                stringer("stack context"),
-						".directory/.file":     stringer("stack context"),
-						".directory/file":      stringer("stack context"),
-						".file.hcl":            stringer(`data = "data"`),
-						".directory/.file.hcl": stringer(`data = "data"`),
-						".directory/file.hcl":  stringer(`data = "data"`),
-					},
-				},
-			},
-			wantReport: generate.Report{
-				Successes: []generate.Result{
-					{
-						Dir:     project.NewPath("/"),
-						Created: []string{".root-file"},
-					},
-					{
-						Dir: project.NewPath("/.directory"),
-						Created: []string{
-							".root-file",
-							"root-file",
-						},
-					},
-					{
-						Dir: project.NewPath("/stack"),
-						Created: []string{
-							".directory/.file",
-							".directory/.file.hcl",
-							".directory/file",
-							".directory/file.hcl",
-							".file",
-							".file.hcl",
-						},
-					},
-				},
-			},
-		},
 	})
 }
 
@@ -882,12 +744,12 @@ func testCodeGeneration(t *testing.T, tcases []testcase) {
 				t.Helper()
 
 				for _, wantDesc := range tcase.want {
-					dirRelPath := wantDesc.dir[1:]
-					dirEntry := s.DirEntry(dirRelPath)
+					stackRelPath := wantDesc.dir[1:]
+					stack := s.StackEntry(stackRelPath)
 
-					for name, wantContent := range wantDesc.files {
-						want := wantContent.String()
-						got := dirEntry.ReadFile(name)
+					for name, wantFiles := range wantDesc.files {
+						want := wantFiles.String()
+						got := stack.ReadFile(name)
 
 						test.AssertGenCodeEquals(t, got, want)
 					}

--- a/test/sandbox/sandbox.go
+++ b/test/sandbox/sandbox.go
@@ -486,9 +486,9 @@ func (de DirEntry) Chmod(relpath string, mode stdfs.FileMode) {
 // ReadFile will read a file inside this dir entry with the given name.
 // It will fail the test if the file doesn't exist, since it assumes an
 // expectation on the file being there.
-func (de DirEntry) ReadFile(name string) string {
+func (de DirEntry) ReadFile(name string) []byte {
 	de.t.Helper()
-	return string(test.ReadFile(de.t, de.abspath, name))
+	return test.ReadFile(de.t, de.abspath, name)
 }
 
 // RemoveFile will delete a file inside this dir entry with the given name.


### PR DESCRIPTION
## What this PR does / why we need it:

This reverts commit 394378ca5f17c2efb67bfcac83054a80abc705b0.

It introduces issues with Terraform modules downloaded that contain generated files.

## Which issue(s) this PR fixes:

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
<!--
If no, just write "no" in the block below.
If yes, please explain the change and update documentation and the CHANGELOG.md file accordingly.
-->
```
no
```
