### PR TITLE
docs: rename cloud-status flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 - Add `list --run-order` flag to list stacks in the order they would be executed.
 - Add support for deployment syncing to script commands.
 - Add `disable_safeguards` configuration option and CLI flag.
+- Add `--detailed-exit-code` to fmt command
+- Add `--detailed-exit-code` to generate command
 
 ## Fixed
 

--- a/docs/cli/stacks/manage.md
+++ b/docs/cli/stacks/manage.md
@@ -19,7 +19,7 @@ terramate create --ensure-stack-ids
 ## List stacks
 
 The list command lists all Terramate stacks in the current directory recursively.
-These can be additionally filtered based on Terramate Cloud status with the `--experimental-status=<status>`
+These can be additionally filtered based on Terramate Cloud status with the `--cloud-status=<status>`
 filter (valid statuses are documented on the [trigger page](../cmdline/trigger.md)).
 
 ### Examples


### PR DESCRIPTION
## What this PR does / why we need it:

- docs: rename cloud-status flag
- docs: add --detailed-exit-code to changelog (it was missing)

## Which issue(s) this PR fixes:

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
No.

```
