### PR TITLE
feat(generate): allow stack_filter for generate_file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 - Backward compatibility in versions `0.0.z` is **not guaranteed** when `z` is increased.
 - Backward compatibility in versions `0.y.z` is **not guaranteed** when `y` is increased.
 
+## Unreleased
+
+### Added
+
+- Add support for `stack_filter` in `generate_file` blocks.
+
 ## 0.4.4
 
 ### Added

--- a/generate/generate_stack_file_test.go
+++ b/generate/generate_stack_file_test.go
@@ -446,3 +446,430 @@ func TestGenerateFileTerramateRootMetadata(t *testing.T) {
 
 	assert.EqualStrings(t, want, got)
 }
+
+func TestGenerateFileStackFilters(t *testing.T) {
+	t.Parallel()
+
+	testCodeGeneration(t, []testcase{
+		{
+			name: "no matching pattern",
+			layout: []string{
+				"s:staecks/stack-1",
+				"s:staecks/stack-2",
+			},
+			configs: []hclconfig{
+				{
+					path: "/staecks",
+					add: GenerateFile(
+						Labels("test"),
+						StackFilter(
+							ProjectPaths("stacks/*"),
+						),
+						Str("content", "content"),
+					),
+				},
+			},
+		},
+		{
+			name: "one matching pattern",
+			layout: []string{
+				"s:stacks/stack-1",
+				"s:staecks/stack-2",
+				"s:stack/stack-3",
+				"s:stackss/stack-4",
+			},
+			configs: []hclconfig{
+				{
+					path: "/",
+					add: GenerateFile(
+						Labels("test"),
+						StackFilter(
+							ProjectPaths("stacks/*"),
+						),
+						Str("content", "content"),
+					),
+				},
+			},
+			want: []generatedFile{
+				{
+					dir: "/stacks/stack-1",
+					files: map[string]fmt.Stringer{
+						"test": stringer("content"),
+					},
+				},
+			},
+			wantReport: generate.Report{
+				Successes: []generate.Result{
+					{
+						Dir:     project.NewPath("/stacks/stack-1"),
+						Created: []string{"test"},
+					},
+				},
+			},
+		},
+		{
+			name: "multiple matching patterns",
+			layout: []string{
+				"s:stacks/stack-1",
+				"s:staecks/stack-2",
+				"s:stack/stack-3",
+				"s:staecks/stack-4",
+			},
+			configs: []hclconfig{
+				{
+					path: "/",
+					add: GenerateFile(
+						Labels("test"),
+						StackFilter(
+							ProjectPaths("stacks/*", "staecks/*"),
+						),
+						Str("content", "content"),
+					),
+				},
+			},
+			want: []generatedFile{
+				{
+					dir: "/stacks/stack-1",
+					files: map[string]fmt.Stringer{
+						"test": stringer("content"),
+					},
+				},
+				{
+					dir: "/staecks/stack-2",
+					files: map[string]fmt.Stringer{
+						"test": stringer("content"),
+					},
+				},
+				{
+					dir: "/staecks/stack-4",
+					files: map[string]fmt.Stringer{
+						"test": stringer("content"),
+					},
+				},
+			},
+			wantReport: generate.Report{
+				Successes: []generate.Result{
+					{
+						Dir:     project.NewPath("/stacks/stack-1"),
+						Created: []string{"test"},
+					},
+					{
+						Dir:     project.NewPath("/staecks/stack-2"),
+						Created: []string{"test"},
+					},
+					{
+						Dir:     project.NewPath("/staecks/stack-4"),
+						Created: []string{"test"},
+					},
+				},
+			},
+		},
+		{
+			name: "AND multiple attributes",
+			layout: []string{
+				"s:stack-1",
+				"s:stack-2",
+			},
+			configs: []hclconfig{
+				{
+					path: "/",
+					add: GenerateFile(
+						Labels("not_generated"),
+						StackFilter(
+							ProjectPaths("stack-1"),
+							RepositoryPaths("stack-2"),
+						),
+						Str("content", "content"),
+					),
+				},
+			},
+		},
+		{
+			name: "OR multiple blocks",
+			layout: []string{
+				"s:stack-1",
+				"s:stack-2",
+			},
+			configs: []hclconfig{
+				{
+					path: "/",
+					add: GenerateFile(
+						Labels("generated"),
+						StackFilter(
+							ProjectPaths("stack-1"),
+						),
+						StackFilter(
+							RepositoryPaths("stack-2"),
+						),
+						Str("content", "content"),
+					),
+				},
+			},
+			want: []generatedFile{
+				{
+					dir: "/stack-1",
+					files: map[string]fmt.Stringer{
+						"generated": stringer("content"),
+					},
+				},
+				{
+					dir: "/stack-2",
+					files: map[string]fmt.Stringer{
+						"generated": stringer("content"),
+					},
+				},
+			},
+			wantReport: generate.Report{
+				Successes: []generate.Result{
+					{
+						Dir:     project.NewPath("/stack-1"),
+						Created: []string{"generated"},
+					},
+					{
+						Dir:     project.NewPath("/stack-2"),
+						Created: []string{"generated"},
+					},
+				},
+			},
+		},
+		{
+			name: "glob patterns",
+			layout: []string{
+				"s:aws/stacks/dev",
+				"s:aws/stacks/dev/substack",
+				"s:aws/stacks/prod",
+				"s:gcp/stacks/dev",
+				"s:gcp/stacks/prod",
+				"s:gcp/stacks/prod/substack",
+				"s:dev",
+			},
+			configs: []hclconfig{
+				{
+					path: "/",
+					add: GenerateFile(
+						Labels("prod_match1"),
+						StackFilter(
+							ProjectPaths("prod"),
+						),
+						Str("content", "content"),
+					),
+				},
+				{
+					path: "/",
+					add: GenerateFile(
+						Labels("prod_match2"),
+						StackFilter(
+							ProjectPaths("**/prod"),
+						),
+						Str("content", "content"),
+					),
+				},
+				{
+					path: "/",
+					add: GenerateFile(
+						Labels("no_prod_match1"),
+						StackFilter(
+							ProjectPaths("*/prod"),
+						),
+						Str("content", "content"),
+					),
+				},
+				{
+					path: "/",
+					add: GenerateFile(
+						Labels("prod_substack_match1"),
+						StackFilter(
+							ProjectPaths("**/prod/*"),
+						),
+						Str("content", "content"),
+					),
+				},
+				{
+					path: "/",
+					add: GenerateFile(
+						Labels("prod_substack_match2"),
+						StackFilter(
+							ProjectPaths("**/prod/**"),
+						),
+						Str("content", "content"),
+					),
+				},
+
+				{
+					path: "/",
+					add: GenerateFile(
+						Labels("aws_prod_match1"),
+						StackFilter(
+							ProjectPaths("aws/**/prod"),
+						),
+						Str("content", "content"),
+					),
+				},
+				{
+					path: "/",
+					add: GenerateFile(
+						Labels("no_aws_substack_match1"),
+						StackFilter(
+							ProjectPaths("aws/*/substack"),
+						),
+						Str("content", "content"),
+					),
+				},
+				{
+					path: "/",
+					add: GenerateFile(
+						Labels("aws_substack_match1"),
+						StackFilter(
+							ProjectPaths("aws/**/substack"),
+						),
+						Str("content", "content"),
+					),
+				},
+				{
+					path: "/",
+					add: GenerateFile(
+						Labels("substack_match1"),
+						StackFilter(
+							ProjectPaths("substack"),
+						),
+						Str("content", "content"),
+					),
+				},
+				{
+					path: "/",
+					add: GenerateFile(
+						Labels("no_substack_match1"),
+						StackFilter(
+							ProjectPaths("/substack"),
+						),
+						Str("content", "content"),
+					),
+				},
+				{
+					path: "/",
+					add: GenerateFile(
+						Labels("root_dev_match1"),
+						StackFilter(
+							ProjectPaths("/dev"),
+						),
+						Str("content", "content"),
+					),
+				},
+				{
+					path: "/",
+					add: GenerateFile(
+						Labels("all_aws_match1"),
+						StackFilter(
+							ProjectPaths("aws/**"),
+						),
+						Str("content", "content"),
+					),
+				},
+				{
+					path: "/",
+					add: GenerateFile(
+						Labels("no_aws_match1"),
+						StackFilter(
+							ProjectPaths("aws/*"),
+						),
+						Str("content", "content"),
+					),
+				},
+			},
+			want: []generatedFile{
+				{
+					dir: "/aws/stacks/dev",
+					files: map[string]fmt.Stringer{
+						"all_aws_match1": stringer("content"),
+					},
+				},
+				{
+					dir: "/aws/stacks/dev/substack",
+					files: map[string]fmt.Stringer{
+						"all_aws_match1":      stringer("content"),
+						"aws_substack_match1": stringer("content"),
+						"substack_match1":     stringer("content"),
+					},
+				},
+				{
+					dir: "/aws/stacks/prod",
+					files: map[string]fmt.Stringer{
+						"all_aws_match1":  stringer("content"),
+						"aws_prod_match1": stringer("content"),
+						"prod_match1":     stringer("content"),
+						"prod_match2":     stringer("content"),
+					},
+				},
+				{
+					dir: "/dev",
+					files: map[string]fmt.Stringer{
+						"root_dev_match1": stringer("content"),
+					},
+				},
+				{
+					dir: "/gcp/stacks/prod",
+					files: map[string]fmt.Stringer{
+						"prod_match1": stringer("content"),
+						"prod_match2": stringer("content"),
+					},
+				},
+				{
+					dir: "/gcp/stacks/prod/substack",
+					files: map[string]fmt.Stringer{
+						"prod_substack_match1": stringer("content"),
+						"prod_substack_match2": stringer("content"),
+						"substack_match1":      stringer("content"),
+					},
+				},
+			},
+			wantReport: generate.Report{
+				Successes: []generate.Result{
+					{
+						Dir: project.NewPath("/aws/stacks/dev"),
+						Created: []string{
+							"all_aws_match1",
+						},
+					},
+					{
+						Dir: project.NewPath("/aws/stacks/dev/substack"),
+						Created: []string{
+							"all_aws_match1",
+							"aws_substack_match1",
+							"substack_match1",
+						},
+					},
+					{
+						Dir: project.NewPath("/aws/stacks/prod"),
+						Created: []string{
+							"all_aws_match1",
+							"aws_prod_match1",
+							"prod_match1",
+							"prod_match2",
+						},
+					},
+					{
+						Dir: project.NewPath("/dev"),
+						Created: []string{
+							"root_dev_match1",
+						},
+					},
+					{
+						Dir: project.NewPath("/gcp/stacks/prod"),
+						Created: []string{
+							"prod_match1",
+							"prod_match2",
+						},
+					},
+					{
+						Dir: project.NewPath("/gcp/stacks/prod/substack"),
+						Created: []string{
+							"prod_substack_match1",
+							"prod_substack_match2",
+							"substack_match1",
+						},
+					},
+				},
+			},
+		},
+	})
+}

