### PR TITLE
feat(cloud): send labels in the deployment creation.

### DIFF
--- a/cloud/types.go
+++ b/cloud/types.go
@@ -220,13 +220,21 @@ type (
 
 	// DeploymentReviewRequest is the review_request object.
 	DeploymentReviewRequest struct {
-		Platform    string `json:"platform"`
-		Repository  string `json:"repository"`
-		CommitSHA   string `json:"commit_sha"`
-		Number      int    `json:"number"`
-		Title       string `json:"title"`
-		Description string `json:"description"`
-		URL         string `json:"url"`
+		Platform    string  `json:"platform"`
+		Repository  string  `json:"repository"`
+		CommitSHA   string  `json:"commit_sha"`
+		Number      int     `json:"number"`
+		Title       string  `json:"title"`
+		Description string  `json:"description"`
+		URL         string  `json:"url"`
+		Labels      []Label `json:"labels,omitempty"`
+	}
+
+	// Label of a review request.
+	Label struct {
+		Name        string `json:"name"`
+		Color       string `json:"color,omitempty"`
+		Description string `json:"description,omitempty"`
 	}
 
 	// UpdateDeploymentStack is the request payload item for updating the deployment status.
@@ -287,6 +295,7 @@ var (
 	_ = Resource(UpdateDeploymentStack{})
 	_ = Resource(UpdateDeploymentStacks{})
 	_ = Resource(DeploymentReviewRequest{})
+	_ = Resource(Label{})
 	_ = Resource(Drifts{})
 	_ = Resource(DriftStackPayloadRequest{})
 	_ = Resource(DriftStackPayloadRequests{})
@@ -513,6 +522,14 @@ func (d DeploymentStackResponse) Validate() error {
 func (rr DeploymentReviewRequest) Validate() error {
 	if rr.Repository == "" {
 		return errors.E(`missing "repository" field`)
+	}
+	return validateResourceList(rr.Labels...)
+}
+
+// Validate the label.
+func (l Label) Validate() error {
+	if l.Name == "" {
+		return errors.E(`missing "name" field`)
 	}
 	return nil
 }

--- a/cmd/terramate/cli/cloud.go
+++ b/cmd/terramate/cli/cloud.go
@@ -405,6 +405,14 @@ func (c *cli) detectCloudMetadata() {
 			CommitSHA:   pull.Head.SHA,
 		}
 
+		for _, l := range pull.Labels {
+			reviewRequest.Labels = append(reviewRequest.Labels, cloud.Label{
+				Name:        l.Name,
+				Color:       l.Color,
+				Description: l.Description,
+			})
+		}
+
 		c.cloud.run.reviewRequest = reviewRequest
 
 	} else {

--- a/cmd/terramate/cli/github/types.go
+++ b/cmd/terramate/cli/github/types.go
@@ -23,8 +23,16 @@ type (
 		MergeCommitSHA string  `json:"merge_commit_sha,omitempty"`
 		Head           RefInfo `json:"head"`
 		Base           RefInfo `json:"base"`
+		Labels         []Label `json:"labels"`
 
 		// rest of the fields aren't important for the cli.
+	}
+
+	// Label of the issue or pull request.
+	Label struct {
+		Name        string `json:"name"`
+		Color       string `json:"color"`
+		Description string `json:"description,omitempty"`
 	}
 
 	// Commit holds information of a specific commit.


### PR DESCRIPTION
## What this PR does / why we need it:

The Terramate Cloud frontend needs the labels (if available) of the PR in each deployment.

## Which issue(s) this PR fixes:

## Special notes for your reviewer:

Still no tests for GH integration.

## Does this PR introduce a user-facing change?
```
no
```
