### PR TITLE
Format all examples in docs

### DIFF
--- a/docs/cli/code-generation/generate-hcl.md
+++ b/docs/cli/code-generation/generate-hcl.md
@@ -134,10 +134,10 @@ generate_hcl "file.tf" {
     tm_dynamic "block" {
       for_each = global.values
       iterator = value
-      labels = ["some", "labels", value.value]
+      labels   = ["some", "labels", value.value]
 
       content {
-        key = value.key
+        key   = value.key
         value = value.value
       }
     }
@@ -181,7 +181,7 @@ generate_hcl "file.tf" {
       iterator = value
 
       attributes = {
-        attr = "index: ${value.key}, value: ${value.value}"
+        attr  = "index: ${value.key}, value: ${value.value}"
         attr2 = not_evaluated.attr
       }
     }
@@ -221,12 +221,12 @@ is false, so it is safe to use it like this:
 generate_hcl "file.tf" {
   content {
     tm_dynamic "block" {
-      for_each = global.values
+      for_each  = global.values
       condition = tm_can(global.values)
-      iterator = value
+      iterator  = value
 
       attributes = {
-        attr = "index: ${value.key}, value: ${value.value}"
+        attr  = "index: ${value.key}, value: ${value.value}"
         attr2 = not_evaluated.attr
       }
     }
@@ -265,7 +265,7 @@ generate_hcl "file" {
   }
   content {
     resource "networking_resource" "name" {
-        # ...
+      # ...
     }
   }
 }
@@ -419,8 +419,8 @@ This:
 generate_hcl "main.tf" {
   content {
     resource "myresource" "name" {
-      data  = upper(global.terramate_data)
-      name  = upper(local.name)
+      data = upper(global.terramate_data)
+      name = upper(local.name)
     }
   }
 }

--- a/docs/cli/code-generation/variables/globals.md
+++ b/docs/cli/code-generation/variables/globals.md
@@ -67,14 +67,17 @@ some use cases. To set a specific value of a key within a `map` without redefini
 globals <variable> [key] [key] ... {
   <key> = <expression>
 } 
+```
 
-# example:
-global "mymap" "nested" {
+Example:
+
+```hcl
+globals "mymap" "nested" {
   key = "value"      # set global.mymap.nested.key = "value"
 }
 
 # equal initial definition without labels:
-global {
+globals {
   mymap = {          # set global.mymap = { nested = { key = "value" } }
     nested = {       # set global.mymap.nested = { key = "value" }
       key = "value"  # set global.mymap.nested.key = "value"

--- a/docs/cli/code-generation/variables/lets.md
+++ b/docs/cli/code-generation/variables/lets.md
@@ -33,7 +33,7 @@ Example:
 generate_file "file.json" {
   lets {
     # let.json is available in the current generate_file block only
-    json = tm_jsonencode({"hello"="world"})
+    json = tm_jsonencode({ "hello" = "world" })
   }
 
   content = let.json

--- a/docs/cli/code-generation/variables/map.md
+++ b/docs/cli/code-generation/variables/map.md
@@ -64,14 +64,14 @@ Take a look at the `global.orders` list declared below:
 ```hcl
 globals {
   orders = [
-    {name = "Morpheus", product = "sunglass", price = 100.5},
-    {name = "Trinity",  product = "cape",     price = 82.30},
-    {name = "Trinity",  product = "necklace", price = 25.0},
-    {name = "Trinity",  product = "sunglass", price = 100.5},
-    {name = "Anderson", product = "ollydbg",  price = 30},
-    {name = "Morpheus", product = "boot",     price = 65},
-    {name = "Anderson", product = "cape",     price = 82.30},
-    {name = "Morpheus", product = "sunglass", price = 145.50},
+    { name = "Morpheus", product = "sunglass", price = 100.5 },
+    { name = "Trinity", product = "cape", price = 82.30 },
+    { name = "Trinity", product = "necklace", price = 25.0 },
+    { name = "Trinity", product = "sunglass", price = 100.5 },
+    { name = "Anderson", product = "ollydbg", price = 30 },
+    { name = "Morpheus", product = "boot", price = 65 },
+    { name = "Anderson", product = "cape", price = 82.30 },
+    { name = "Morpheus", product = "sunglass", price = 145.50 },
   ]
 }
 ```

--- a/docs/cli/introduction.md
+++ b/docs/cli/introduction.md
@@ -200,11 +200,11 @@ Terramate CLI allows us to generate all kinds of code and files using its built-
 
 ```hcl
 generate_file "hello_world.json" {
-  content = tm_jsonencode({"hello" = "world"})
+  content = tm_jsonencode({ "hello" = "world" })
 }
 
 generate_file "hello_world.yml" {
-  content = tm_yamlencode({"hello" = "world"})
+  content = tm_yamlencode({ "hello" = "world" })
 }
 ```
 

--- a/docs/cli/orchestration/run-commands-in-stacks.md
+++ b/docs/cli/orchestration/run-commands-in-stacks.md
@@ -97,13 +97,14 @@ using the `watch` property in the configuration of a stack.
 
 ```hcl
 stack {
-  name        = "Some Application"
-  tags        = ["kubernetes"]
-  id          = "f2b426b2-f614-4fa5-8f12-af78e5dcc13e"
-  watch       = [
+  name = "Some Application"
+  tags = ["kubernetes"]
+  id   = "f2b426b2-f614-4fa5-8f12-af78e5dcc13e"
+  watch = [
     "/path/to/file",
   ]
 }
+
 ```
 
 ### Changing the run scope and order

--- a/docs/cli/projects/configuration.md
+++ b/docs/cli/projects/configuration.md
@@ -20,9 +20,10 @@ terramate {
   required_version = "~> 0.4.3"
 
   config {
-  # config options
+    # config options
   }
 }
+
 ```
 
 
@@ -80,8 +81,8 @@ terramate {
   config {
     git {
       # Git configuration
-      default_remote    = "origin"
-      default_branch    = "main"
+      default_remote = "origin"
+      default_branch = "main"
 
       # Safeguard
       check_untracked   = false

--- a/docs/cli/stacks/index.md
+++ b/docs/cli/stacks/index.md
@@ -108,7 +108,7 @@ stack {
   # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   # Optionally the trigger behavior can be configured 
   # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  
+
   # If any of the configured files changed, this stack will be marked as changed in the change detection.
   watch = [
     "/policies/mypolicy.json"


### PR DESCRIPTION
Run `terramate fmt` on all examples used in the documentation