--- a/generate/genhcl/genhcl.go
+++ b/generate/genhcl/genhcl.go
@@ -158,7 +158,7 @@ func Load(
 				"project path":    cond.ProjectPaths,
 				"repository path": cond.RepositoryPaths,
 			} {
-				if globs != nil && !matchAnyGlob(globs, st.Dir.String()) {
+				if globs != nil && !hcl.MatchAnyGlob(globs, st.Dir.String()) {
 					log.Logger.Trace().Msgf("Skipping %q, %s doesn't match any filter in %v", st.Dir, n, globs)
 					matched = false
 					break
@@ -275,15 +275,6 @@ func Load(
 	})
 
 	return hcls, nil
-}
-
-func matchAnyGlob(globs []glob.Glob, s string) bool {
-	for _, g := range globs {
-		if g.Match(s) {
-			return true
-		}
-	}
-	return false
 }
 
 type dynBlockAttributes struct {

--- a/hcl/hcl_test.go
+++ b/hcl/hcl_test.go
@@ -927,7 +927,26 @@ func TestHCLParserMultipleErrors(t *testing.T) {
 func TestHCLParserGenerateStackFilters(t *testing.T) {
 	for _, tc := range []testcase{
 		{
-			name: "invalid project_paths list",
+			name: "generate_file - invalid project_paths list",
+			input: []cfgfile{
+				{
+					filename: "gen.tm",
+					body: `
+						generate_file "test.tf" {
+							stack_filter { project_paths = "*" }
+							content = "foo"
+						}
+					`,
+				},
+			},
+			want: want{
+				errs: []error{
+					errors.E(hcl.ErrTerramateSchema),
+				},
+			},
+		},
+		{
+			name: "generate_hcl - invalid project_paths list",
 			input: []cfgfile{
 				{
 					filename: "gen.tm",
@@ -946,7 +965,26 @@ func TestHCLParserGenerateStackFilters(t *testing.T) {
 			},
 		},
 		{
-			name: "invalid project_paths list element",
+			name: "generate_file - invalid project_paths list element",
+			input: []cfgfile{
+				{
+					filename: "gen.tm",
+					body: `
+						generate_file "test.tf" {
+							stack_filter { project_paths = ["blah", 1] }
+							content = "foo"
+						}
+					`,
+				},
+			},
+			want: want{
+				errs: []error{
+					errors.E(hcl.ErrTerramateSchema),
+				},
+			},
+		},
+		{
+			name: "generate_hcl - invalid project_paths list element",
 			input: []cfgfile{
 				{
 					filename: "gen.tm",
@@ -954,6 +992,26 @@ func TestHCLParserGenerateStackFilters(t *testing.T) {
 						generate_hcl "test.tf" {
 							stack_filter { project_paths = ["blah", 1] }
 							content { foo = "bar" }
+						}
+					`,
+				},
+			},
+			want: want{
+				errs: []error{
+					errors.E(hcl.ErrTerramateSchema),
+				},
+			},
+		},
+		{
+			name: "generate_file - invalid context",
+			input: []cfgfile{
+				{
+					filename: "gen.tm",
+					body: `
+						generate_file "test.tf" {
+							context = root
+							stack_filter { project_paths = ["blah"] }
+							content = "foo"
 						}
 					`,
 				},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/terramate-io/terramate/blob/main/CONTRIBUTING.md
2. If the PR is unfinished, mark it as draft: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request
3. Please update the PR title using the Conventional Commits convention: https://www.conventionalcommits.org/en/v1.0.0/
    Example: feat: add support for XYZ.
-->

## What this PR does / why we need it:
This PR allows the `stack_filter` block that was added in #1307 for `generate_hcl` to be used with `generate_file` as well.
It's only supported with `context = stack`.

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Keep it empty if not applicable.
-->

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
<!--
If no, just write "no" in the block below.
If yes, please explain the change and update documentation and the CHANGELOG.md file accordingly.
-->
```
A new block type is added to the configuration schema.
```
