### PR TITLE
feat: introduce --disable-safeguards=<options>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
   - `terramate list --experimental-status=` -> `terramate list --cloud-status=`
 - Add `list --run-order` flag to list stacks in the order they would be executed.
 - Add support for deployment syncing to script commands.
+- Add `disable_safeguards` configuration option and CLI flag.
 
 ## 0.4.4
 

--- a/cmd/terramate/cli/clitest/messages.go
+++ b/cmd/terramate/cli/clitest/messages.go
@@ -41,4 +41,7 @@ const (
 
 	// ErrCloudInvalidTerraformPlanFilePath indicates the plan file is not valid.
 	ErrCloudInvalidTerraformPlanFilePath errors.Kind = "invalid plan file path"
+
+	// ErrSafeguardKeywordValidation indicates the safeguard keywords validation failed.
+	ErrSafeguardKeywordValidation errors.Kind = "failed to validate safeguard keywords"
 )

--- a/docs/cli/configuration/index.md
+++ b/docs/cli/configuration/index.md
@@ -161,6 +161,7 @@ The `terramate.config` block has no labels and has the following schema:
 | name             |      type      | description |
 |------------------|----------------|-------------|
 | [git](#terramateconfiggit-block-schema) | block | git configuration |
+| disable_safeguards | set(string) | list of safeguards to be disabled |
 
 ## terramate.config.git block schema
 
@@ -171,9 +172,9 @@ The `terramate.config.git` block has no labels and has the following schema:
 | default\_branch | string | The default git branch |
 | default\_remote | string | The default git remote |
 | default\_branch\_base\_ref| string | The default git branch base reference |
-| check\_untracked | boolean | Enable check of untracked files | true
-| check\_uncommitted | boolean | Enable check of uncommitted files | true
-| check\_remote | boolean | Enable checking if local main is updated with remote | true
+| check\_untracked | boolean | (DEPRECATED) Enable check of untracked files | true
+| check\_uncommitted | boolean | (DEPRECATED) Enable check of uncommitted files | true
+| check\_remote | boolean | (DEPRECATED) Enable checking if local main is updated with remote | true
 
 ## terramate.config.run block schema
 
@@ -181,7 +182,7 @@ The `terramate.config.run` block has no labels and has the following schema:
 
 | name             |      type      | description | default |
 |------------------|----------------|-------------|---------|
-| check\_gen_\_code | boolean | Enable check for up to date generated code | true
+| check\_gen\_code | boolean | (DEPRECATED) Enable check for up to date generated code | true
 
 ## terramate.config.run.env block schema
 

--- a/docs/cli/orchestration/safeguards.md
+++ b/docs/cli/orchestration/safeguards.md
@@ -5,8 +5,7 @@ description: Learn about the various safeguards provided by Terramate CLI that h
 
 # Safeguards
 
-Terramate CLI has a number of safeguards when executing commands with `terramate run`, to ensure that the code you're running
-against is *exactly what you intended*.
+Terramate CLI has a number of safeguards when executing commands with `terramate run`, to ensure that the code you're running against is *exactly what you intended*.
 
 ## Git checks
 
@@ -33,8 +32,51 @@ We also recommend using git hooks (e.g. [pre-commit](https://pre-commit.com/)) t
 ## Disabling checks
 
 Safeguards are enabled per default and help you to keep your environment safe, but if required
-they *can* be disabled either via environment variable or via the [project configuration](../projects/configuration.md).
-Environment variables always take precedence over project config.
+they *can* be disabled via CLI flags, environment variables or using the [project configuration](../projects/configuration.md).
+Environment variables and CLI flags always take precedence over project config.
+
+The `terramate.config.disable_safeguards` supports a list of check keywords to be disabled.
+Below is a list of supported values:
+
+| Check name | Description |
+| --- | --- |
+| all | Disable all checks |
+| git | Disable all git related checks |
+| git-untracked | Disable the check for untracked files |
+| git-uncommitted | Disable the check for uncommitted files |
+| git-out-of-sync | Disable the check for git remote out of sync |
+| outdated-code | Disable the check for outdated code |
+
+The keywords above can be used together in the environment variable `TM_DISABLE_SAFEGUARDS`,
+in the `terramate.config.disable_safeguards` or provided in the command line in
+the `--disable-safeguards=<options>`. Examples:
+
+Using environment variable:
+```
+TM_DISABLE_SAFEGUARDS=git-untracked,git-uncommitted terramate run -- <cmd>
+```
+
+Using cli flag:
+
+```
+terramate run --disable-safeguards=git-untracked,git-uncommitted -- <cmd>
+```
+
+Using the configuration file:
+
+```hcl
+# terramate.tm
+terramate {
+  config {
+    disable_safeguards = ["git-untracked", "git-uncommitted"]
+  }
+}
+```
+
+### Deprecated config and environment variables
+
+The list of attributes and correspondent environment variable listed below are
+deprecated and can be removed in future versions of Terramate.
 
 | Project configuration setting | Environment variable |
 | --- | --- |
@@ -43,7 +85,7 @@ Environment variables always take precedence over project config.
 | `terramate.config.git.check_uncommitted = false` | `TM_DISABLE_CHECK_GIT_UNCOMMITTED=true` |
 | `terramate.config.run.check_gen_code = false` | `TM_DISABLE_CHECK_GEN_CODE=true` |
 
-### Example of a project config disabling all checks
+#### Example of a project config disabling all checks
 
 ```hcl
 # terramate.tm.hcl

--- a/safeguard/doc.go
+++ b/safeguard/doc.go
@@ -1,0 +1,6 @@
+// Copyright 2024 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+// Package safeguard provides types and methods for dealing with
+// safeguards keywords.
+package safeguard

--- a/safeguard/safeguard.go
+++ b/safeguard/safeguard.go
@@ -1,0 +1,72 @@
+// Copyright 2024 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+package safeguard
+
+import "github.com/terramate-io/terramate/errors"
+
+// Keyword is a safeguard keyword.
+type Keyword string
+
+// Keywords is list of ketywords.
+type Keywords []Keyword
+
+// Available keywords.
+const (
+	All            Keyword = "all"
+	None           Keyword = "none"
+	Git            Keyword = "git"
+	GitUntracked   Keyword = "git-untracked"
+	GitUncommitted Keyword = "git-uncommitted"
+	GitOutOfSync   Keyword = "git-out-of-sync"
+	Outdated       Keyword = "outdated-code"
+)
+
+// FromStrings constructs a Keywords list out of a list of strings.
+func FromStrings(strs []string) (Keywords, error) {
+	var keywords Keywords
+	for _, str := range strs {
+		k := Keyword(str)
+		if !k.IsValid() {
+			return nil, errors.E(`invalid keyword %q`, str)
+		}
+		keywords = append(keywords, k)
+	}
+	return keywords, nil
+}
+
+// Validate the keywords.
+func (ks Keywords) Validate() error {
+	for _, k := range ks {
+		if !k.IsValid() {
+			return errors.E("invalid safeguard keyword: %s", k)
+		}
+	}
+	return nil
+}
+
+// Has tell if target exists in the list of keywords.
+func (ks Keywords) Has(target ...Keyword) bool {
+	for _, t := range target {
+		for _, k := range ks {
+			if k == t {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// IsValid checks if k is valid.
+func (k Keyword) IsValid() bool {
+	valid := map[Keyword]bool{
+		All:            true,
+		None:           true,
+		Git:            true,
+		GitUntracked:   true,
+		GitUncommitted: true,
+		GitOutOfSync:   true,
+		Outdated:       true,
+	}
+	return valid[k]
+}


### PR DESCRIPTION
## What this PR does / why we need it:

Introduces the flag `--disable-safeguards=<list of options>` and `terramate.config.disable_safeguards` configuration option. The options are:

| keyword            | meaning     |
| ------------------ | ----------- |
| git-untracked      | Disables the check for untracked files       |
| git-uncommitted    | Disables the check for uncommitted files     |
| git-out-of-sync    | Disables the check for git remote out of sync |
| outdated-code      | Disables the check for outdated code          |

Additionally, the following group keywords are supported:

| keyword            | meaning     |
| ------------------ | ----------- |
| git                | Disables all git related checks |
| all                | Disables all checks |
| none               | Re-enables all checks (if disabled by the config) |

The environment variable `TM_DISABLE_SAFEGUARDS` can also be used and it supports the same keyword list as the flag and config.
The list of keywords must be comma-separated list of strings.

Example:

```
terramate run --disable-safeguards=git-untracked,outdated-code -- <cmd>
```

The `-X` flag is a shorthand for `--disable-safeguards=all`.

The older flags `--disable-check-git-untracked`, `--disable-check-git-uncommitted` and `--disable-check-gen-code` are deprecated now.

## Which issue(s) this PR fixes:

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
yes, it adds new flags and environment variable support.
```
