### PR TITLE
feat: promote experimental cloud commands and flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
   - `terramate experimental cloud login` -> `terramate cloud login`
   - `terramate experimental cloud info` -> `terramate cloud info`
   - `terramate experimental cloud drift show` -> `terramate cloud drift show`
+- Promote `--experimental-status` flag to `--cloud-status` flag
+  - `terramate experimental trigger --experimental-status=` -> `terramate experimental trigger --cloud-status=`
 
 ## 0.4.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 ### Added
 
 - Add support for `stack_filter` in `generate_file` blocks.
+- Promote cloud commands
+  - `terramate experimental cloud login` -> `terramate cloud login`
+  - `terramate experimental cloud info` -> `terramate cloud info`
+  - `terramate experimental cloud drift show` -> `terramate cloud drift show`
 
 ## 0.4.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
   - `terramate experimental cloud drift show` -> `terramate cloud drift show`
 - Promote `--experimental-status` flag to `--cloud-status` flag
   - `terramate experimental trigger --experimental-status=` -> `terramate experimental trigger --cloud-status=`
+  - `terramate list --experimental-status=` -> `terramate list --cloud-status=`
 
 ## 0.4.4
 

--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -184,6 +184,15 @@ type cliSpec struct {
 		} `cmd:"" help:"Show information available in the project"`
 	} `cmd:"" help:"Terramate debugging commands"`
 
+	Cloud struct {
+		Login struct{} `cmd:"" help:"login for cloud.terramate.io"`
+		Info  struct{} `cmd:"" help:"cloud information status"`
+		Drift struct {
+			Show struct {
+			} `cmd:"" help:"show drifts"`
+		} `cmd:"" help:"manage cloud drifts"`
+	} `cmd:"" help:"Terramate Cloud commands"`
+
 	Experimental struct {
 		Clone struct {
 			SrcDir          string `arg:"" name:"srcdir" predictor:"file" help:"Path of the stack being cloned"`
@@ -238,7 +247,7 @@ type cliSpec struct {
 				Show struct {
 				} `cmd:"" help:"show drifts"`
 			} `cmd:"" help:"manage cloud drifts"`
-		} `cmd:"" help:"Terramate Cloud commands"`
+		} `cmd:"" hidden:"" help:"Terramate Cloud commands"`
 	} `cmd:"" help:"Experimental features (may change or be removed in the future)"`
 }
 
@@ -436,7 +445,14 @@ func newCLI(version string, args []string, stdin io.Reader, stdout, stderr io.Wr
 			fatal(err, "installing shell completions")
 		}
 		return &cli{exit: true}
