### PR TITLE
feat(scripts): support for deployment cloud sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
   - `terramate experimental trigger --experimental-status=` -> `terramate experimental trigger --cloud-status=`
   - `terramate list --experimental-status=` -> `terramate list --cloud-status=`
 - Add `list --run-order` flag to list stacks in the order they would be executed.
+- Add support for deployment syncing to script commands.
 
 ## 0.4.4
 

--- a/cloud/testserver/cloudstore/store.go
+++ b/cloud/testserver/cloudstore/store.go
@@ -86,7 +86,7 @@ type (
 		ID          int64                     `json:"id"`
 		StackMetaID string                    `json:"stack_meta_id"`
 		Status      drift.Status              `json:"status"`
-		Details     *cloud.DriftDetails       `json:"details"`
+		Details     *cloud.ChangesetDetails   `json:"details"`
 		Metadata    *cloud.DeploymentMetadata `json:"metadata"`
 		Command     []string                  `json:"command"`
 		StartedAt   *time.Time                `json:"started_at,omitempty"`

--- a/cloud/types.go
+++ b/cloud/types.go
@@ -74,8 +74,8 @@ type (
 		MetaTags        []string `json:"meta_tags,omitempty"`
 	}
 
-	// DriftDetails represents the details of a drift.
-	DriftDetails struct {
+	// ChangesetDetails represents the details of a drift.
+	ChangesetDetails struct {
 		Provisioner    string `json:"provisioner"`
 		ChangesetASCII string `json:"changeset_ascii,omitempty"`
 		ChangesetJSON  string `json:"changeset_json,omitempty"`
@@ -123,7 +123,7 @@ type (
 	Drift struct {
 		ID       int64               `json:"id"`
 		Status   drift.Status        `json:"status"`
-		Details  *DriftDetails       `json:"drift_details,omitempty"`
+		Details  *ChangesetDetails   `json:"drift_details,omitempty"`
 		Metadata *DeploymentMetadata `json:"metadata,omitempty"`
 	}
 
@@ -140,7 +140,7 @@ type (
 	DriftStackPayloadRequest struct {
 		Stack      Stack               `json:"stack"`
 		Status     drift.Status        `json:"drift_status"`
-		Details    *DriftDetails       `json:"drift_details,omitempty"`
+		Details    *ChangesetDetails   `json:"drift_details,omitempty"`
 		Metadata   *DeploymentMetadata `json:"metadata,omitempty"`
 		StartedAt  *time.Time          `json:"started_at,omitempty"`
 		FinishedAt *time.Time          `json:"finished_at,omitempty"`
@@ -251,6 +251,7 @@ type (
 	UpdateDeploymentStack struct {
 		StackID int64             `json:"stack_id"`
 		Status  deployment.Status `json:"status"`
+		Details *ChangesetDetails `json:"changeset_details,omitempty"`
 	}
 
 	// UpdateDeploymentStacks is the request payload for updating the deployment status.
@@ -311,7 +312,7 @@ var (
 	_ = Resource(Drifts{})
 	_ = Resource(DriftStackPayloadRequest{})
 	_ = Resource(DriftStackPayloadRequests{})
-	_ = Resource(DriftDetails{})
+	_ = Resource(ChangesetDetails{})
 	_ = Resource(DeploymentLogs{})
 	_ = Resource(DeploymentLog{})
 	_ = Resource(EmptyResponse(""))
@@ -471,7 +472,7 @@ func (ds DriftsStackPayloadResponse) Validate() error {
 }
 
 // Validate the drift details.
-func (ds DriftDetails) Validate() error {
+func (ds ChangesetDetails) Validate() error {
 	if ds.Provisioner == "" && ds.ChangesetASCII == "" && ds.ChangesetJSON == "" {
 		// TODO: backend returns the `details` object even if it was not synchronized.
 		return nil

--- a/cmd/terramate/e2etests/cloud/run_cloud_deployment_test.go
+++ b/cmd/terramate/e2etests/cloud/run_cloud_deployment_test.go
@@ -4,6 +4,7 @@
 package cloud_test
 
 import (
+	"fmt"
 	"net"
 	"net/http"
 	"os"
@@ -362,6 +363,231 @@ func TestCLIRunWithCloudSyncDeployment(t *testing.T) {
 			runflags = append(runflags, "--")
 			runflags = append(runflags, tc.cmd...)
 			result := cli.Run(runflags...)
+			AssertRunResult(t, result, tc.want.run)
+			assertRunEvents(t, cloudData, runid, ids, tc.want.events)
+		})
+	}
+}
+
+func TestCLIScriptRunWithCloudSyncDeployment(t *testing.T) {
+	t.Parallel()
+
+	makeScriptDef := func(name string, syncDeployment bool, plan string) string {
+		return fmt.Sprintf(`script "%s" {
+			description = "no"
+			job {
+				command = ["echo", "${terramate.stack.name}", {
+					cloud_sync_deployment = %v,
+					cloud_sync_terraform_plan_file = "%s"
+				}]
+			}
+		}`, name, syncDeployment, plan)
+	}
+
+	type want struct {
+		run    RunExpected
+		events eventsResponse
+	}
+	type testcase struct {
+		name       string
+		layout     []string
+		scripts    map[string]string
+		skipIDGen  bool
+		workingDir string
+		scriptCmd  string
+		want       want
+	}
+
+	for _, tc := range []testcase{
+		{
+			name: "all stacks must have ids",
+			layout: []string{
+				"s:s1",
+				"s:s2",
+			},
+			scripts: map[string]string{
+				"deploy.tm": makeScriptDef("deploy", true, ""),
+			},
+			skipIDGen: true,
+			scriptCmd: "deploy",
+			want: want{
+				run: RunExpected{
+					Status:      1,
+					StderrRegex: string(clitest.ErrCloudStacksWithoutID),
+				},
+			},
+		},
+		{
+			name: "failed script command",
+			layout: []string{
+				"s:stack",
+				`f:stack/scripts.tm:script deploy {
+					description = "no"
+					job {
+						command = ["echooooo", "${terramate.stack.name}", {
+							cloud_sync_deployment = true
+						}]
+					}
+				}`,
+			},
+			scriptCmd: "deploy",
+			want: want{
+				run: RunExpected{
+					Status:      1,
+					StderrRegex: "executable file not found",
+				},
+				events: eventsResponse{
+					"stack": []string{"pending", "running", "failed"},
+				},
+			},
+		},
+		{
+			name: "failed script cmd cancels execution of subsequent stacks",
+			layout: []string{
+				"s:s1",
+				"s:s2",
+				`f:scripts.tm:script deploy {
+					description = "no"
+					job {
+						command = ["echooooo", "${terramate.stack.name}", {
+							cloud_sync_deployment = true
+						}]
+					}
+				}`,
+			},
+			scriptCmd: "deploy",
+			want: want{
+				run: RunExpected{
+					Status:      1,
+					StderrRegex: "executable file not found",
+				},
+				events: eventsResponse{
+					"s1": []string{"pending", "running", "failed"},
+					"s2": []string{"pending", "canceled"},
+				},
+			},
+		},
+		{
+			name:   "basic success",
+			layout: []string{"s:stack"},
+			scripts: map[string]string{
+				"deploy.tm": makeScriptDef("deploy", true, ""),
+			},
+			scriptCmd: "deploy",
+			want: want{
+				run: RunExpected{
+					Status:       0,
+					IgnoreStderr: true,
+					Stdout:       "stack\n",
+				},
+				events: eventsResponse{
+					"stack": []string{"pending", "running", "ok"},
+				},
+			},
+		},
+		{
+			name: "multiple stacks - sync all",
+			layout: []string{
+				"s:s1",
+				"s:s2",
+				"s:s3",
+			},
+			scripts: map[string]string{
+				"deploy.tm": makeScriptDef("deploy", true, ""),
+			},
+			scriptCmd: "deploy",
+			want: want{
+				run: RunExpected{
+					Status:       0,
+					IgnoreStderr: true,
+					Stdout:       "s1\ns2\ns3\n",
+				},
+				events: eventsResponse{
+					"s1": []string{"pending", "running", "ok"},
+					"s2": []string{"pending", "running", "ok"},
+					"s3": []string{"pending", "running", "ok"},
+				},
+			},
+		},
+		{
+			name: "multiple stacks - partial sync",
+			layout: []string{
+				"s:s1",
+				"s:s2",
+				"s:s3",
+			},
+			scripts: map[string]string{
+				"deploy_sync.tm":       makeScriptDef("deploy", true, ""),
+				"s2/deploy_no_sync.tm": makeScriptDef("deploy", false, ""),
+			},
+			scriptCmd: "deploy",
+			want: want{
+				run: RunExpected{
+					Status:       0,
+					IgnoreStderr: true,
+					Stdout:       "s1\ns3\ns2\n",
+				},
+				events: eventsResponse{
+					"s1": []string{"pending", "running", "ok"},
+					"s3": []string{"pending", "running", "ok"},
+				},
+			},
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cloudData, err := cloudstore.LoadDatastore(testserverJSONFile)
+			assert.NoError(t, err)
+			addr := startFakeTMCServer(t, cloudData)
+
+			s := sandbox.New(t)
+			var genLayout []string
+			ids := []string{}
+			if !tc.skipIDGen {
+				for _, layout := range tc.layout {
+					if layout[0] == 's' {
+						if strings.Contains(layout, "id=") {
+							t.Fatalf("testcases should not contain stack IDs but found %s", layout)
+						}
+						id := strings.ToLower(strings.Replace(layout[2:]+"-id-"+t.Name(), "/", "-", -1))
+						if len(id) > 64 {
+							id = id[:64]
+						}
+						ids = append(ids, id)
+						layout += ":id=" + id
+					}
+					genLayout = append(genLayout, layout)
+				}
+			} else {
+				genLayout = tc.layout
+			}
+
+			for path, def := range tc.scripts {
+				genLayout = append(genLayout, fmt.Sprintf("f:%s:%s", path, def))
+			}
+
+			genLayout = append(genLayout, `f:terramate.tm:
+			terramate {
+			  config {
+				experiments = ["scripts"]
+			  }
+			}`)
+
+			s.BuildTree(genLayout)
+			s.Git().CommitAll("all stacks committed")
+
+			env := RemoveEnv(os.Environ(), "CI")
+			env = append(env, "TMC_API_URL=http://"+addr)
+			cli := NewCLI(t, filepath.Join(s.RootDir(), filepath.FromSlash(tc.workingDir)), env...)
+
+			uuid, err := uuid.NewRandom()
+			assert.NoError(t, err)
+			runid := uuid.String()
+			cli.AppendEnv = []string{"TM_TEST_RUN_ID=" + runid}
+
+			result := cli.RunScript(tc.scriptCmd)
 			AssertRunResult(t, result, tc.want.run)
 			assertRunEvents(t, cloudData, runid, ids, tc.want.events)
 		})

--- a/cmd/terramate/e2etests/cloud/run_cloud_drift_test.go
+++ b/cmd/terramate/e2etests/cloud/run_cloud_drift_test.go
@@ -395,7 +395,7 @@ func TestCLIRunWithCloudSyncDriftStatus(t *testing.T) {
 								MetaID:        "s1",
 							},
 							Status: drift.Drifted,
-							Details: &cloud.DriftDetails{
+							Details: &cloud.ChangesetDetails{
 								Provisioner:   "terraform",
 								ChangesetJSON: loadJSONPlan(t, "testdata/cloud-sync-drift-plan-file/sanitized.plan.json"),
 							},
@@ -415,7 +415,7 @@ func TestCLIRunWithCloudSyncDriftStatus(t *testing.T) {
 								MetaID:        "s2",
 							},
 							Status: drift.Drifted,
-							Details: &cloud.DriftDetails{
+							Details: &cloud.ChangesetDetails{
 								Provisioner:   "terraform",
 								ChangesetJSON: loadJSONPlan(t, "testdata/cloud-sync-drift-plan-file/sanitized.plan.json"),
 							},

--- a/cmd/terramate/e2etests/core/run_script_test.go
+++ b/cmd/terramate/e2etests/core/run_script_test.go
@@ -67,9 +67,9 @@ func TestRunScript(t *testing.T) {
 			runScript: []string{"somescript"},
 			want: RunExpected{
 				StderrRegexes: []string{
-					"Found somescript defined at /stack-a/script.tm:.* having 2 job\\(s\\)",
-					"/stack-a \\(job:0.0\\)> echo hello",
-					"/stack-a \\(job:1.0\\)> echo some message",
+					"Script 0 at /stack-a/script.tm:.* having 2 job\\(s\\)",
+					"/stack-a \\(script:0 job:0.0\\)> echo hello",
+					"/stack-a \\(script:0 job:1.0\\)> echo some message",
 				},
 				StdoutRegexes: []string{
 					"hello",
@@ -126,9 +126,9 @@ func TestRunScript(t *testing.T) {
 			runScript: []string{"somescript"},
 			want: RunExpected{
 				StderrRegexes: []string{
-					"Found somescript defined at /stack-a/script.tm:.* having 1 job\\(s\\)",
-					"/stack-a \\(job:0.0\\)> echo some message",
-					"/stack-a/child \\(job:0.0\\)> echo some message",
+					"Script 0 at /stack-a/script.tm:.* having 1 job\\(s\\)",
+					"/stack-a \\(script:0 job:0.0\\)> echo some message",
+					"/stack-a/child \\(script:0 job:0.0\\)> echo some message",
 				},
 				StdoutRegexes: []string{
 					"some message",
@@ -157,8 +157,8 @@ func TestRunScript(t *testing.T) {
 			runScript: []string{"--tags=kubernetes", "somescript"},
 			want: RunExpected{
 				Stdout: `some message`,
-				Stderr: "Found somescript defined at /stack-a/script.tm:2,5-7,6 having 1 job(s)\n" +
-					"/stack-a/child (job:0.0)> echo some message\n",
+				Stderr: "Script 0 at /stack-a/script.tm:2,5-7,6 having 1 job(s)\n" +
+					"/stack-a/child (script:0 job:0.0)> echo some message\n",
 				FlattenStdout: true,
 			},
 		},
@@ -184,8 +184,8 @@ func TestRunScript(t *testing.T) {
 			runScript: []string{"--no-tags=terraform", "somescript"},
 			want: RunExpected{
 				Stdout: `some message`,
-				Stderr: "Found somescript defined at /stack-a/script.tm:2,5-7,6 having 1 job(s)\n" +
-					"/stack-a/child (job:0.0)> echo some message\n",
+				Stderr: "Script 0 at /stack-a/script.tm:2,5-7,6 having 1 job(s)\n" +
+					"/stack-a/child (script:0 job:0.0)> echo some message\n",
 				FlattenStdout: true,
 			},
 		},
@@ -212,8 +212,8 @@ func TestRunScript(t *testing.T) {
 			runScript: []string{"--no-recursive", "somescript"},
 			want: RunExpected{
 				Stdout: `some message`,
-				Stderr: "Found somescript defined at /stack-a/script.tm:2,5-7,6 having 1 job(s)\n" +
-					"/stack-a (job:0.0)> echo some message\n",
+				Stderr: "Script 0 at /stack-a/script.tm:2,5-7,6 having 1 job(s)\n" +
+					"/stack-a (script:0 job:0.0)> echo some message\n",
 				FlattenStdout: true,
 			},
 		},
@@ -238,10 +238,10 @@ func TestRunScript(t *testing.T) {
 			},
 			runScript: []string{"--dry-run", "somescript"},
 			want: RunExpected{
-				Stdout: "\n",
+				Stdout: "",
 				Stderr: "This is a dry run, commands will not be executed.\n" +
-					"Found somescript defined at /stack-a/script.tm:2,5-7,6 having 1 job(s)\n" +
-					"/stack-a (job:0.0)> echo some message\n",
+					"Script 0 at /stack-a/script.tm:2,5-7,6 having 1 job(s)\n" +
+					"/stack-a (script:0 job:0.0)> echo some message\n",
 			},
 		},
 	} {
@@ -319,12 +319,11 @@ func TestRunScriptOnChangedStacks(t *testing.T) {
 
 	// run-script should execute the script on both stacks
 	AssertRunResult(t, cli.RunScript("--changed", "somescript"), RunExpected{
-		Stdout: "\n" +
-			"hello stack\n\n" +
+		Stdout: "hello stack\n" +
 			"hello child\n",
-		Stderr: "Found somescript defined at /stack/script.tm:2,5-7,6 having 1 job(s)\n" +
-			"/stack (job:0.0)> echo hello stack\n" +
-			"/stack/child (job:0.0)> echo hello child\n",
+		Stderr: "Script 0 at /stack/script.tm:2,5-7,6 having 1 job(s)\n" +
+			"/stack (script:0 job:0.0)> echo hello stack\n" +
+			"/stack/child (script:0 job:0.0)> echo hello child\n",
 	})
 
 	// when a stack is changed and committed
@@ -337,10 +336,9 @@ func TestRunScriptOnChangedStacks(t *testing.T) {
 	// run-script --changed should execute the script only on that stack
 	AssertRunResult(t, cli.RunScript("--changed", "somescript"),
 		RunExpected{
-			Stdout: "\n" +
-				"hello stack\n",
-			Stderr: "Found somescript defined at /stack/script.tm:2,5-7,6 having 1 job(s)\n" +
-				"/stack (job:0.0)> echo hello stack\n",
+			Stdout: "hello stack\n",
+			Stderr: "Script 0 at /stack/script.tm:2,5-7,6 having 1 job(s)\n" +
+				"/stack (script:0 job:0.0)> echo hello stack\n",
 		})
 
 }

--- a/config/script.go
+++ b/config/script.go
@@ -263,7 +263,7 @@ func unmarshalScriptCommandOptions(obj cty.Value, expr hhcl.Expression) (*Script
 			}
 			r.CloudSyncDeployment = v.True()
 
-		case "cloud_sync_terraform_plan":
+		case "cloud_sync_terraform_plan_file":
 			if v.Type() != cty.String {
 				errs.Append(errors.E(ErrScriptInvalidCmdOptions, expr.Range(),
 					"command option '%s' must be a string, but has type %s",

--- a/config/script_test.go
+++ b/config/script_test.go
@@ -354,7 +354,7 @@ func TestScriptEval(t *testing.T) {
 						  [
 							["echo", "hello", {
 								cloud_sync_deployment = false
-								cloud_sync_terraform_plan = "plan_a"
+								cloud_sync_terraform_plan_file = "plan_a"
 							}],
 						  ]
 						`),
@@ -363,7 +363,7 @@ func TestScriptEval(t *testing.T) {
 						Command: makeCommand(t, `
 							["echo", "hello", {
 								cloud_sync_deployment = true
-								cloud_sync_terraform_plan = "plan_b"
+								cloud_sync_terraform_plan_file = "plan_b"
 							}]
 						`),
 					},
@@ -466,7 +466,7 @@ func TestScriptEval(t *testing.T) {
 							  [
 								["echo", "hello", {
 									cloud_sync_deployment = true
-									cloud_sync_terraform_plan = "plan_a"
+									cloud_sync_terraform_plan_file = "plan_a"
 								}],
 							  ]
 							`),
@@ -475,7 +475,7 @@ func TestScriptEval(t *testing.T) {
 						Command: makeCommand(t, `
 								["echo", "hello", {
 									cloud_sync_deployment = true
-									cloud_sync_terraform_plan = "plan_a"
+									cloud_sync_terraform_plan_file = "plan_a"
 								}]
 							`),
 					},

--- a/docs/cli/orchestration/scripts.md
+++ b/docs/cli/orchestration/scripts.md
@@ -89,8 +89,11 @@ provide to the `terramate script run` command in order to execute the script:
       - `commands` *(required)* - A list of commands. Each item is a list that has the form `[ command, arg1, arg2, ...]`
       that will be executed accordingly. Terramate Functions and variable interpolation of the following namespaces
       is supported: `global`, `terramate`, and `env`
+      Optionally, the last item of the argument list can be an object containing Terramate-specific options for this command.
+      In this case, the form is extended to `[ command, arg1, arg2, ..., {option1: value1, option2: value2} ]`.
+      See below for a list of supported command options.
 
-To run a Terraform deployment a script can be defined as:
+To run a Terraform deployment, a script can be defined as:
 
 ```hcl
 script "deploy" {
@@ -105,6 +108,12 @@ script "deploy" {
   }
 }
 ```
+
+### Command options
+
+- `cloud_sync_deployment` *(optional boolean)* Send information about the deployment to Terramate Cloud. See [Sending deployment data to Terramate Cloud](../cmdline/run.md#sending-deployment-data-to-terramate-cloud). Only one command per script may have this option set to true.
+- `cloud_sync_terraform_plan_file` *(optional string)* Sync a Terraform plan file to Terramate Cloud with the deployment. This option is only used
+when `cloud_sync_deployment` is set to true.
 
 ## Running Scripts
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/terramate-io/terramate/blob/main/CONTRIBUTING.md
2. If the PR is unfinished, mark it as draft: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request
3. Please update the PR title using the Conventional Commits convention: https://www.conventionalcommits.org/en/v1.0.0/
    Example: feat: add support for XYZ.
-->

## What this PR does / why we need it:
This PR implements cloud deployment syncing similar to `terramate run --cloud-sync-deployment`, but for individual script commands.

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Keep it empty if not applicable.
-->

## Special notes for your reviewer:

* The `ExecContext` was extended and has also been renamed in the process. It was used in many places and the variables had a different name each time, i.e. `run, runContext, stackContext, stacks, runStacks`. Refactored this so its always `run`/`runs`.
* The output of `script run` was changed so that code between `run` and `script run` could be re-used more easily.

## Does this PR introduce a user-facing change?
<!--
If no, just write "no" in the block below.
If yes, please explain the change and update documentation and the CHANGELOG.md file accordingly.
-->
```
- Support for optional script command options have been added, which allow syncing deployment info to Terramate Cloud.
- The output formatting of terramate script run has been changed slightly.
```
