### PR TITLE
fix: multiple stack_filter patterns did not match in some cases

### DIFF
--- a/generate/genhcl/genhcl.go
+++ b/generate/genhcl/genhcl.go
@@ -154,12 +154,12 @@ func Load(
 		for _, cond := range hclBlock.StackFilters {
 			matched := true
 
-			for n, g := range map[string]glob.Glob{
+			for n, globs := range map[string][]glob.Glob{
 				"project path":    cond.ProjectPaths,
 				"repository path": cond.RepositoryPaths,
 			} {
-				if g != nil && !g.Match(st.Dir.String()) {
-					log.Logger.Trace().Msgf("Skipping %q, %s doesn't match filter %v", st.Dir, n, g)
+				if globs != nil && !matchAnyGlob(globs, st.Dir.String()) {
+					log.Logger.Trace().Msgf("Skipping %q, %s doesn't match any filter in %v", st.Dir, n, globs)
 					matched = false
 					break
 				}
@@ -275,6 +275,15 @@ func Load(
 	})
 
 	return hcls, nil
+}
+
+func matchAnyGlob(globs []glob.Glob, s string) bool {
+	for _, g := range globs {
+		if g.Match(s) {
+			return true
+		}
+	}
+	return false
 }
 
 type dynBlockAttributes struct {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/terramate-io/terramate/blob/main/CONTRIBUTING.md
2. If the PR is unfinished, mark it as draft: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request
3. Please update the PR title using the Conventional Commits convention: https://www.conventionalcommits.org/en/v1.0.0/
    Example: feat: add support for XYZ.
-->

## What this PR does / why we need it:

After some investigation it seems there is a bug in the glob library we use with certain pattern combinations:
```
g := glob.MustCompile("{**/project-factory/*/custom-roles/*,**/projects/*/landing-zone/custom-roles/*", '/')
const p = "stacks/project-factory/factory-1/custom-roles/role-1"
g.Match(p) // false, should be true
```
This PR adds a workaround by matching each pattern individually. It also escapes reserved special characters in patterns.

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Keep it empty if not applicable.
-->

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
<!--
If no, just write "no" in the block below.
If yes, please explain the change and update documentation and the CHANGELOG.md file accordingly.
-->
```
no
```
