### PR TITLE
fix: change detector cannot read user's git config.

### DIFF
--- a/cmd/terramate/cli/project.go
+++ b/cmd/terramate/cli/project.go
@@ -22,6 +22,7 @@ type project struct {
 	root           config.Root
 	baseRef        string
 	normalizedRepo string
+	stackManager   *stack.Manager
 
 	git struct {
 		wrapper                   *git.Git

--- a/stack/manager_test.go
+++ b/stack/manager_test.go
@@ -147,9 +147,10 @@ func TestListChangedStacks(t *testing.T) {
 			repo := tc.repobuilder(t)
 			root, err := config.LoadRoot(repo.Dir)
 			assert.NoError(t, err)
-			m := stack.NewManager(root, tc.baseRef)
+			g := test.NewGitWrapper(t, repo.Dir, []string{})
+			m := stack.NewGitAwareManager(root, g)
 
-			report, err := m.ListChanged()
+			report, err := m.ListChanged(tc.baseRef)
 			assert.EqualErrs(t, tc.want.err, err, "ListChanged() error")
 
 			changedStacks := report.Stacks
@@ -169,7 +170,7 @@ func TestListChangedStackReason(t *testing.T) {
 	repo := singleNotMergedCommitBranch(t)
 
 	m := newManager(t, repo.Dir)
-	report, err := m.ListChanged()
+	report, err := m.ListChanged(defaultBranch)
 	assert.NoError(t, err, "unexpected error")
 
 	changed := report.Stacks
@@ -180,7 +181,7 @@ func TestListChangedStackReason(t *testing.T) {
 	repo = singleStackDependentModuleChangedRepo(t)
 
 	m = newManager(t, repo.Dir)
-	report, err = m.ListChanged()
+	report, err = m.ListChanged(defaultBranch)
 	assert.NoError(t, err, "unexpected error")
 
 	changed = report.Stacks
@@ -551,7 +552,8 @@ module "module2" {
 func newManager(t *testing.T, basedir string) *stack.Manager {
 	root, err := config.LoadRoot(basedir)
 	assert.NoError(t, err)
-	return stack.NewManager(root, defaultBranch)
+	g := test.NewGitWrapper(t, basedir, []string{})
+	return stack.NewGitAwareManager(root, g)
 }
 
 func createStack(t *testing.T, root *config.Root, absdir string) {


### PR DESCRIPTION
## What this PR does / why we need it:

The Terramate change detector does not load user's global config and then is unable to ignore files configured in the `core.excludeFiles` option.

This fixes a reported bug where the user had a global `.gitignore` configuration but Terramate kept complaining of untracked files in the repository.

## Which issue(s) this PR fixes:

Fixes an issue reported by a customer but not tracked in GitHub.

## Special notes for your reviewer:

- Depends on #1358
- I removed the @snakster implementation for retrieving global config (the inner vs outer wrappers) because they are not needed anymore.
- Now Terramate uses a single git wrapper with the exception that module change detector needs a different Workdir but that's the only different option.

## Does this PR introduce a user-facing change?
```
no
```
