### PR TITLE
chore(gha): re-enable CI runs on main.

### DIFF
--- a/.github/workflows/ci-experimental.yml
+++ b/.github/workflows/ci-experimental.yml
@@ -3,7 +3,7 @@
 
 name: ci-experimental
 on:
-  pull_request:
+  push:
     paths-ignore:
       - 'docs/**'
       - 'makefiles/**'
@@ -24,10 +24,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{github.event.pull_request.head.ref}}
-          repository: ${{github.event.pull_request.head.repo.full_name}}
-          fetch-depth: 0
       - uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 name: ci
-on:
-  pull_request:
+on: [push]
 
 jobs:
   checks:
@@ -12,9 +11,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{github.event.pull_request.head.ref}}
-          repository: ${{github.event.pull_request.head.repo.full_name}}
           fetch-depth: 0
+          
       - uses: actions/setup-go@v4
         with:
           go-version: '1.20'
@@ -46,8 +44,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{github.event.pull_request.head.ref}}
-          repository: ${{github.event.pull_request.head.repo.full_name}}
+          ref: ${{ github.head_ref }}
           fetch-depth: 0
       - uses: actions/setup-go@v4
         with:


### PR DESCRIPTION
## What this PR does / why we need it:

It was disabled by mistake in commit 4a60f6484450b82b2673bf6fb0acebadd94ce5c8

## Which issue(s) this PR fixes:
no

## Special notes for your reviewer:

It also rollback the changes for running CI on contributor's fork repo.

## Does this PR introduce a user-facing change?
```
no
```
