### PR TITLE
chore: fix CHANGELOG for next stable release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,10 +27,11 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 - Add `terramate.config.experiments` configuration to enable experimental features.
 - Add support for statuses `ok, failed, drifted and healthy` to the `--experimental-status` flag.
 - Add experimental `script` configuration block.
-- Add `terramate experimental script list` to list scripts visible in current directory.
-- Add `terramate experimental script tree` to show a tree view of scripts visible in current directory.
-- Add `terramate experimental script info <scriptname>` to show details about a script.
-- Add `terramate experimental script run <scriptname>` to run a script in all relevant stacks.
+- Add `terramate script list` to list scripts visible in current directory.
+- Add `terramate script tree` to show a tree view of scripts visible in current directory.
+- Add `terramate script info <scriptname>` to show details about a script.
+- Add `terramate script run <scriptname>` to run a script in all relevant stacks.
+- Add `stack_filter` block to `generate_hcl` for path-based conditional generation.
 
 ### Fixed
 


### PR DESCRIPTION
## What this PR does / why we need it:

- The `script` command was promoted out of the `experimental` sub-command and this change wasn't included in the CHANGELOG.
- The `stack_filter` block was not included in the CHANGELOG.

## Which issue(s) this PR fixes:
none

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
no
```
