### PR TITLE
chore: Improve output of terramate run

### DIFF
--- a/cmd/terramate/e2etests/cloud/run_cloud_config_test.go
+++ b/cmd/terramate/e2etests/cloud/run_cloud_config_test.go
@@ -180,6 +180,7 @@ func TestCloudConfig(t *testing.T) {
 
 			cmd := []string{
 				"run",
+				"--quiet",
 				"--cloud-sync-deployment",
 				"--", HelperPath, "true",
 			}

--- a/cmd/terramate/e2etests/cloud/run_cloud_deployment_test.go
+++ b/cmd/terramate/e2etests/cloud/run_cloud_deployment_test.go
@@ -134,9 +134,12 @@ func TestCLIRunWithCloudSyncDeployment(t *testing.T) {
 			cmd:      []string{HelperPath, "cat", "test.txt"},
 			want: want{
 				run: RunExpected{
-					Status:       1,
-					Stdout:       "test",
-					IgnoreStderr: true,
+					Status: 1,
+					Stdout: "test",
+					StderrRegexes: []string{
+						"Error: one or more commands failed",
+						"execution failed",
+					},
 				},
 				events: eventsResponse{
 					"s1": []string{"pending", "running", "failed"},
@@ -354,7 +357,7 @@ func TestCLIRunWithCloudSyncDeployment(t *testing.T) {
 			runid := uuid.String()
 			cli.AppendEnv = []string{"TM_TEST_RUN_ID=" + runid}
 
-			runflags := []string{"run", "--cloud-sync-deployment"}
+			runflags := []string{"run", "--quiet", "--cloud-sync-deployment"}
 			runflags = append(runflags, tc.runflags...)
 			runflags = append(runflags, "--")
 			runflags = append(runflags, tc.cmd...)

--- a/cmd/terramate/e2etests/cloud/run_cloud_drift_test.go
+++ b/cmd/terramate/e2etests/cloud/run_cloud_drift_test.go
@@ -491,7 +491,7 @@ func TestCLIRunWithCloudSyncDriftStatus(t *testing.T) {
 			env = append(env, "TMC_API_URL=http://"+addr)
 			cli := NewCLI(t, filepath.Join(s.RootDir(), filepath.FromSlash(tc.workingDir)), env...)
 			cli.PrependToPath(filepath.Dir(TerraformTestPath))
-			runflags := []string{"run", "--cloud-sync-drift-status"}
+			runflags := []string{"run", "--quiet", "--cloud-sync-drift-status"}
 			runflags = append(runflags, tc.runflags...)
 			runflags = append(runflags, "--")
 			runflags = append(runflags, tc.cmd...)

--- a/cmd/terramate/e2etests/cloud/run_cloud_uimode_test.go
+++ b/cmd/terramate/e2etests/cloud/run_cloud_uimode_test.go
@@ -74,6 +74,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 					uimode: cli.HumanMode,
 					cmd: []string{
 						"run",
+						"--quiet",
 						"--cloud-sync-deployment",
 						"--", HelperPath, "true",
 					},
@@ -83,6 +84,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 					uimode: cli.AutomationMode,
 					cmd: []string{
 						"run",
+						"--quiet",
 						"--cloud-sync-deployment",
 						"--", HelperPath, "true",
 					},
@@ -92,6 +94,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 					uimode: cli.HumanMode,
 					cmd: []string{
 						"run",
+						"--quiet",
 						"--cloud-sync-drift-status",
 						"--", HelperPath, "true",
 					},
@@ -101,6 +104,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 					uimode: cli.AutomationMode,
 					cmd: []string{
 						"run",
+						"--quiet",
 						"--cloud-sync-drift-status",
 						"--", HelperPath, "true",
 					},
@@ -236,6 +240,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 					uimode: cli.HumanMode,
 					cmd: []string{
 						"run",
+						"--quiet",
 						"--cloud-sync-deployment",
 						"--", HelperPath, "true",
 					},
@@ -245,6 +250,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 					uimode: cli.AutomationMode,
 					cmd: []string{
 						"run",
+						"--quiet",
 						"--cloud-sync-deployment",
 						"--", HelperPath, "true",
 					},
@@ -254,6 +260,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 					uimode: cli.HumanMode,
 					cmd: []string{
 						"run",
+						"--quiet",
 						"--cloud-sync-drift-status",
 						"--", HelperPath, "true",
 					},
@@ -263,6 +270,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 					uimode: cli.AutomationMode,
 					cmd: []string{
 						"run",
+						"--quiet",
 						"--cloud-sync-drift-status",
 						"--", HelperPath, "true",
 					},
@@ -975,6 +983,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 					uimode: cli.HumanMode,
 					cmd: []string{
 						"run",
+						"--quiet",
 						"--cloud-sync-deployment",
 						"--", HelperPath, "true",
 					},
@@ -984,6 +993,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 					uimode: cli.AutomationMode,
 					cmd: []string{
 						"run",
+						"--quiet",
 						"--cloud-sync-deployment",
 						"--", HelperPath, "true",
 					},
@@ -993,6 +1003,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 					uimode: cli.HumanMode,
 					cmd: []string{
 						"run",
+						"--quiet",
 						"--cloud-sync-drift-status",
 						"--", HelperPath, "true",
 					},
@@ -1002,6 +1013,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 					uimode: cli.AutomationMode,
 					cmd: []string{
 						"run",
+						"--quiet",
 						"--cloud-sync-drift-status",
 						"--", HelperPath, "true",
 					},

--- a/cmd/terramate/e2etests/core/exp_trigger_test.go
+++ b/cmd/terramate/e2etests/core/exp_trigger_test.go
@@ -206,6 +206,7 @@ func TestRunChangedDetectsTriggeredStack(t *testing.T) {
 
 	AssertRunResult(t, cli.Run(
 		"run",
+		"--quiet",
 		"--changed",
 		HelperPath,
 		"cat",
@@ -219,6 +220,7 @@ func TestRunChangedDetectsTriggeredStack(t *testing.T) {
 
 	AssertRunResult(t, cli.Run(
 		"run",
+		"--quiet",
 		"--changed",
 		HelperPath,
 		"cat",

--- a/cmd/terramate/e2etests/core/general_test.go
+++ b/cmd/terramate/e2etests/core/general_test.go
@@ -153,6 +153,7 @@ func TestListAndRunChangedStack(t *testing.T) {
 
 	AssertRunResult(t, cli.Run(
 		"run",
+		"--quiet",
 		"--changed",
 		HelperPath,
 		"cat",
@@ -198,6 +199,7 @@ func TestListAndRunChangedStackInAbsolutePath(t *testing.T) {
 
 	AssertRunResult(t, cli.Run(
 		"run",
+		"--quiet",
 		"--changed",
 		HelperPath,
 		"cat",
@@ -269,9 +271,7 @@ func TestBaseRefFlagPrecedenceOverDefault(t *testing.T) {
 	git.Push("main")
 
 	AssertRunResult(t, cli.ListChangedStacks("--git-change-base", "origin/main"),
-		RunExpected{
-			IgnoreStderr: true,
-		},
+		RunExpected{},
 	)
 }
 

--- a/cmd/terramate/e2etests/core/run_eval_test.go
+++ b/cmd/terramate/e2etests/core/run_eval_test.go
@@ -133,7 +133,7 @@ func TestRunEval(t *testing.T) {
 			}
 			s.BuildTree(tc.layout)
 			tmCli := NewCLI(t, s.RootDir())
-			cmd := []string{`run`}
+			cmd := []string{"run", "--quiet"}
 			if tc.eval {
 				cmd = append(cmd, `--eval`)
 			}

--- a/cmd/terramate/e2etests/core/run_unix_test.go
+++ b/cmd/terramate/e2etests/core/run_unix_test.go
@@ -81,7 +81,7 @@ func TestRunLookPathFromStackEnviron(t *testing.T) {
 
 	tm := NewCLI(t, s.RootDir())
 
-	AssertRunResult(t, tm.Run("run", "--", programName, "echo", "Hello from myscript"),
+	AssertRunResult(t, tm.Run("run", "--quiet", "--", programName, "echo", "Hello from myscript"),
 		RunExpected{
 			Stdout: "Hello from myscript\n",
 		})

--- a/cmd/terramate/e2etests/core/safeguard_test.go
+++ b/cmd/terramate/e2etests/core/safeguard_test.go
@@ -147,6 +147,7 @@ func TestSafeguardCheckRemoteDisabled(t *testing.T) {
 		tmcli, file, _ := setup(t)
 		AssertRunResult(t, tmcli.Run(
 			"run",
+			"--quiet",
 			"--disable-check-git-remote",
 			HelperPath,
 			"cat",
@@ -158,7 +159,7 @@ func TestSafeguardCheckRemoteDisabled(t *testing.T) {
 		tmcli, file, _ := setup(t, testEnviron(t)...)
 		tmcli.AppendEnv = append(tmcli.AppendEnv, "TM_DISABLE_CHECK_GIT_REMOTE=true")
 
-		AssertRunResult(t, tmcli.Run("run", HelperPath,
+		AssertRunResult(t, tmcli.Run("run", "--quiet", HelperPath,
 			"cat", file.HostPath()), RunExpected{
 			Stdout: fileContents,
 		})
@@ -214,7 +215,7 @@ func TestSafeguardCheckRemoteDisabled(t *testing.T) {
 			git.Add(rootConfig)
 			git.Commit("commit root config")
 
-			AssertRunResult(t, tmcli.Run("run", HelperPath,
+			AssertRunResult(t, tmcli.Run("run", "--quiet", HelperPath,
 				"cat", file.HostPath()), RunExpected{
 				Stdout: fileContents,
 			})
@@ -241,6 +242,7 @@ func TestSafeguardCheckRemoteDisabled(t *testing.T) {
 
 			AssertRunResult(t, tmcli.Run(
 				"run",
+				"--quiet",
 				"--disable-check-git-remote",
 				HelperPath,
 				"cat",
@@ -284,6 +286,7 @@ func TestSafeguardCheckRemoteDisabledWorksWithoutNetworking(t *testing.T) {
 	})
 	AssertRunResult(t, tm.Run(
 		"run",
+		"--quiet",
 		"--disable-check-git-remote",
 		HelperPath,
 		"cat",

--- a/cmd/terramate/e2etests/core/version_check_test.go
+++ b/cmd/terramate/e2etests/core/version_check_test.go
@@ -27,7 +27,7 @@ func TestVersionCheck(t *testing.T) {
 		"experimental run-graph": "experimental run-graph",
 		"generate":               "generate",
 		"list":                   "list",
-		"run":                    fmt.Sprintf("run %s cat %s", HelperPath, stack.DefaultFilename),
+		"run":                    fmt.Sprintf("run --quiet %s cat %s", HelperPath, stack.DefaultFilename),
 	}
 	uncheckedCmds := map[string]string{
 		"help":            "--help",

--- a/printer/printer.go
+++ b/printer/printer.go
@@ -63,6 +63,16 @@ func (p *Printer) ErrorWithDetailsln(title string, err error) {
 	}
 }
 
+// WarnWithDetailsln is similar to ErrorWithDetailsln but prints a warning
+// instead
+func (p *Printer) WarnWithDetailsln(title string, err error) {
+	p.Warnln(title)
+
+	for _, item := range toStrings(err) {
+		fmt.Fprintln(p.w, boldYellow(">"), item)
+	}
+}
+
 // Errorln prints a message with a "Error:" prefix. The prefix is prinited in
 // the boldRed style.
 func (p *Printer) Errorln(title string) {

--- a/run/order.go
+++ b/run/order.go
@@ -14,6 +14,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/terramate-io/terramate/config"
 	"github.com/terramate-io/terramate/errors"
+	"github.com/terramate-io/terramate/printer"
 	"github.com/terramate-io/terramate/run/dag"
 )
 
@@ -162,13 +163,15 @@ func BuildDAG(
 			}
 			st, err := os.Stat(abspath)
 			if err != nil {
-				log.Warn().
-					Err(err).
-					Msgf("building dag: failed to stat %s path %s - ignoring", fieldname, abspath)
+				printer.Stderr.WarnWithDetailsln(
+					fmt.Sprintf("Stack references invalid path in '%s' attribute", fieldname),
+					err,
+				)
 			} else if !st.IsDir() {
-				log.Warn().
-					Msgf("building dag: stack.%s path %s is not a directory - ignoring",
-						fieldname, pathstr)
+				printer.Stderr.WarnWithDetailsln(
+					fmt.Sprintf("Stack references invalid path in '%s' attribute", fieldname),
+					errors.E("Path %s is not a directory", pathstr),
+				)
 			} else {
 				uniqPaths[pathstr] = struct{}{}
 			}


### PR DESCRIPTION
## What this PR does / why we need it:

This PR improves the output of `terramate run` using the `printer` package.

Main changes:

* Print error messages of run command using the printer package
* Print `terramate: Entering stack in stackpath` in run command
  * not printed when `--quiet` is set
* Print `terramate: Executing command "echo hi"` in run command
  * not printed when `--quiet` is set
* Improve dry-run output (remove old dry-run output completely)
* Improve warnings in run/run-order DAG processing

## Which issue(s) this PR fixes:

## Special notes for your reviewer:

Depends on https://github.com/terramate-io/terramate/pull/1317

### Example screenshots

![image](https://github.com/terramate-io/terramate/assets/92498/8ec0bbeb-5790-4ac4-8fad-caa2658a1205)
---
![image](https://github.com/terramate-io/terramate/assets/92498/98c0f7a9-95a0-4022-81b5-ff6c5d1c6be9)
----
![image](https://github.com/terramate-io/terramate/assets/92498/3664e117-a180-4680-a8d9-8896d9f4526d)




## Does this PR introduce a user-facing change?

Yes, the output of the following commands has been improved:

* `terramate run somecmd`
* `terramate run --dry-run somecmd`
