### PR TITLE
feat: promote experimental commands

### DIFF
--- a/cmd/terramate/e2etests/core/debug_show_generate_test.go
+++ b/cmd/terramate/e2etests/core/debug_show_generate_test.go
@@ -156,7 +156,7 @@ func TestGenerateDebug(t *testing.T) {
 			}
 
 			ts := NewCLI(t, filepath.Join(s.RootDir(), tc.wd))
-			AssertRunResult(t, ts.Run("experimental", "generate", "debug"), tc.want)
+			AssertRunResult(t, ts.Run("debug", "show", "generate-origins"), tc.want)
 		})
 	}
 }
@@ -200,18 +200,18 @@ func TestGenerateDebugWithChanged(t *testing.T) {
 /stack-1/file.txt origin: /config.tm:1,1-3,2
 `
 	ts := NewCLI(t, s.RootDir())
-	AssertRunResult(t, ts.Run("experimental", "generate", "debug", "--changed"), RunExpected{
+	AssertRunResult(t, ts.Run("debug", "show", "generate-origins", "--changed"), RunExpected{
 		Stdout: want,
 	})
 
 	ts = NewCLI(t, filepath.Join(s.RootDir(), "stack-1"))
-	AssertRunResult(t, ts.Run("experimental", "generate", "debug", "--changed"), RunExpected{
+	AssertRunResult(t, ts.Run("debug", "show", "generate-origins", "--changed"), RunExpected{
 		Stdout: want,
 	})
 
 	ts = NewCLI(t, filepath.Join(s.RootDir(), "stack-2"))
-	AssertRunResult(t, ts.Run("experimental", "generate", "debug", "--changed"), RunExpected{})
+	AssertRunResult(t, ts.Run("debug", "show", "generate-origins", "--changed"), RunExpected{})
 
 	ts = NewCLI(t, filepath.Join(s.RootDir(), "no-stack"))
-	AssertRunResult(t, ts.Run("experimental", "generate", "debug", "--changed"), RunExpected{})
+	AssertRunResult(t, ts.Run("debug", "show", "generate-origins", "--changed"), RunExpected{})
 }

--- a/cmd/terramate/e2etests/core/debug_show_globals_test.go
+++ b/cmd/terramate/e2etests/core/debug_show_globals_test.go
@@ -253,7 +253,7 @@ stack "/stacks/stack-name":
 				}
 
 				ts := NewCLI(t, project.AbsPath(s.RootDir(), tcase.wd))
-				AssertRunResult(t, ts.Run("experimental", "globals"), tcase.want)
+				AssertRunResult(t, ts.Run("debug", "show", "globals"), tcase.want)
 			}
 		})
 	}

--- a/cmd/terramate/e2etests/core/debug_show_metadata_test.go
+++ b/cmd/terramate/e2etests/core/debug_show_metadata_test.go
@@ -236,7 +236,7 @@ stack "/stack":
 			s.BuildTree(tc.layout)
 
 			cli := NewCLI(t, project.AbsPath(s.RootDir(), tc.wd))
-			AssertRunResult(t, cli.Run("experimental", "metadata"), tc.want)
+			AssertRunResult(t, cli.Run("debug", "show", "metadata"), tc.want)
 		})
 	}
 }

--- a/cmd/terramate/e2etests/core/imports_test.go
+++ b/cmd/terramate/e2etests/core/imports_test.go
@@ -40,7 +40,7 @@ func TestImportsGlob(t *testing.T) {
 
 		tmcli := NewCLI(t, s.RootDir())
 		AssertRunResult(t,
-			tmcli.Run("experimental", "globals"),
+			tmcli.Run("debug", "show", "globals"),
 			want,
 		)
 	}

--- a/cmd/terramate/e2etests/core/run_test.go
+++ b/cmd/terramate/e2etests/core/run_test.go
@@ -2505,7 +2505,7 @@ stack "/stack":
 	TERRAMATE_OVERRIDDEN=%s
 `, exportedTerramateTest, stackGlobal, stackName, newTerramateOverriden)
 
-		AssertRunResult(t, tm.Run("experimental", "run-env"), RunExpected{
+		AssertRunResult(t, tm.Run("debug", "show", "runtime-env"), RunExpected{
 			IgnoreStderr: true,
 			Stdout:       want})
 	})

