### PR TITLE
fix: stack ordering not respected in script run.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 ## Fixed
 
 - Fix `tm_dynamic.attributes` being wrapped many times leading to stack exhaustion when cloning expressions in projects with lots of stacks.
+- Stack ordering not respected in the `script run`.
 
 ## 0.4.4
 

--- a/cmd/terramate/e2etests/cloud/run_cloud_deployment_test.go
+++ b/cmd/terramate/e2etests/cloud/run_cloud_deployment_test.go
@@ -558,7 +558,7 @@ func TestCLIScriptRunWithCloudSyncDeployment(t *testing.T) {
 				run: RunExpected{
 					Status:       0,
 					IgnoreStderr: true,
-					Stdout:       "s1\ns3\ns2\n",
+					Stdout:       "s1\ns2\ns3\n",
 				},
 				events: eventsResponse{
 					"s1": []string{"pending", "running", "ok"},


### PR DESCRIPTION
## What this PR does / why we need it:

Fixes `script run` to respect the stack ordering defined in the stack configuration.

## Which issue(s) this PR fixes:
Fixes an issue reported in discord.

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
fixes a major issue
```
