### PR TITLE
fix(ls): panic when failing to load root config.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 - Add `terramate.config.generate.hcl_magic_header_comment_style` option for setting the generated comment style.
 - Add support for formatting specific files and stdin (`terramate fmt [file...]` or `terramate fmt -`).
 
+### Fixed
+
+- Fix language server panic when root directory contain errors.
+
 ## 0.4.5
 
 ### Added

--- a/ls/ls.go
+++ b/ls/ls.go
@@ -362,12 +362,16 @@ func listFiles(fromFile string) ([]string, error) {
 // is handled separately because it can be unsaved.
 func (s *Server) checkFiles(files []string, currentFile string, currentContent string) error {
 	dir := filepath.Dir(currentFile)
-	root, rootdir, found, _ := config.TryLoadConfig(dir)
+	var experiments []string
+	root, rootdir, found, err := config.TryLoadConfig(dir)
+	if err == nil {
+		experiments = root.Tree().Node.Experiments()
+	}
 	if !found {
 		rootdir = s.workspace
 	}
 
-	parser, err := hcl.NewTerramateParser(rootdir, dir, root.Tree().Node.Experiments()...)
+	parser, err := hcl.NewTerramateParser(rootdir, dir, experiments...)
 	if err != nil {
 		return errors.E(err, "failed to create terramate parser")
 	}


### PR DESCRIPTION
## What this PR does / why we need it:

When an error happens while looking for the root config, the language server panics with the stack trace below:

```
2024-02-10T14:38:52Z DBG handling request. action=server.Handler() method=textDocument/didOpen params={"textDocument":{"languageId":"terramate","text":"terramate {\n    config {\n        git {\n            default_branch = \"trunk\"\n        }\n    }\n}\n","uri":"file:///Users/tiagodemoura/src/vscode-terramate/testFixture/invalid/multiple-tm-config-git/tm2.tm","version":1}} workspace=/Users/tiagodemoura/src/vscode-terramate
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x1012a3d04]

goroutine 8 [running]:
github.com/terramate-io/terramate/config.(*Root).Tree(...)
	/Users/tiagodemoura/src/terramate/config/config.go:125
github.com/terramate-io/terramate/ls.(*Server).checkFiles(0x140001102d0, {0x140002ce380, 0x2, 0x101287df4?}, {0x14000024697, 0x5a}, {0x1400001ab40, 0x5e})
	/Users/tiagodemoura/src/terramate/ls/ls.go:370 +0x64
github.com/terramate-io/terramate/ls.(*Server).checkAndReply(0x14000024690?, {0x101414268, 0x140001d1040}, 0x140002ce320, {0x14000024697, 0x5a}, {0x1400001ab40, 0x5e})
	/Users/tiagodemoura/src/terramate/ls/ls.go:324 +0x10c
github.com/terramate-io/terramate/ls.(*Server).handleDocumentOpen(0x73?, {0x101414268, 0x140001d1040}, 0x1400014cab8?, {0x1264f6e98, 0x140002c2e70}, {{0x101412b48, 0x14000027ff0}, 0xff, {0x0, ...}, ...})
	/Users/tiagodemoura/src/terramate/ls/ls.go:184 +0xf4
github.com/terramate-io/terramate/ls.(*Server).Handler(0x140001102d0, {0x101414268, 0x140001d1040}, 0x140002ce320, {0x1264f6e98?, 0x140002c2e70?})
	/Users/tiagodemoura/src/terramate/ls/ls.go:90 +0x418
go.lsp.dev/jsonrpc2.(*conn).run(0x140001d2ff0, {0x101414268, 0x140001d1040}, 0x140001e81f0)
	/Users/tiagodemoura/go/pkg/mod/go.lsp.dev/jsonrpc2@v0.10.0/conn.go:206 +0x258
created by go.lsp.dev/jsonrpc2.(*conn).Go in goroutine 1
	/Users/tiagodemoura/go/pkg/mod/go.lsp.dev/jsonrpc2@v0.10.0/conn.go:189 +0xa8
[Error - 14:38:52] Connection to server got closed. Server will not be restarted.
```

## Which issue(s) this PR fixes:

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
yes, fixes a LS bug.
```
