### PR TITLE
chore: ignore some paths in ci checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@
 name: ci
 on:
   pull_request:
+    paths-ignore:
+      - '*.md'
+      - 'VERSION'
 
 jobs:
   checks:

--- a/.github/workflows/release-dryrun.yml
+++ b/.github/workflows/release-dryrun.yml
@@ -1,0 +1,37 @@
+# Copyright 2023 Terramate GmbH
+# SPDX-License-Identifier: MPL-2.0
+
+name: release-dryrun
+on:
+  pull_request:
+    paths:
+      - 'VERSION'
+      - 'Makefile'
+      - 'makefiles/**'
+      - '.goreleaser.yaml'
+      - 'hack/release/Dockerfile'
+
+jobs:
+  release_dry_run:
+    name: Release Dry Run
+
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
+          fetch-depth: 0
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.20'
+
+      - name: Configure asdf and plugins needed
+        uses: asdf-vm/actions/install@83133f03f5693901c2296a8e622955087dc20267
+
+      - name: check semver in VERSION
+        run: make version/check
+
+      - name: release dry run
+        run: terramate run --tags golang --changed -- make release/dry-run

--- a/hack/version-check
+++ b/hack/version-check
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -e
+
+VERSION=$(cat VERSION)
+
+if [[ $VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]; then
+  echo "VERSION contains a valid semver: $VERSION"
+else
+  echo "ERROR: VERSION does not contain a valid semver: $VERSION"
+  exit 1
+fi

--- a/makefiles/unix.mk
+++ b/makefiles/unix.mk
@@ -51,6 +51,11 @@ test/ci: build
 mod/check:
 	@./hack/mod-check
 
+## check if VERSION file contains a valid semantic version
+.PHONY: version/check
+version/check:
+	@./hack/version-check
+
 ## creates a new release tag
 .PHONY: release/tag
 release/tag: VERSION?=v$(shell cat VERSION)


### PR DESCRIPTION
## What this PR does / why we need it:

This PR skips testing when there are no code changes. This should should speed up the following PR types:
* the PRs where only the markdown files in root are changed (e.g. CHANGELOG.md, README.md etc)
* The PRs where only `VERSION` is changed (e.g. https://github.com/terramate-io/terramate/pull/1407)

Changes in this PR:

* Ignore markdown files and `VERSION` in the ci job
* Move release-dryrun job to release-dryrun.yml
* Run release-dryrun.yml only when `VERSION` is changing.

## Which issue(s) this PR fixes:

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
No

```
