### PR TITLE
chore(cloud): add support attaching planfiles to synced deployments

### DIFF
--- a/cmd/terramate/cli/run.go
+++ b/cmd/terramate/cli/run.go
@@ -111,12 +111,10 @@ func (c *cli) runOnStacks() {
 		fatal(errors.E("--cloud-sync-deployment conflicts with --cloud-sync-drift-status"))
 	}
 
-	if c.parsedArgs.Run.CloudSyncDeployment && c.parsedArgs.Run.CloudSyncTerraformPlanFile != "" {
-		fatal(errors.E("--cloud-sync-terraform-plan-file can only be used with --cloud-sync-drift-status"))
-	}
+	cloudSyncEnabled := c.parsedArgs.Run.CloudSyncDeployment || c.parsedArgs.Run.CloudSyncDriftStatus
 
-	if c.parsedArgs.Run.CloudSyncTerraformPlanFile != "" && !c.parsedArgs.Run.CloudSyncDriftStatus {
-		fatal(errors.E("--cloud-sync-terraform-plan-file should be used with --cloud-sync-drift-status flag"))
+	if c.parsedArgs.Run.CloudSyncTerraformPlanFile != "" && !cloudSyncEnabled {
+		fatal(errors.E("--cloud-sync-terraform-plan-file requires flags --cloud-sync-deployment or --cloud-sync-drift-status"))
 	}
 
 	if c.parsedArgs.Run.CloudSyncDeployment || c.parsedArgs.Run.CloudSyncDriftStatus {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/terramate-io/terramate/blob/main/CONTRIBUTING.md
2. If the PR is unfinished, mark it as draft: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request
3. Please update the PR title using the Conventional Commits convention: https://www.conventionalcommits.org/en/v1.0.0/
    Example: feat: add support for XYZ.
-->

## What this PR does / why we need it:
This PR adds support for using the `terramate run` options  `--cloud-sync-deployment` and `--cloud-sync-terraform-plan-file` in combination. It will attach information from a given Terraform planfile to the cloud deployment status.

Note that the plan must exist before the run is executed.

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Keep it empty if not applicable.
-->
## Special notes for your reviewer:
* The core of this functionality had already been implemented in #1355, because scripts is using the same code path.
* This is not tested via test server yet, because it wasn't clear to me which endpoint to use to query the result. This will be done in a later PR, together with adding tests for the scripts' variant of this feature.

## Does this PR introduce a user-facing change?
<!--
If no, just write "no" in the block below.
If yes, please explain the change and update documentation and the CHANGELOG.md file accordingly.
-->
```
It allows a new combination of flags that was previously not supported.
```
