### PR TITLE
fix: move run-graph back to experimental

### DIFF
--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -179,12 +179,6 @@ type cliSpec struct {
 			} `cmd:"" help:"Show generate debug information"`
 			RuntimeEnv struct{} `cmd:"" help:"List run environment variables for all stacks"`
 		} `cmd:"" help:"Show information available in the project"`
-		Render struct {
-			RunGraph struct {
-				Outfile string `short:"o" predictor:"file" default:"" help:"Output .dot file"`
-				Label   string `short:"l" default:"stack.name" help:"Label used in graph nodes (it could be either \"stack.name\" or \"stack.dir\""`
-			} `cmd:"" help:"Generate a graph of the execution order"`
-		} `cmd:"" help:"Render information about a project"`
 	} `cmd:"" help:"Terramate debugging commands"`
 
 	Experimental struct {
@@ -199,6 +193,11 @@ type cliSpec struct {
 			Reason             string `default:"" name:"reason" help:"Reason for the stack being triggered"`
 			ExperimentalStatus string `help:"Filter by status"`
 		} `cmd:"" help:"Triggers a stack"`
+
+		RunGraph struct {
+			Outfile string `short:"o" predictor:"file" default:"" help:"Output .dot file"`
+			Label   string `short:"l" default:"stack.name" help:"Label used in graph nodes (it could be either \"stack.name\" or \"stack.dir\""`
+		} `cmd:"" help:"Generate a graph of the execution order"`
 
 		RunOrder struct {
 			Basedir string `arg:"" optional:"true" help:"Base directory to search stacks"`
@@ -580,7 +579,7 @@ func (c *cli) run() {
 	case "debug show metadata":
 		c.setupGit()
 		c.printMetadata()
-	case "debug render run-graph":
+	case "experimental run-graph":
 		c.setupGit()
 		c.generateGraph()
 	case "experimental run-order":
@@ -1397,7 +1396,7 @@ func (c *cli) generateGraph() {
 		Str("workingDir", c.wd()).
 		Logger()
 
-	switch c.parsedArgs.Debug.Render.RunGraph.Label {
+	switch c.parsedArgs.Experimental.RunGraph.Label {
 	case "stack.name":
 		logger.Debug().Msg("Set label to stack name.")
 
@@ -1454,7 +1453,7 @@ func (c *cli) generateGraph() {
 
 	logger.Debug().
 		Msg("Set output of graph.")
-	outFile := c.parsedArgs.Debug.Render.RunGraph.Outfile
+	outFile := c.parsedArgs.Experimental.RunGraph.Outfile
 	var out io.Writer
 	if outFile == "" {
 

--- a/cmd/terramate/e2etests/core/safeguard_test.go
+++ b/cmd/terramate/e2etests/core/safeguard_test.go
@@ -31,7 +31,7 @@ func TestSafeguardCheckRemoteNotRequiredInSomeCommands(t *testing.T) {
 		"debug show metadata",
 		"debug show globals",
 		"experimental run-order",
-		"debug render run-graph",
+		"experimental run-graph",
 		"experimental eval 1+1",
 		"experimental partial-eval 1+1",
 		"experimental get-config-value global",

--- a/cmd/terramate/e2etests/core/version_check_test.go
+++ b/cmd/terramate/e2etests/core/version_check_test.go
@@ -24,7 +24,7 @@ func TestVersionCheck(t *testing.T) {
 		"debug show metadata":    "debug show metadata",
 		"debug show globals":     "debug show globals",
 		"experimental run-order": "experimental run-order",
-		"debug render run-graph": "debug render run-graph",
+		"experimental run-graph": "experimental run-graph",
 		"generate":               "generate",
 		"list":                   "list",
 		"run":                    fmt.Sprintf("run --quiet %s cat %s", HelperPath, stack.DefaultFilename),

--- a/cmd/terramate/e2etests/internal/runner/runner.go
+++ b/cmd/terramate/e2etests/internal/runner/runner.go
@@ -256,7 +256,7 @@ func (tm CLI) StacksRunOrder(args ...string) RunResult {
 
 // StacksRunGraph is a helper for executing `terramate experimental run-graph`.
 func (tm CLI) StacksRunGraph(args ...string) RunResult {
-	return tm.Run(append([]string{"debug", "render", "run-graph"}, args...)...)
+	return tm.Run(append([]string{"experimental", "run-graph"}, args...)...)
 }
 
 // ListStacks is a helper for executinh `terramate list`.

--- a/docs/cli/cmdline/run-graph.md
+++ b/docs/cli/cmdline/run-graph.md
@@ -5,6 +5,11 @@ description: With the terramate run-graph command you can print a graph describi
 
 # Run Graph
 
+::: warning
+This is an experimental command and is likely subject to change in the future.
+:::
+
+
 The `run-graph` command prints a graph describing the [order of execution](../orchestration/index.md) of your stacks.
 
 ## Usage
@@ -16,5 +21,5 @@ The `run-graph` command prints a graph describing the [order of execution](../or
 Print the graph for all stacks in the current directory recursively:
 
 ```bash
-terramate debug render run-graph
+terramate experimental run-graph
 ```


### PR DESCRIPTION
## What this PR does / why we need it:

The `run-graph` command needs to be improved to support the following feature:
* A reverse option to render the graph in reverse order (or reverse the direction of the arrows)

## Which issue(s) this PR fixes:

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
Yes, the `run-graph` command is being moved to `experimental`.
```
