### PR TITLE
chore: Add TMC backend as co-codeowner of cloud subdirectory

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 *       @terramate-io/cli-tooling
+/cloud  @terramate-io/cli-tooling @terramate-io/tmc-backend


### PR DESCRIPTION
## What this PR does / why we need it:

Add TMC backend team as part of cloud client to raise awareness of its usage.

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?

no
