### PR TITLE
refactor: deprecate flags --disable-checkpoint*

### DIFF
--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -115,8 +115,9 @@ type cliSpec struct {
 
 	deprecatedGlobalSafeguardsCliSpec
 
-	DisableCheckpoint          bool `optional:"true" default:"false" help:"Disable checkpoint checks for updates"`
-	DisableCheckpointSignature bool `optional:"true" default:"false" help:"Disable checkpoint signature"`
+	// DEPRECATED
+	DisableCheckpoint          bool `hidden:"true" optional:"true" default:"false" help:"Disable checkpoint checks for updates"`
+	DisableCheckpointSignature bool `hidden:"true" optional:"true" default:"false" help:"Disable checkpoint signature"`
 
 	Create struct {
 		Path           string   `arg:"" optional:"" name:"path" predictor:"file" help:"Path of the new stack relative to the working dir"`

--- a/docs/cli/cmdline/index.md
+++ b/docs/cli/cmdline/index.md
@@ -29,8 +29,6 @@ All sub-commands support the `--help` flag as well for specific details.
 
 <!-- - `--disable-check-git-untracked`      Disable git check for untracked files. -->
 <!-- - `--disable-check-git-uncommitted`    Disable git check for uncommitted files. -->
-<!-- - `--disable-checkpoint`               Disable checkpoint checks for updates. -->
-<!-- - `--disable-checkpoint-signature`     Disable checkpoint signature. -->
 
 ## Auto Completions
 


### PR DESCRIPTION
## What this PR does / why we need it:

Deprecates the flags `--disable-checkpoint` and `--disable-checkpoint-signature`.

## Which issue(s) this PR fixes:
none

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
no
```
