### PR TITLE
fix: use req.GetBody when dumping req

### DIFF
--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -431,6 +431,14 @@ func (c *Client) URL(path string, queries ...url.Values) url.URL {
 func dumpRequest(req *http.Request) ([]byte, error) {
 	reqCopy := req.Clone(req.Context())
 
+	var err error
+	if req.GetBody != nil {
+		reqCopy.Body, err = req.GetBody()
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	reqCopy.Header.Set("Authorization", "REDACTED")
 
 	return httputil.DumpRequestOut(reqCopy, true)


### PR DESCRIPTION
## What this PR does / why we need it:

The `Request.Clone()` function is misleading, it does not create a copy of the original request's body, resulting in dumprequest+printf draining the original request's body.

See https://github.com/golang/go/issues/36095


## Which issue(s) this PR fixes:

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
No.
```