--- a/cmd/terramate/e2etests/core/safeguard_test.go
+++ b/cmd/terramate/e2etests/core/safeguard_test.go
@@ -28,14 +28,14 @@ func TestSafeguardCheckRemoteNotRequiredInSomeCommands(t *testing.T) {
 	cli := NewCLI(t, s.RootDir())
 
 	cmds := []string{
-		"experimental metadata",
-		"experimental globals",
+		"debug show metadata",
+		"debug show globals",
 		"experimental run-order",
-		"experimental run-graph",
+		"debug render run-graph",
 		"experimental eval 1+1",
 		"experimental partial-eval 1+1",
 		"experimental get-config-value global",
-		"experimental generate debug",
+		"debug show generate-origins",
 		"create stack-2",
 		"generate",
 		"list",

--- a/cmd/terramate/e2etests/core/version_check_test.go
+++ b/cmd/terramate/e2etests/core/version_check_test.go
@@ -21,10 +21,10 @@ func TestVersionCheck(t *testing.T) {
 	t.Parallel()
 
 	checkedCmds := map[string]string{
-		"experimental metadata":  "experimental metadata",
-		"experimental globals":   "experimental globals",
+		"debug show metadata":    "debug show metadata",
+		"debug show globals":     "debug show globals",
 		"experimental run-order": "experimental run-order",
-		"experimental run-graph": "experimental run-graph",
+		"debug render run-graph": "debug render run-graph",
 		"generate":               "generate",
 		"list":                   "list",
 		"run":                    fmt.Sprintf("run --quiet %s cat %s", HelperPath, stack.DefaultFilename),

--- a/cmd/terramate/e2etests/internal/runner/runner.go
+++ b/cmd/terramate/e2etests/internal/runner/runner.go
@@ -256,7 +256,7 @@ func (tm CLI) StacksRunOrder(args ...string) RunResult {
 
 // StacksRunGraph is a helper for executing `terramate experimental run-graph`.
 func (tm CLI) StacksRunGraph(args ...string) RunResult {
-	return tm.Run(append([]string{"experimental", "run-graph"}, args...)...)
+	return tm.Run(append([]string{"debug", "render", "run-graph"}, args...)...)
 }
 
 // ListStacks is a helper for executinh `terramate list`.

--- a/docs/cli/cmdline/globals.md
+++ b/docs/cli/cmdline/globals.md
@@ -5,26 +5,22 @@ description: With the terramate globals command you print all globals used in st
 
 # Globals
 
-::: warning
-This is an experimental command and is likely subject to change in the future.
-:::
-
 The `globals` command outputs all globals computed for a stack and all child stacks recursively.
 
 ## Usage
 
-`terramate experimental globals [options]`
+`terramate debug show globals [options]`
 
 ## Examples
 
 Print globals for the stack in the current directory:
 
 ```bash
-terramate experimental globals
+terramate debug show globals
 ```
 
-Change the working directory: 
+Change the working directory:
 
 ```bash
-terramate experimental globals --chdir stacks/example
+terramate debug show globals --chdir stacks/example
 ```

--- a/docs/cli/cmdline/metadata.md
+++ b/docs/cli/cmdline/metadata.md
@@ -5,26 +5,22 @@ description: With the terramate metadata command you can see a list of stacks an
 
 # Metadata
 
-::: warning
-This is an experimental command and is likely subject to change in the future.
-:::
-
-The `metadata` command prints information stacks and their metadata in the current directory recursively. 
+The `metadata` command prints information stacks and their metadata in the current directory recursively.
 
 ## Usage
 
-`terramate experimental metadata`
+`terramate debug show metadata`
 
 ## Examples
 
 List all stacks and their metadata in the current directory recursively:
 
 ```bash
-terramate experimental metadata
+terramate debug show metadata
 ```
 
 Explicitly change the working directory:
 
 ```bash
-terramate experimental metadata --chdir path/to/directory
+terramate debug show metadata --chdir path/to/directory
 ```

--- a/docs/cli/cmdline/run-env.md
+++ b/docs/cli/cmdline/run-env.md
@@ -1,25 +1,22 @@
 ---
-title: terramate run-env - Command
+title: terramate runtime-env - Command
 description: With the terramate run-env command see all environment variables configured for stacks.
 ---
 
 # Run Env
 
-::: warning
-This is an experimental command and is likely subject to change in the future.
-:::
 
 The `run-env` command prints all values configured in the `terramate.config.run.env` blocks for all stacks in the current
 directory recursively.
 
 ## Usage
 
-`terramate experimental run-env [options]`
+`terramate debug show runtime-env [options]`
 
 ## Examples
 
 Print all values environment variables configured for stacks and child stacks in the current directory:
 
 ```bash
-terramate experimental run-env
+terramate debug show runtime-env
 ```

--- a/docs/cli/cmdline/run-graph.md
+++ b/docs/cli/cmdline/run-graph.md
@@ -5,20 +5,16 @@ description: With the terramate run-graph command you can print a graph describi
 
 # Run Graph
 
-::: warning
-This is an experimental command and is likely subject to change in the future.
-:::
-
 The `run-graph` command prints a graph describing the [order of execution](../orchestration/index.md) of your stacks.
 
 ## Usage
 
-`terramate experimental run-graph`
+`terramate debug render run-graph`
 
 ## Examples
 
-Print the graph for all stacks in the current directory recursively: 
+Print the graph for all stacks in the current directory recursively:
 
 ```bash
-terramate experimental run-graph
+terramate debug render run-graph
 ```

--- a/docs/cli/getting-started/index.md
+++ b/docs/cli/getting-started/index.md
@@ -278,10 +278,10 @@ globals {
 }
 ```
 
-To view how globals are evaluated in each stack, run the experimental command `terramate experimental globals`:
+To view how globals are evaluated in each stack, run the experimental command `terramate debug show globals`:
 
 ```bash
-$ terramate experimental globals
+$ terramate debug show globals
 stack "/dev/mysite":
         env   = "dev"
         title = "THIS IS DEV"


### PR DESCRIPTION
## What this PR does / why we need it:

The following commands are being promoted out of experimental:

* `experimental metadata` -> `debug show metadata`
* `experimental globals` -> `debug show globals`
* `experimental generate debug` -> `debug show generate-origins`
* `experimental run-env` -> `debug show runtime-env`
* `experimental run-graph` -> `debug render run-graph`

## Which issue(s) this PR fixes:

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?

```
Yes, users must switch to the new command path for the above mentioned commands.
```