-	case "experimental cloud login":
+	case "experimental cloud login": // Deprecated: use cloud login
+		err := googleLogin(output, idpkey(), clicfg)
+		if err != nil {
+			fatal(err, "authentication failed")
+		}
+		output.MsgStdOut("authenticated successfully")
+		return &cli{exit: true}
+	case "cloud login":
 		err := googleLogin(output, idpkey(), clicfg)
 		if err != nil {
 			fatal(err, "authentication failed")
@@ -603,9 +619,13 @@ func (c *cli) run() {
 		log.Fatal().Msg("no variable specified")
 	case "experimental get-config-value <var>":
 		c.getConfigValue()
-	case "experimental cloud info":
+	case "experimental cloud info": // Deprecated
 		c.cloudInfo()
-	case "experimental cloud drift show":
+	case "experimental cloud drift show": // Deprecated
+		c.cloudDriftShow()
+	case "cloud info":
+		c.cloudInfo()
+	case "cloud drift show":
 		c.cloudDriftShow()
 	case "script list":
 		c.checkScriptEnabled()

--- a/cmd/terramate/e2etests/cloud/exp_trigger_cloud_test.go
+++ b/cmd/terramate/e2etests/cloud/exp_trigger_cloud_test.go
@@ -63,7 +63,7 @@ func TestTriggerUnhealthyStacks(t *testing.T) {
 	env := RemoveEnv(os.Environ(), "CI")
 	env = append(env, "TMC_API_URL=http://"+addr, "CI=")
 	cli := NewCLI(t, s.RootDir(), env...)
-	AssertRunResult(t, cli.Run("experimental", "trigger", "--experimental-status=unhealthy"), RunExpected{
+	AssertRunResult(t, cli.Run("experimental", "trigger", "--cloud-status=unhealthy"), RunExpected{
 		IgnoreStdout: true,
 	})
 
@@ -94,10 +94,10 @@ func TestCloudTriggerUnhealthy(t *testing.T) {
 
 	for _, tc := range []testcase{
 		{
-			name:       "local repository is not permitted with --experimental-status=",
+			name:       "local repository is not permitted with --cloud-status=",
 			layout:     []string{"s:s1:id=s1"},
 			repository: test.TempDir(t),
-			flags:      []string{`--experimental-status=unhealthy`},
+			flags:      []string{`--cloud-status=unhealthy`},
 			want: want{
 				trigger: RunExpected{
 					Status:      1,
@@ -114,7 +114,7 @@ func TestCloudTriggerUnhealthy(t *testing.T) {
 			want: want{
 				trigger: RunExpected{
 					Status:      1,
-					StderrRegex: "trigger command expects either a stack path or the --experimental-status flag",
+					StderrRegex: "trigger command expects either a stack path or the --cloud-status flag",
 				},
 			},
 		},
@@ -124,7 +124,7 @@ func TestCloudTriggerUnhealthy(t *testing.T) {
 				"s:s1:id=s1",
 				"s:s2:id=s2",
 			},
-			flags: []string{"--experimental-status=unhealthy"},
+			flags: []string{"--cloud-status=unhealthy"},
 		},
 		{
 			name: "1 cloud stack healthy, other absent, asking for unhealthy: trigger nothing",
@@ -145,7 +145,7 @@ func TestCloudTriggerUnhealthy(t *testing.T) {
 					},
 				},
 			},
-			flags: []string{`--experimental-status=unhealthy`},
+			flags: []string{`--cloud-status=unhealthy`},
 		},
 		{
 			name: "1 cloud stack unhealthy but different repository, trigger nothing",
@@ -166,7 +166,7 @@ func TestCloudTriggerUnhealthy(t *testing.T) {
 					},
 				},
 			},
-			flags: []string{`--experimental-status=unhealthy`},
+			flags: []string{`--cloud-status=unhealthy`},
 		},
 		{
 			name: "1 cloud stack failed, other absent, asking for unhealthy, trigger the failed",
@@ -187,7 +187,7 @@ func TestCloudTriggerUnhealthy(t *testing.T) {
 					},
 				},
 			},
-			flags: []string{`--experimental-status=unhealthy`},
+			flags: []string{`--cloud-status=unhealthy`},
 			want: want{
 				trigger: RunExpected{
 					StdoutRegex: "Created trigger for stack",
@@ -227,7 +227,7 @@ func TestCloudTriggerUnhealthy(t *testing.T) {
 					},
 				},
 			},
-			flags: []string{`--experimental-status=unhealthy`},
+			flags: []string{`--cloud-status=unhealthy`},
 			want: want{
 				trigger: RunExpected{
 					StdoutRegex: "Created trigger for stack",
@@ -267,7 +267,7 @@ func TestCloudTriggerUnhealthy(t *testing.T) {
 					},
 				},
 			},
-			flags: []string{`--experimental-status=ok`},
+			flags: []string{`--cloud-status=ok`},
 			want: want{
 				trigger: RunExpected{
 					StdoutRegex: "Created trigger for stack",
@@ -307,7 +307,7 @@ func TestCloudTriggerUnhealthy(t *testing.T) {
 					},
 				},
 			},
-			flags: []string{`--experimental-status=ok`},
+			flags: []string{`--cloud-status=ok`},
 			want: want{
 				trigger: RunExpected{
 					StdoutRegex: "Created trigger for stack",
@@ -347,7 +347,7 @@ func TestCloudTriggerUnhealthy(t *testing.T) {
 					},
 				},
 			},
-			flags: []string{`--experimental-status=failed`},
+			flags: []string{`--cloud-status=failed`},
 			want: want{
 				trigger: RunExpected{
 					StdoutRegex: "Created trigger for stack",
@@ -387,7 +387,7 @@ func TestCloudTriggerUnhealthy(t *testing.T) {
 					},
 				},
 			},
-			flags: []string{`--experimental-status=drifted`},
+			flags: []string{`--cloud-status=drifted`},
 			want: want{
 				trigger: RunExpected{
 					StdoutRegex: "Created trigger for stack",
@@ -424,7 +424,7 @@ func TestCloudTriggerUnhealthy(t *testing.T) {
 					},
 				},
 			},
-			flags: []string{`--experimental-status=unhealthy`},
+			flags: []string{`--cloud-status=unhealthy`},
 		},
 		{
 			name: "2 local stacks, 2 same unhealthy stacks, trigger both",
@@ -456,7 +456,7 @@ func TestCloudTriggerUnhealthy(t *testing.T) {
 					},
 				},
 			},
-			flags: []string{`--experimental-status=unhealthy`},
+			flags: []string{`--cloud-status=unhealthy`},
 			want: want{
 				trigger: RunExpected{
 					StdoutRegex: "Created trigger for stack",
@@ -497,7 +497,7 @@ func TestCloudTriggerUnhealthy(t *testing.T) {
 					},
 				},
 			},
-			flags: []string{`--experimental-status=unhealthy`},
+			flags: []string{`--cloud-status=unhealthy`},
 			want: want{
 				trigger: RunExpected{
 					StdoutRegex: "Created trigger for stack",

--- a/cmd/terramate/e2etests/cloud/interop/interoperability_test.go
+++ b/cmd/terramate/e2etests/cloud/interop/interoperability_test.go
@@ -28,12 +28,12 @@ func TestInteropSyncDeployment(t *testing.T) {
 		},
 	)
 	AssertRunResult(t,
-		tmcli.Run("list", "--experimental-status=unhealthy"), RunExpected{
+		tmcli.Run("list", "--cloud-status=unhealthy"), RunExpected{
 			Stdout: nljoin("."),
 		},
 	)
 	AssertRun(t, tmcli.Run("run", "--cloud-sync-deployment", "--", HelperPath, "true"))
-	AssertRun(t, tmcli.Run("list", "--experimental-status=unhealthy"))
+	AssertRun(t, tmcli.Run("list", "--cloud-status=unhealthy"))
 }
 
 func TestInteropDrift(t *testing.T) {
@@ -61,7 +61,7 @@ func TestInteropDrift(t *testing.T) {
 		},
 	)
 	AssertRunResult(t,
-		tmcli.Run("list", "--experimental-status=unhealthy"), RunExpected{
+		tmcli.Run("list", "--cloud-status=unhealthy"), RunExpected{
 			Stdout: nljoin("."),
 		},
 	)
@@ -86,7 +86,7 @@ func TestInteropDrift(t *testing.T) {
 		},
 	)
 	AssertRunResult(t,
-		tmcli.Run("list", "--experimental-status=unhealthy"), RunExpected{
+		tmcli.Run("list", "--cloud-status=unhealthy"), RunExpected{
 			Stdout: nljoin("."),
 		},
 	)
@@ -103,7 +103,7 @@ func TestInteropDrift(t *testing.T) {
 
 	// check reseting the drift status to OK
 	AssertRun(t, tmcli.Run("run", "--cloud-sync-drift-status", "--", HelperPath, "exit", "0"))
-	AssertRun(t, tmcli.Run("list", "--experimental-status=unhealthy"))
+	AssertRun(t, tmcli.Run("list", "--cloud-status=unhealthy"))
 	AssertRunResult(t,
 		tmcli.Run("cloud", "drift", "show"),
 		RunExpected{

--- a/cmd/terramate/e2etests/cloud/interop/interoperability_test.go
+++ b/cmd/terramate/e2etests/cloud/interop/interoperability_test.go
@@ -67,7 +67,7 @@ func TestInteropDrift(t *testing.T) {
 	)
 	// Check if there are no drift details
 	AssertRunResult(t,
-		tmcli.Run("experimental", "cloud", "drift", "show"), RunExpected{
+		tmcli.Run("cloud", "drift", "show"), RunExpected{
 			StderrRegex: "Stack .*? is drifted, but no details are available",
 			Status:      1,
 		},
@@ -92,7 +92,7 @@ func TestInteropDrift(t *testing.T) {
 	)
 	// Check the drift details
 	AssertRunResult(t,
-		tmcli.Run("experimental", "cloud", "drift", "show"), RunExpected{
+		tmcli.Run("cloud", "drift", "show"), RunExpected{
 			StdoutRegexes: []string{
 				"hello world", // content of the file
 				"local_file",  // name of the resource
@@ -105,7 +105,7 @@ func TestInteropDrift(t *testing.T) {
 	AssertRun(t, tmcli.Run("run", "--cloud-sync-drift-status", "--", HelperPath, "exit", "0"))
 	AssertRun(t, tmcli.Run("list", "--experimental-status=unhealthy"))
 	AssertRunResult(t,
-		tmcli.Run("experimental", "cloud", "drift", "show"),
+		tmcli.Run("cloud", "drift", "show"),
 		RunExpected{
 			StdoutRegex: "Stack .*? is not drifted",
 			Status:      0,

--- a/cmd/terramate/e2etests/cloud/list_cloud_test.go
+++ b/cmd/terramate/e2etests/cloud/list_cloud_test.go
@@ -37,10 +37,10 @@ func TestCloudListUnhealthy(t *testing.T) {
 
 	for _, tc := range []listCloudTestcase{
 		{
-			name:       "local repository is not permitted with --experimental-status=",
+			name:       "local repository is not permitted with --cloud-status=",
 			layout:     []string{"s:s1:id=s1"},
 			repository: test.TempDir(t),
-			flags:      []string{`--experimental-status=unhealthy`},
+			flags:      []string{`--cloud-status=unhealthy`},
 			want: RunExpected{
 				Status:      1,
 				StderrRegex: "unhealthy status filter does not work with filesystem based remotes",
@@ -62,7 +62,7 @@ func TestCloudListUnhealthy(t *testing.T) {
 				"s:s1:id=s1",
 				"s:s2:id=s2",
 			},
-			flags: []string{"--experimental-status=unhealthy"},
+			flags: []string{"--cloud-status=unhealthy"},
 		},
 		{
 			name: "1 cloud stack healthy, others absent, asking for unhealthy: return nothing",
@@ -83,7 +83,7 @@ func TestCloudListUnhealthy(t *testing.T) {
 					},
 				},
 			},
-			flags: []string{`--experimental-status=unhealthy`},
+			flags: []string{`--cloud-status=unhealthy`},
 		},
 		{
 			name: "1 cloud stack healthy, others absent, asking for ok: return ok",
@@ -104,7 +104,7 @@ func TestCloudListUnhealthy(t *testing.T) {
 					},
 				},
 			},
-			flags: []string{`--experimental-status=ok`},
+			flags: []string{`--cloud-status=ok`},
 			want: RunExpected{
 				Stdout: nljoin("s1"),
 			},
@@ -128,7 +128,7 @@ func TestCloudListUnhealthy(t *testing.T) {
 					},
 				},
 			},
-			flags: []string{`--experimental-status=healthy`},
+			flags: []string{`--cloud-status=healthy`},
 			want: RunExpected{
 				Stdout: nljoin("s1"),
 			},
@@ -152,7 +152,7 @@ func TestCloudListUnhealthy(t *testing.T) {
 					},
 				},
 			},
-			flags: []string{`--experimental-status=unhealthy`},
+			flags: []string{`--cloud-status=unhealthy`},
 		},
 		{
 			name: "1 cloud stack drifted, other absent, asking for unhealthy: return drifted",
@@ -173,7 +173,7 @@ func TestCloudListUnhealthy(t *testing.T) {
 					},
 				},
 			},
-			flags: []string{`--experimental-status=unhealthy`},
+			flags: []string{`--cloud-status=unhealthy`},
 			want: RunExpected{
 				Stdout: nljoin("s1"),
 			},
@@ -197,7 +197,7 @@ func TestCloudListUnhealthy(t *testing.T) {
 					},
 				},
 			},
-			flags: []string{`--experimental-status=unhealthy`},
+			flags: []string{`--cloud-status=unhealthy`},
 			want: RunExpected{
 				Stdout: nljoin("s1"),
 			},
@@ -232,7 +232,7 @@ func TestCloudListUnhealthy(t *testing.T) {
 					},
 				},
 			},
-			flags: []string{`--experimental-status=unhealthy`},
+			flags: []string{`--cloud-status=unhealthy`},
 			want: RunExpected{
 				Stdout: nljoin("s1"),
 			},
@@ -264,7 +264,7 @@ func TestCloudListUnhealthy(t *testing.T) {
 					},
 				},
 			},
-			flags: []string{`--experimental-status=unhealthy`},
+			flags: []string{`--cloud-status=unhealthy`},
 		},
 		{
 			name: "2 local stacks, 2 same unhealthy stacks, return both",
@@ -296,7 +296,7 @@ func TestCloudListUnhealthy(t *testing.T) {
 					},
 				},
 			},
-			flags: []string{`--experimental-status=unhealthy`},
+			flags: []string{`--cloud-status=unhealthy`},
 			want: RunExpected{
 				Stdout: nljoin("s1", "s2"),
 			},
@@ -332,7 +332,7 @@ func TestCloudListUnhealthy(t *testing.T) {
 					},
 				},
 			},
