### PR TITLE
chore: hide subcommands from --help.

### DIFF
--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -302,7 +302,8 @@ func newCLI(version string, args []string, stdin io.Reader, stdout, stderr io.Wr
 		kong.Description("A tool for managing terraform stacks"),
 		kong.UsageOnError(),
 		kong.ConfigureHelp(kong.HelpOptions{
-			Compact: true,
+			Compact:             true,
+			NoExpandSubcommands: true,
 		}),
 		kong.Exit(func(status int) {
 			// Avoid kong aborting entire process since we designed CLI as lib


### PR DESCRIPTION
## What this PR does / why we need it:

Only shows top-level commands in the `--help`. 

## Which issue(s) this PR fixes:

none

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
yes but it's just a cosmetic change.
```
