### PR TITLE
chore(scripts): add support for command options

### DIFF
--- a/cmd/terramate/cli/run_script.go
+++ b/cmd/terramate/cli/run_script.go
@@ -91,14 +91,14 @@ func (c *cli) runScript() {
 			for jobNum, j := range evalScript.Jobs {
 				c.output.MsgStdOut("")
 				for cmdNum, cmd := range j.Commands() {
-					printCommand(c.stderr, cmd, st.Dir().String(), jobNum, cmdNum)
+					printCommand(c.stderr, cmd.Args, st.Dir().String(), jobNum, cmdNum)
 
 					env, err := run.LoadEnv(c.cfg(), st.Stack)
 					if err != nil {
 						logger.Fatal().Err(err).Msg("failed to load env")
 					}
 
-					if err := c.executeCommand(cmd, st.Dir().HostPath(c.rootdir()), newEnvironFrom(env)); err != nil {
+					if err := c.executeCommand(cmd.Args, st.Dir().HostPath(c.rootdir()), newEnvironFrom(env)); err != nil {
 						logger.Fatal().Err(err).Msg("unable to execute command")
 					}
 				}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/terramate-io/terramate/blob/main/CONTRIBUTING.md
2. If the PR is unfinished, mark it as draft: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request
3. Please update the PR title using the Conventional Commits convention: https://www.conventionalcommits.org/en/v1.0.0/
    Example: feat: add support for XYZ.
-->

## What this PR does / why we need it:
This PR adds support for an optional options object at the end of the command list. This is part of supporting cloud deployment sync for scripts.

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Keep it empty if not applicable.
-->

## Special notes for your reviewer:
* The options don't do anything yet, this will be done in a future PR. They are just parsed and validated for now.

## Does this PR introduce a user-facing change?
<!--
If no, just write "no" in the block below.
If yes, please explain the change and update documentation and the CHANGELOG.md file accordingly.
-->
```
no
```