-			flags: []string{`--experimental-status=unhealthy`},
+			flags: []string{`--cloud-status=unhealthy`},
 			want: RunExpected{
 				Stdout: nljoin("s1", "s2"),
 			},
@@ -407,7 +407,7 @@ func paginationTestcase(perPage int) listCloudTestcase {
 		layout:  layout,
 		stacks:  stacks,
 		perPage: perPage,
-		flags:   []string{`--experimental-status=unhealthy`},
+		flags:   []string{`--cloud-status=unhealthy`},
 		want: RunExpected{
 			Stdout: nljoin(names...),
 		},

--- a/cmd/terramate/e2etests/cloud/run_cloud_uimode_test.go
+++ b/cmd/terramate/e2etests/cloud/run_cloud_uimode_test.go
@@ -114,7 +114,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 				{
 					name:   "cloud info",
 					uimode: cli.HumanMode,
-					cmd:    []string{"experimental", "cloud", "info"},
+					cmd:    []string{"cloud", "info"},
 					want: RunExpected{
 						Status: 0,
 						Stdout: "status: signed in\nprovider: Google Social Provider\nuser: Batman\nemail: batman@terramate.io\norganizations: Terramate (terramate)\n",
@@ -123,7 +123,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 				{
 					name:   "cloud info",
 					uimode: cli.AutomationMode,
-					cmd:    []string{"experimental", "cloud", "info"},
+					cmd:    []string{"cloud", "info"},
 					want: RunExpected{
 						Status: 0,
 						Stdout: "status: signed in\nprovider: Google Social Provider\nuser: Batman\nemail: batman@terramate.io\norganizations: Terramate (terramate)\n",
@@ -207,7 +207,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 				{
 					name:   "cloud info",
 					uimode: cli.HumanMode,
-					cmd:    []string{"experimental", "cloud", "info"},
+					cmd:    []string{"cloud", "info"},
 					want: RunExpected{
 						Status: 1,
 						StderrRegexes: []string{
@@ -218,7 +218,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 				{
 					name:   "cloud info",
 					uimode: cli.AutomationMode,
-					cmd:    []string{"experimental", "cloud", "info"},
+					cmd:    []string{"cloud", "info"},
 					want: RunExpected{
 						Status: 1,
 						StderrRegexes: []string{
@@ -280,7 +280,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 				{
 					name:   "cloud info",
 					uimode: cli.HumanMode,
-					cmd:    []string{"experimental", "cloud", "info"},
+					cmd:    []string{"cloud", "info"},
 					want: RunExpected{
 						Status: 0,
 						Stdout: "status: signed in\nprovider: Google Social Provider\nuser: Batman\nemail: batman@terramate.io\norganizations: Terramate (terramate)\n",
@@ -289,7 +289,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 				{
 					name:   "cloud info",
 					uimode: cli.AutomationMode,
-					cmd:    []string{"experimental", "cloud", "info"},
+					cmd:    []string{"cloud", "info"},
 					want: RunExpected{
 						Status: 0,
 						Stdout: "status: signed in\nprovider: Google Social Provider\nuser: Batman\nemail: batman@terramate.io\norganizations: Terramate (terramate)\n",
@@ -373,7 +373,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 				{
 					name:   "cloud info",
 					uimode: cli.HumanMode,
-					cmd:    []string{"experimental", "cloud", "info"},
+					cmd:    []string{"cloud", "info"},
 					want: RunExpected{
 						Status: 1,
 						StderrRegexes: []string{
@@ -385,7 +385,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 				{
 					name:   "cloud info",
 					uimode: cli.AutomationMode,
-					cmd:    []string{"experimental", "cloud", "info"},
+					cmd:    []string{"cloud", "info"},
 					want: RunExpected{
 						Status: 1,
 						StderrRegexes: []string{
@@ -479,7 +479,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 				{
 					name:   "cloud info",
 					uimode: cli.HumanMode,
-					cmd:    []string{"experimental", "cloud", "info"},
+					cmd:    []string{"cloud", "info"},
 					want: RunExpected{
 						Status: 1,
 						StderrRegexes: []string{
@@ -491,7 +491,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 				{
 					name:   "cloud info",
 					uimode: cli.AutomationMode,
-					cmd:    []string{"experimental", "cloud", "info"},
+					cmd:    []string{"cloud", "info"},
 					want: RunExpected{
 						Status: 1,
 						StderrRegexes: []string{
@@ -564,7 +564,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 				{
 					name:   "cloud info",
 					uimode: cli.HumanMode,
-					cmd:    []string{"experimental", "cloud", "info"},
+					cmd:    []string{"cloud", "info"},
 					want: RunExpected{
 						Status: 1,
 						StderrRegexes: []string{
@@ -576,7 +576,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 				{
 					name:   "cloud info",
 					uimode: cli.AutomationMode,
-					cmd:    []string{"experimental", "cloud", "info"},
+					cmd:    []string{"cloud", "info"},
 					want: RunExpected{
 						Status: 1,
 						StderrRegexes: []string{
@@ -672,7 +672,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 				{
 					name:   "cloud info",
 					uimode: cli.HumanMode,
-					cmd:    []string{"experimental", "cloud", "info"},
+					cmd:    []string{"cloud", "info"},
 					want: RunExpected{
 						Status: 0,
 						Stdout: "status: signed in\nprovider: Google Social Provider\nuser: Batman\nemail: batman@terramate.io\n",
@@ -684,7 +684,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 				{
 					name:   "cloud info",
 					uimode: cli.AutomationMode,
-					cmd:    []string{"experimental", "cloud", "info"},
+					cmd:    []string{"cloud", "info"},
 					want: RunExpected{
 						Status: 0,
 						Stdout: "status: signed in\nprovider: Google Social Provider\nuser: Batman\nemail: batman@terramate.io\n",
@@ -804,7 +804,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 				{
 					name:   "cloud info",
 					uimode: cli.HumanMode,
-					cmd:    []string{"experimental", "cloud", "info"},
+					cmd:    []string{"cloud", "info"},
 					want: RunExpected{
 						Status: 0,
 						Stdout: "status: signed in\nprovider: Google Social Provider\nuser: Batman\nemail: batman@terramate.io\norganizations: Mineiros (mineiros), Terramate (terramate)\n",
@@ -816,7 +816,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 				{
 					name:   "cloud info",
 					uimode: cli.AutomationMode,
-					cmd:    []string{"experimental", "cloud", "info"},
+					cmd:    []string{"cloud", "info"},
 					want: RunExpected{
 						Status: 0,
 						Stdout: "status: signed in\nprovider: Google Social Provider\nuser: Batman\nemail: batman@terramate.io\norganizations: Mineiros (mineiros), Terramate (terramate)\n",
@@ -927,7 +927,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 				{
 					name:   "cloud info",
 					uimode: cli.HumanMode,
-					cmd:    []string{"experimental", "cloud", "info"},
+					cmd:    []string{"cloud", "info"},
 					want: RunExpected{
 						Status: 0,
 						Stdout: "status: signed in\nprovider: Google Social Provider\nuser: Batman\nemail: batman@terramate.io\norganizations: Terramate (terramate-io), Mineiros (mineiros-io)\n",
@@ -939,7 +939,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 				{
 					name:   "cloud info",
 					uimode: cli.AutomationMode,
-					cmd:    []string{"experimental", "cloud", "info"},
+					cmd:    []string{"cloud", "info"},
 					want: RunExpected{
 						Status: 0,
 						Stdout: "status: signed in\nprovider: Google Social Provider\nuser: Batman\nemail: batman@terramate.io\norganizations: Terramate (terramate-io), Mineiros (mineiros-io)\n",
@@ -1037,7 +1037,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 				{
 					name:   "cloud info",
 					uimode: cli.HumanMode,
-					cmd:    []string{"experimental", "cloud", "info"},
+					cmd:    []string{"cloud", "info"},
 					want: RunExpected{
 						Status: 0,
 						Stdout: "status: signed in\nprovider: Google Social Provider\nuser: Batman\nemail: batman@terramate.io\norganizations: Mineiros (mineiros), Terramate (terramate)\n",
@@ -1049,7 +1049,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 				{
 					name:   "cloud info",
 					uimode: cli.AutomationMode,
-					cmd:    []string{"experimental", "cloud", "info"},
+					cmd:    []string{"cloud", "info"},
 					want: RunExpected{
 						Status: 0,
 						Stdout: "status: signed in\nprovider: Google Social Provider\nuser: Batman\nemail: batman@terramate.io\norganizations: Mineiros (mineiros), Terramate (terramate)\n",

--- a/docs/cli/cmdline/cloud-drift-show.md
+++ b/docs/cli/cmdline/cloud-drift-show.md
@@ -5,12 +5,8 @@ description: With the terramate cloud drift show command you can view the drift 
 
 # Cloud Drift Show
 
-::: warning
-This is an experimental command and is likely subject to change in the future.
-:::
-
 The `cloud drift show` command shows any drift that has occurred in the current stack in the working directory (or use `-C` to point to the directory). You must be [logged into](./cloud-login.md) to your Terramate Cloud account.
 
 ## Usage
 
-`terramate -C <stack-directory> experimental cloud drift show`
+`terramate -C <stack-directory> cloud drift show`

--- a/docs/cli/cmdline/cloud-info.md
+++ b/docs/cli/cmdline/cloud-info.md
@@ -5,12 +5,8 @@ description: With the terramate cloud info command you can see information about
 
 # Cloud Info
 
-::: warning
-This is an experimental command and is likely subject to change in the future.
-:::
-
 The `cloud info` command prints information about your current session in Terramate Cloud.
 
 ## Usage
 
-`terramate experimental cloud info`
+`terramate cloud info`

--- a/docs/cli/cmdline/cloud-login.md
+++ b/docs/cli/cmdline/cloud-login.md
@@ -5,12 +5,8 @@ description: With the terramate cloud login command you can log in to your Terra
 
 # Cloud Login
 
-::: warning
-This is an experimental command and is likely subject to change in the future.
-:::
-
 The `cloud login` command authorizes Terramate CLI to access Terramate Cloud.
 
 ## Usage
 
-`terramate experimental cloud login`
+`terramate cloud login`

--- a/docs/cli/cmdline/list.md
+++ b/docs/cli/cmdline/list.md
@@ -5,7 +5,7 @@ description: With the terramate list command you can list all stacks in the curr
 
 # List
 
-The `list` command lists all Terramate stacks in the current directory recursively. These can be additionally filtered based on Terramate Cloud status with the `--experimental-status=<status>` filter (valid statuses are documented on the [trigger page](./trigger.md))
+The `list` command lists all Terramate stacks in the current directory recursively. These can be additionally filtered based on Terramate Cloud status with the `--cloud-status=<status>` filter (valid statuses are documented on the [trigger page](./trigger.md))
 
 ## Usage
 
@@ -28,5 +28,5 @@ terramate list --chdir path/to/directory
 List all stacks below the current directory that have a "drifted" status on Terramate Cloud
 
 ```bash
-terramate list --experimental-status=drifted
+terramate list --cloud-status=drifted
 ```

--- a/docs/cli/cmdline/trigger.md
+++ b/docs/cli/cmdline/trigger.md
@@ -14,7 +14,7 @@ The `trigger` command forcibly marks a stack as "changed" even if it doesn't con
 which should then be committed. `terramate run` will then execute commands against any stacks that have been triggered
 in the last commit (as well as any other changed stacks).
 
-The trigger mechanism has various use cases. It may be that a previous CI/CD run failed or that you have detected drift between the code and the actual state. For those using Terramate Cloud, the additional `--experimental-status=<status>` argument can be used to trigger stacks that are in one of the following states:
+The trigger mechanism has various use cases. It may be that a previous CI/CD run failed or that you have detected drift between the code and the actual state. For those using Terramate Cloud, the additional `--cloud-status=<status>` argument can be used to trigger stacks that are in one of the following states:
 
 | Status      | Meaning                                                                  |
 | ----------- | ------------------------------------------------------------------------ |
@@ -39,5 +39,5 @@ terramate experimental trigger /path/to/stack
 Create triggers for all stacks that have drifted
 
 ```bash
-terramate experimental trigger --experimental-status=drifted
+terramate experimental trigger --cloud-status=drifted
 ```


### PR DESCRIPTION
## What this PR does / why we need it:

- feat: promote experimental cloud commands
- feat: promote exp trigger status to --cloud-status
- feat: promote list status to --cloud-status

## Which issue(s) this PR fixes:

## Special notes for your reviewer:

* I created one PR for all the changes to avoid the extra work of reviewing/merging multiple PRs.
* I tested that each commit is functional using this command:
  - git rebase --exec "make test" main

## Does this PR introduce a user-facing change?
```
Yes, it moves some commands and flags out of experimental. The docs have been
updated to reflect this. For details of each change, see the commit messages.
```
