### PR TITLE
chore: Create default printers

### DIFF
--- a/printer/printer.go
+++ b/printer/printer.go
@@ -6,6 +6,7 @@ package printer
 import (
 	"fmt"
 	"io"
+	"os"
 
 	"github.com/fatih/color"
 	"github.com/terramate-io/terramate/errors"
@@ -16,6 +17,13 @@ var (
 	boldYellow = color.New(color.Bold, color.FgYellow).Sprint
 	boldRed    = color.New(color.Bold, color.FgRed).Sprint
 	boldGreen  = color.New(color.Bold, color.FgGreen).Sprint
+)
+
+var (
+	// Stderr is the default stderr printer
+	Stderr = NewPrinter(os.Stderr)
+	// Stdout is the default stdout printer
+	Stdout = NewPrinter(os.Stdout)
 )
 
 // Printer encapuslates an io.Writer


### PR DESCRIPTION
## What this PR does / why we need it:

The default printers can be used by other packages without haaving to
manage printer instances e.g.:

```
printer.StdErr.Errorln("")
printer.StdErr.Successln("")
```

This approach is similar to the standard library `log` package where
a default logger instance is pre-initialized.

See https://github.com/golang/go/blob/master/src/log/log.go

## Which issue(s) this PR fixes:

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
no