### PR TITLE
chore: add missing json tag to github.Commit.Commit field.

### DIFF
--- a/cmd/terramate/cli/github/types.go
+++ b/cmd/terramate/cli/github/types.go
@@ -34,7 +34,7 @@ type (
 			Author    GitMetadata
 			Committer GitMetadata
 			Message   string
-		}
+		} `json:"commit"`
 		Author       User
 		Committer    User
 		Verification struct {


### PR DESCRIPTION
## What this PR does / why we need it:

The `encoding/json` uses a case insensitive matcher if an explicit `json:` tag is not used.

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
no
```
