### PR TITLE
fix: script commands abort if not enabled

### DIFF
--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -160,12 +160,12 @@ type cliSpec struct {
 		List struct{} `cmd:"" help:"Show a list of all scripts in the current directory"`
 		Tree struct{} `cmd:"" help:"Show a tree of all scripts in the current directory"`
 		Info struct {
-			Labels []string `arg:"" name:"labels" passthrough:"" help:"Name of the script"`
+			Cmds []string `arg:"" optional:"true" passthrough:"" help:"Script to show info"`
 		} `cmd:"" help:"Show detailed information about a script"`
 		Run struct {
 			NoRecursive bool     `default:"false" help:"Do not recurse into child stacks"`
 			DryRun      bool     `default:"false" help:"Plan the execution but do not execute it"`
-			Labels      []string `arg:"" name:"labels" passthrough:"" help:"Script to execute"`
+			Cmds        []string `arg:"" optional:"true" passthrough:"" help:"Script to execute"`
 		} `cmd:"" help:"Run script in stacks"`
 	} `cmd:"" help:"Terramate Script commands"`
 
@@ -606,14 +606,22 @@ func (c *cli) run() {
 	case "experimental cloud drift show":
 		c.cloudDriftShow()
 	case "script list":
+		c.checkScriptEnabled()
 		c.printScriptList()
 	case "script tree":
+		c.checkScriptEnabled()
 		c.printScriptTree()
-	case "script info <labels>":
+	case "script info":
+		c.checkScriptEnabled()
+		log.Fatal().Msg("no script specified")
+	case "script info <cmds>":
+		c.checkScriptEnabled()
 		c.printScriptInfo()
 	case "script run":
+		c.checkScriptEnabled()
 		log.Fatal().Msg("no script specified")
-	case "script run <labels>":
+	case "script run <cmds>":
+		c.checkScriptEnabled()
 		c.setupGit()
 		c.runScript()
 	default:

--- a/cmd/terramate/cli/script_info.go
+++ b/cmd/terramate/cli/script_info.go
@@ -4,8 +4,11 @@
 package cli
 
 import (
+	"os"
 	"sort"
+	"strings"
 
+	"github.com/fatih/color"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/terramate-io/terramate/config"
 	"github.com/terramate-io/terramate/hcl"
@@ -15,7 +18,7 @@ import (
 )
 
 func (c *cli) printScriptInfo() {
-	labels := c.parsedArgs.Script.Info.Labels
+	labels := c.parsedArgs.Script.Info.Cmds
 
 	stacks, err := c.computeSelectedStacks(false)
 	if err != nil {
@@ -24,6 +27,12 @@ func (c *cli) printScriptInfo() {
 
 	m := newScriptsMatcher(labels)
 	m.Search(c.cfg(), stacks)
+
+	if len(m.Results) == 0 {
+		c.output.MsgStdErr(color.RedString("script not found: ") +
+			strings.Join(c.parsedArgs.Script.Info.Cmds, " "))
+		os.Exit(1)
+	}
 
 	for _, x := range m.Results {
 		c.output.MsgStdOut("Definition: %v", x.ScriptCfg.Range)

--- a/cmd/terramate/e2etests/core/run_script_test.go
+++ b/cmd/terramate/e2etests/core/run_script_test.go
@@ -33,6 +33,17 @@ func TestRunScript(t *testing.T) {
 
 	for _, tc := range []testcase{
 		{
+			name: "aborts if scripts are not enabled",
+			layout: []string{
+				"s:stack-a",
+			},
+			runScript: []string{"somescript"},
+			want: RunExpected{
+				StderrRegex: " feature is not enabled",
+				Status:      1,
+			},
+		},
+		{
 			name: "script defined in stack should run successfully",
 			layout: []string{
 				terramateConfig,

--- a/cmd/terramate/e2etests/core/script_info_test.go
+++ b/cmd/terramate/e2etests/core/script_info_test.go
@@ -100,7 +100,8 @@ Jobs:
 			script: "not_found",
 			dir:    "",
 			want: RunExpected{
-				Stdout: "",
+				StderrRegex: "script not found",
+				Status:      1,
 			},
 		},
 		{

--- a/config/config.go
+++ b/config/config.go
@@ -10,6 +10,8 @@ import (
 	"sort"
 	"strings"
 
+	"golang.org/x/exp/slices"
+
 	"github.com/rs/zerolog/log"
 	"github.com/terramate-io/terramate"
 	"github.com/terramate-io/terramate/config/filter"
@@ -450,6 +452,15 @@ func NewTree(cfgdir string) *Tree {
 		dir:      cfgdir,
 		Children: make(map[string]*Tree),
 	}
+}
+
+// HasExperiment returns true if the given experiment name is set.
+func (root *Root) HasExperiment(name string) bool {
+	if root.tree.Node.Terramate == nil || root.tree.Node.Terramate.Config == nil {
+		return false
+	}
+
+	return slices.Contains(root.tree.Node.Terramate.Config.Experiments, name)
 }
 
 // Skip returns true if the given file/dir name should be ignored by Terramate.


### PR DESCRIPTION
## What this PR does / why we need it:

If `scripts` is not enabled we must give a good error message explaining how to enable them.

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
no other than better error.
```
