### PR TITLE
feat(cloud): send reviewers in deployment creation.

### DIFF
--- a/cloud/types.go
+++ b/cloud/types.go
@@ -220,14 +220,15 @@ type (
 
 	// DeploymentReviewRequest is the review_request object.
 	DeploymentReviewRequest struct {
-		Platform    string  `json:"platform"`
-		Repository  string  `json:"repository"`
-		CommitSHA   string  `json:"commit_sha"`
-		Number      int     `json:"number"`
-		Title       string  `json:"title"`
-		Description string  `json:"description"`
-		URL         string  `json:"url"`
-		Labels      []Label `json:"labels,omitempty"`
+		Platform    string    `json:"platform"`
+		Repository  string    `json:"repository"`
+		CommitSHA   string    `json:"commit_sha"`
+		Number      int       `json:"number"`
+		Title       string    `json:"title"`
+		Description string    `json:"description"`
+		URL         string    `json:"url"`
+		Labels      []Label   `json:"labels,omitempty"`
+		Reviewers   Reviewers `json:"reviewers,omitempty"`
 	}
 
 	// Label of a review request.
@@ -236,6 +237,15 @@ type (
 		Color       string `json:"color,omitempty"`
 		Description string `json:"description,omitempty"`
 	}
+
+	// Reviewer is the user's reviewer of a Pull/Merge Request.
+	Reviewer struct {
+		Login     string `json:"login"`
+		AvatarURL string `json:"avatar_url,omitempty"`
+	}
+
+	// Reviewers is a list of reviewers.
+	Reviewers []Reviewer
 
 	// UpdateDeploymentStack is the request payload item for updating the deployment status.
 	UpdateDeploymentStack struct {
@@ -295,6 +305,8 @@ var (
 	_ = Resource(UpdateDeploymentStack{})
 	_ = Resource(UpdateDeploymentStacks{})
 	_ = Resource(DeploymentReviewRequest{})
+	_ = Resource(Reviewer{})
+	_ = Resource(Reviewers{})
 	_ = Resource(Label{})
 	_ = Resource(Drifts{})
 	_ = Resource(DriftStackPayloadRequest{})
@@ -533,6 +545,17 @@ func (l Label) Validate() error {
 	}
 	return nil
 }
+
+// Validate the reviewer.
+func (r Reviewer) Validate() error {
+	if r.Login == "" {
+		return errors.E(`missing "login" field`)
+	}
+	return nil
+}
+
+// Validate the reviewers list.
+func (rs Reviewers) Validate() error { return validateResourceList(rs...) }
 
 // Validate the UpdateDeploymentStack object.
 func (d UpdateDeploymentStack) Validate() error {

--- a/cmd/terramate/cli/github/types.go
+++ b/cmd/terramate/cli/github/types.go
@@ -28,6 +28,16 @@ type (
 		// rest of the fields aren't important for the cli.
 	}
 
+	// Review represents the review information.
+	Review struct {
+		User              User      `json:"user"`
+		Body              string    `json:"body,omitempty"`
+		State             string    `json:"state,omitempty"`
+		SubmittedAt       time.Time `json:"submitted_at,omitempty"`
+		AuthorAssociation string    `json:"author_association,omitempty"`
+		CommitID          string    `json:"commit_id,omitempty"`
+	}
+
 	// Label of the issue or pull request.
 	Label struct {
 		Name        string `json:"name"`
@@ -85,4 +95,7 @@ type (
 
 	// Pulls represents a list of pull objects.
 	Pulls []Pull
+
+	// Reviews is a list of review objects.
+	Reviews []Review
 )

--- a/cmd/terramate/e2etests/cloud/interop/interoperability_test.go
+++ b/cmd/terramate/e2etests/cloud/interop/interoperability_test.go
@@ -41,7 +41,7 @@ func TestInteropDrift(t *testing.T) {
 	AssertRunResult(t, tmcli.Run("list"), RunExpected{
 		Stdout: nljoin("."),
 	})
-	// inititialize the providers
+	// initialize the providers
 	AssertRunResult(t,
 		tmcli.Run("run", "--", TerraformTestPath, "init"),
 		RunExpected{


### PR DESCRIPTION
## What this PR does / why we need it:

The Terramate Cloud frontend needs the list of reviewers of each deployment.

## Which issue(s) this PR fixes:

## Special notes for your reviewer:

Unfortunately no tests were added because it requires a GH API fake server.

## Does this PR introduce a user-facing change?
```
no
```
