### PR TITLE
fix: experimental eval output interpreted as fmt.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 ### Fixed
 
 - fix(generate): blocks with context=root were ignored if defined in stacks.
+- fix: experimental eval/partial-eval/get-config-value wrongly interprets the output as a formatter.
 
 ## 0.4.3
 

--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -1720,7 +1720,7 @@ func (c *cli) partialEval() {
 		if err != nil {
 			fatal(err, "partial eval %q", exprStr)
 		}
-		c.output.MsgStdOut(string(hclwrite.Format(ast.TokensForExpression(newexpr).Bytes())))
+		c.output.MsgStdOut("%s", string(hclwrite.Format(ast.TokensForExpression(newexpr).Bytes())))
 	}
 }
 
@@ -1794,7 +1794,7 @@ func (c *cli) outputEvalResult(val cty.Value, asJSON bool) {
 		}
 	}
 
-	c.output.MsgStdOut(string(data))
+	c.output.MsgStdOut("%s", string(data))
 }
 
 func (c *cli) detectEvalContext(overrideGlobals map[string]string) *eval.Context {

--- a/cmd/terramate/e2etests/core/exp_eval_test.go
+++ b/cmd/terramate/e2etests/core/exp_eval_test.go
@@ -257,6 +257,20 @@ func TestExpEval(t *testing.T) {
 				Stdout: addnl(`"AAA"`),
 			},
 		},
+		{
+			// issue: https://github.com/terramate-io/terramate/issues/1327
+			name: "regression check: globals containing percents",
+			overrideGlobals: map[string]string{
+				"x": `"E%2BkKhZA%3D"`,
+			},
+			expr: `global.x`,
+			wantEval: RunExpected{
+				Stdout: addnl(`E%2BkKhZA%3D`),
+			},
+			wantPartial: RunExpected{
+				Stdout: addnl(`"E%2BkKhZA%3D"`),
+			},
+		},
 	}
 
 	for _, tcase := range testcases {


### PR DESCRIPTION
## What this PR does / why we need it:

The output of `eval`, `partial-eval` and `get-config-value` was being interpreted as Go's printf formatter.

## Which issue(s) this PR fixes:
Fixes #1327 

## Special notes for your reviewer:

There are more places with incorrect usage of the function `MsgStdOut()` but they are harmless and will be fixed in a separate PR.

## Does this PR introduce a user-facing change?
```
yes but in the output of the experimental commands (eval, partial-eval and get-config-value).
```
