### PR TITLE
fix(script): command and commands disallow list types.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 
 - Fix `tm_dynamic.attributes` being wrapped many times leading to stack exhaustion when cloning expressions in projects with lots of stacks.
 - Stack ordering not respected in the `script run`.
+- Fix `script.job.command[s]` not handling (typed) lists.
 
 ## 0.4.4
 

--- a/config/script.go
+++ b/config/script.go
@@ -147,8 +147,9 @@ func evalScriptDesc(evalctx *eval.Context, expr hhcl.Expression, name string) (s
 }
 
 func unmarshalScriptJobCommands(cmdList cty.Value, expr hhcl.Expression) ([]*ScriptCmd, error) {
-	if !cmdList.Type().IsTupleType() {
-		return nil, errors.E(ErrScriptInvalidTypeCommands, expr.Range(), "commands should be a list")
+	if !cmdList.Type().IsTupleType() && !cmdList.Type().IsListType() {
+		return nil, errors.E(ErrScriptInvalidTypeCommands,
+			expr.Range(), "commands should be a list but got %s", cmdList.Type().FriendlyName())
 	}
 
 	if cmdList.LengthInt() == 0 {
@@ -163,7 +164,7 @@ func unmarshalScriptJobCommands(cmdList cty.Value, expr hhcl.Expression) ([]*Scr
 	for it.Next() {
 		index++
 		_, elem := it.Element()
-		if !elem.Type().IsTupleType() {
+		if !elem.Type().IsTupleType() && !elem.Type().IsListType() {
 			errs.Append(errors.E(ErrScriptInvalidTypeCommands, expr.Range(),
 				"commands must be a list of list, but element %d has type %q",
 				index, elem.Type().FriendlyName()))
@@ -192,8 +193,9 @@ func unmarshalScriptJobCommands(cmdList cty.Value, expr hhcl.Expression) ([]*Scr
 }
 
 func unmarshalScriptJobCommand(cmdValues cty.Value, expr hhcl.Expression) (*ScriptCmd, error) {
-	if !cmdValues.Type().IsTupleType() {
-		return nil, errors.E(ErrScriptInvalidTypeCommand, expr.Range(), "command must be a list")
+	if !cmdValues.Type().IsTupleType() && !cmdValues.Type().IsListType() {
+		return nil, errors.E(ErrScriptInvalidTypeCommand, expr.Range(), "command must be a list but got %s",
+			cmdValues.Type().FriendlyName())
 	}
 
 	if cmdValues.LengthInt() == 0 {

--- a/config/script_test.go
+++ b/config/script_test.go
@@ -154,6 +154,65 @@ func TestScriptEval(t *testing.T) {
 			},
 		},
 		{
+			name: "command attribute with list type",
+			script: hcl.Script{
+				Labels: labels,
+				Description: hcl.NewScriptDescription(
+					makeAttribute(t, "description", `"some description"`)),
+				Jobs: []*hcl.ScriptJob{
+					{
+						Command: makeCommand(t, `true ? tm_concat(["echo"], ["something"]) : []`),
+					},
+				},
+			},
+			globals: map[string]cty.Value{
+				"some_string_var": cty.StringVal("terramate"),
+			},
+			want: config.Script{
+				Labels:      labels,
+				Description: "some description",
+				Jobs: []config.ScriptJob{
+					{
+						Cmd: &config.ScriptCmd{
+							Args: []string{"echo", "something"},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "commands attribute with list type",
+			script: hcl.Script{
+				Labels: labels,
+				Description: hcl.NewScriptDescription(
+					makeAttribute(t, "description", `"some description"`)),
+				Jobs: []*hcl.ScriptJob{
+					{
+						Commands: makeCommands(t, `true ? tm_concat([["echo", "something"]], [["echo", "other", "thing"]]) : []`),
+					},
+				},
+			},
+			globals: map[string]cty.Value{
+				"some_string_var": cty.StringVal("terramate"),
+			},
+			want: config.Script{
+				Labels:      labels,
+				Description: "some description",
+				Jobs: []config.ScriptJob{
+					{
+						Cmds: []*config.ScriptCmd{
+							{
+								Args: []string{"echo", "something"},
+							},
+							{
+								Args: []string{"echo", "other", "thing"},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "command with first item interpolated",
 			script: hcl.Script{
 				Labels: labels,


### PR DESCRIPTION
## What this PR does / why we need it:

The script block evaluator is not handling lists but just tuples.
Example below shows the problem:

```
script "cmd" {
  description = "aaa"
  job {
    command = true ? tm_concat(["echo"], ["something"]) : []
  }
}
```

It fails with error below:
```
test:1,1-4,15: invalid type for script.command: command must be a list but got list of string
```

## Which issue(s) this PR fixes:

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
yes, fixes a bug.
```
