### PR TITLE
feat: submit stack preview progress to TMC

### DIFF
--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -44,8 +44,6 @@ const (
 	MembershipsPath = "/v1/memberships"
 	// DeploymentsPath is the deployments endpoint base path.
 	DeploymentsPath = "/v1/deployments"
-	// PreviewsPath is the previews endpoints base path.
-	PreviewsPath = "/v1/previews"
 	// DriftsPath is the drifts endpoint base path.
 	DriftsPath = "/v1/drifts"
 	// StacksPath is the stacks endpoint base path.
@@ -224,22 +222,6 @@ func (c *Client) UpdateDeploymentStacks(ctx context.Context, orgUUID UUID, deplo
 		c.URL(path.Join(DeploymentsPath, string(orgUUID), string(deploymentUUID), "stacks")),
 	)
 	return err
-}
-
-// createPreview creates a new preview for an organization
-func (c *Client) createPreview(
-	ctx context.Context,
-	orgUUID UUID,
-	payload CreatePreviewPayloadRequest,
-) (CreatePreviewResponse, error) {
-	if err := payload.Validate(); err != nil {
-		return CreatePreviewResponse{}, errors.E(err, "invalid payload")
-	}
-
-	return Post[CreatePreviewResponse](
-		ctx, c, payload,
-		c.URL(path.Join(PreviewsPath, string(orgUUID))),
-	)
 }
 
 // CreateStackDrift pushes a new drift status for the given stack.

--- a/cloud/preview/preview.go
+++ b/cloud/preview/preview.go
@@ -3,9 +3,62 @@
 
 package preview
 
+import "github.com/terramate-io/terramate/errors"
+
+// StackStatus is the status of a stack in a preview run
+type StackStatus string
+
 const (
-	// StatusAffected is the status for a stack that is affected in a PR
-	StatusAffected = "affected"
-	// StatusPending is the status for a stack that is selected in a preview run
-	StatusPending = "pending"
+	// StackStatusAffected is the status for a stack that is affected in a PR
+	StackStatusAffected StackStatus = "affected"
+	// StackStatusPending is the status for a stack that is selected in a preview run
+	StackStatusPending StackStatus = "pending"
+	// StackStatusRunning is the status for a stack that is currently running in a preview run
+	StackStatusRunning StackStatus = "running"
+	// StackStatusUnchanged is the status for a stack that has no changes in a preview run (successful exit code 0)
+	StackStatusUnchanged StackStatus = "unchanged"
+	// StackStatusChanged is the status for a stack that has changes in a preview run (successful exit code 2)
+	StackStatusChanged StackStatus = "changed"
+	// StackStatusCanceled is the status for a stack that has been canceled in a preview run
+	StackStatusCanceled StackStatus = "canceled"
+	// StackStatusFailed is the status for a stack that has failed in a preview run (non-successful exit code)
+	StackStatusFailed StackStatus = "failed"
 )
+
+// ErrInvalidStackStatus represents an invalid stack status
+const ErrInvalidStackStatus = errors.Kind("invalid stack status")
+
+func (p StackStatus) String() string {
+	return string(p)
+}
+
+// Validate validates the stack status
+func (p StackStatus) Validate() error {
+	switch p {
+	case StackStatusAffected,
+		StackStatusPending,
+		StackStatusRunning,
+		StackStatusUnchanged,
+		StackStatusChanged,
+		StackStatusCanceled,
+		StackStatusFailed:
+		return nil
+	default:
+		return errors.E(ErrInvalidStackStatus, "unrecognized value")
+	}
+}
+
+// DerivePreviewStatus derives the preview status from the exit code of
+// a preview command
+func DerivePreviewStatus(exitCode int) StackStatus {
+	switch exitCode {
+	case 2:
+		return StackStatusChanged
+	case 0:
+		return StackStatusUnchanged
+	case -1:
+		return StackStatusCanceled
+	default:
+		return StackStatusFailed
+	}
+}

--- a/cloud/preview/preview_test.go
+++ b/cloud/preview/preview_test.go
@@ -1,0 +1,101 @@
+// Copyright 2024 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+package preview_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/madlambda/spells/assert"
+	"github.com/terramate-io/terramate/cloud/preview"
+)
+
+func TestStackStatus(t *testing.T) {
+	t.Parallel()
+	type want struct {
+		validationErr error
+	}
+	type testcase struct {
+		name        string
+		stackStatus string
+		want        want
+	}
+
+	testcases := []testcase{
+		{name: "affected", stackStatus: "affected", want: want{validationErr: nil}},
+		{name: "pending", stackStatus: "pending", want: want{validationErr: nil}},
+		{name: "running", stackStatus: "running", want: want{validationErr: nil}},
+		{name: "unchanged", stackStatus: "unchanged", want: want{validationErr: nil}},
+		{name: "changed", stackStatus: "changed", want: want{validationErr: nil}},
+		{name: "canceled", stackStatus: "canceled", want: want{validationErr: nil}},
+		{name: "failed", stackStatus: "failed", want: want{validationErr: nil}},
+		{name: "empty", stackStatus: "", want: want{validationErr: errors.New("invalid stack status: unrecognized value")}},
+		{name: "somestatus", stackStatus: "", want: want{validationErr: errors.New("invalid stack status: unrecognized value")}},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			status := preview.StackStatus(tc.stackStatus)
+			err := status.Validate()
+			assert.EqualErrs(t, tc.want.validationErr, err, "unexpected validation error")
+		})
+	}
+}
+
+func TestDerivePreviewStatus(t *testing.T) {
+	t.Parallel()
+	type want struct {
+		status preview.StackStatus
+	}
+	type testcase struct {
+		name     string
+		exitCode int
+		want     want
+	}
+
+	testcases := []testcase{
+		{
+			name:     "exit code -1",
+			exitCode: -1,
+			want: want{
+				status: preview.StackStatusCanceled,
+			},
+		},
+		{
+			name:     "exit code 0",
+			exitCode: 0,
+			want: want{
+				status: preview.StackStatusUnchanged,
+			},
+		},
+		{
+			name:     "exit code 1",
+			exitCode: 1,
+			want: want{
+				status: preview.StackStatusFailed,
+			},
+		},
+		{
+			name:     "exit code 2",
+			exitCode: 2,
+			want: want{
+				status: preview.StackStatusChanged,
+			},
+		},
+		{
+			name:     "exit code other",
+			exitCode: 9,
+			want: want{
+				status: preview.StackStatusFailed,
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			status := preview.DerivePreviewStatus(tc.exitCode)
+			assert.EqualStrings(t, tc.want.status.String(), status.String(), "unexpected status")
+		})
+	}
+}

--- a/cloud/types.go
+++ b/cloud/types.go
@@ -326,6 +326,7 @@ var (
 	_ = Resource(CommandLog{})
 	_ = Resource(CreatePreviewPayloadRequest{})
 	_ = Resource(CreatePreviewResponse{})
+	_ = Resource(UpdateStackPreviewPayloadRequest{})
 	_ = Resource(EmptyResponse(""))
 )
 

--- a/cloud/types_preview.go
+++ b/cloud/types_preview.go
@@ -3,7 +3,10 @@
 
 package cloud
 
-import "github.com/terramate-io/terramate/errors"
+import (
+	"github.com/terramate-io/terramate/cloud/preview"
+	"github.com/terramate-io/terramate/errors"
+)
 
 type (
 	// PreviewStacks is a list of stack objects for the request payload
@@ -14,8 +17,8 @@ type (
 	PreviewStack struct {
 		Stack
 
-		PreviewStatus string   `json:"preview_status"`
-		Cmd           []string `json:"cmd"`
+		PreviewStatus preview.StackStatus `json:"preview_status"`
+		Cmd           []string            `json:"cmd,omitempty"`
 	}
 	// CreatePreviewPayloadRequest is the request payload for the creation of
 	// stack deployments.
@@ -42,7 +45,29 @@ type (
 		PreviewID string                `json:"preview_id"`
 		Stacks    ResponsePreviewStacks `json:"stacks"`
 	}
+
+	// UpdateStackPreviewPayloadRequest is the request payload for the update of
+	// stack previews.
+	UpdateStackPreviewPayloadRequest struct {
+		Status           string            `json:"status"`
+		ChangesetDetails *ChangesetDetails `json:"changeset_details,omitempty"`
+	}
 )
+
+// Validate the UpdateStackPreviewPayloadRequest object.
+func (r UpdateStackPreviewPayloadRequest) Validate() error {
+	errs := errors.L()
+	if r.Status == "" {
+		errs.Append(errors.E("status is required"))
+	}
+
+	if r.ChangesetDetails != nil {
+		if err := r.ChangesetDetails.Validate(); err != nil {
+			errs.Append(err)
+		}
+	}
+	return errs.AsError()
+}
 
 // Validate the ResponsePreviewStacks object.
 func (s ResponsePreviewStacks) Validate() error {

--- a/cmd/terramate/cli/clitest/messages.go
+++ b/cmd/terramate/cli/clitest/messages.go
@@ -37,7 +37,7 @@ const (
 	ErrCloudStacksWithoutID errors.Kind = "all the cloud sync features requires that selected stacks contain an ID field"
 
 	// ErrCloudTerraformPlanFile indicates there was an error gathering the plan file details.
-	ErrCloudTerraformPlanFile errors.Kind = "failed to gather drift details from plan file"
+	ErrCloudTerraformPlanFile errors.Kind = "failed to gather details from plan file"
 
 	// ErrCloudInvalidTerraformPlanFilePath indicates the plan file is not valid.
 	ErrCloudInvalidTerraformPlanFilePath errors.Kind = "invalid plan file path"

--- a/cmd/terramate/cli/cloud_sync_drift.go
+++ b/cmd/terramate/cli/cloud_sync_drift.go
@@ -4,16 +4,8 @@
 package cli
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
-	"os"
-	"os/exec"
-	"path/filepath"
-	"time"
 
-	tfjson "github.com/hashicorp/terraform-json"
-	"github.com/hashicorp/terraform-json/sanitize"
 	"github.com/rs/zerolog/log"
 	"github.com/terramate-io/terramate/cloud"
 	"github.com/terramate-io/terramate/cloud/drift"
@@ -86,105 +78,4 @@ func (c *cli) cloudSyncDriftStatus(run runContext, res runResult, err error) {
 	} else {
 		logger.Debug().Msg("synced drift_status successfully")
 	}
-}
-
-func (c *cli) getTerraformChangeset(run runContext, planfile string) (*cloud.ChangesetDetails, error) {
-	logger := log.With().
-		Str("action", "getTerraformChangeset").
-		Str("planfile", planfile).
-		Stringer("stack", run.Stack.Dir).
-		Logger()
-
-	if filepath.IsAbs(planfile) {
-		return nil, errors.E(clitest.ErrCloudInvalidTerraformPlanFilePath, "path must be relative to the running stack")
-	}
-
-	absPlanFilePath := filepath.Join(run.Stack.HostDir(c.cfg()), planfile)
-	_, err := os.Lstat(absPlanFilePath)
-	if err != nil {
-		return nil, errors.E(err, "checking plan file")
-	}
-
-	renderedPlan, err := c.runTerraformShow(run, planfile, "-no-color")
-	if err != nil {
-		logger.Warn().Err(err).Msg("failed to synchronize the ASCII plan output")
-	}
-
-	var newJSONPlanData []byte
-	jsonPlanData, err := c.runTerraformShow(run, planfile, "-no-color", "-json")
-	if err == nil {
-		newJSONPlanData, err = sanitizeJSONPlan([]byte(jsonPlanData))
-		if err != nil {
-			logger.Warn().Err(err).Msg("failed to sanitize the JSON plan output")
-		}
-	} else {
-		logger.Warn().Err(err).Msg("failed to synchronize the JSON plan output")
-	}
-
-	if renderedPlan == "" && len(newJSONPlanData) == 0 {
-		return nil, nil
-	}
-
-	return &cloud.ChangesetDetails{
-		Provisioner:    "terraform",
-		ChangesetASCII: renderedPlan,
-		ChangesetJSON:  string(newJSONPlanData),
-	}, nil
-}
-
-func sanitizeJSONPlan(jsonPlanBytes []byte) ([]byte, error) {
-	var oldPlan tfjson.Plan
-	err := json.Unmarshal([]byte(jsonPlanBytes), &oldPlan)
-	if err != nil {
-		return nil, errors.E(err, "unmarshaling Terraform JSON plan")
-	}
-	err = oldPlan.Validate()
-	if err != nil {
-		return nil, errors.E(err, "validating plan file")
-	}
-
-	const replaceWith = "__terramate_redacted__"
-	newPlan, err := sanitize.SanitizePlanWithValue(&oldPlan, replaceWith)
-	if err != nil {
-		return nil, errors.E(err)
-	}
-	newJSONPlanData, err := json.Marshal(newPlan)
-	if err != nil {
-		return nil, errors.E(err, "failed to marshal sanitized Terraform JSON plan")
-	}
-	return newJSONPlanData, nil
-}
-
-func (c *cli) runTerraformShow(run runContext, planfile string, flags ...string) (string, error) {
-	var stdout, stderr bytes.Buffer
-
-	args := []string{
-		"show",
-	}
-	args = append(args, flags...)
-	args = append(args, planfile)
-
-	const tfShowTimeout = 5 * time.Second
-	ctx, cancel := context.WithTimeout(context.Background(), tfShowTimeout)
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, "terraform", args...)
-	cmd.Dir = run.Stack.Dir.HostPath(c.rootdir())
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-
-	logger := log.With().
-		Str("action", "runTerraformShow").
-		Str("planfile", planfile).
-		Stringer("stack", run.Stack.Dir).
-		Str("command", cmd.String()).
-		Logger()
-
-	err := cmd.Run()
-	if err != nil {
-		logger.Error().Str("stderr", stderr.String()).Msg("command stderr")
-		return "", errors.E(clitest.ErrCloudTerraformPlanFile, "executing: %s", cmd.String())
-	}
-
-	return stdout.String(), nil
 }

--- a/cmd/terramate/cli/cloud_sync_terraform_plan.go
+++ b/cmd/terramate/cli/cloud_sync_terraform_plan.go
@@ -1,0 +1,122 @@
+// Copyright 2024 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+
+	tfjson "github.com/hashicorp/terraform-json"
+	"github.com/hashicorp/terraform-json/sanitize"
+	"github.com/rs/zerolog/log"
+	"github.com/terramate-io/terramate/cloud"
+	"github.com/terramate-io/terramate/cmd/terramate/cli/clitest"
+	"github.com/terramate-io/terramate/errors"
+)
+
+func (c *cli) getTerraformChangeset(run runContext, planfile string) (*cloud.ChangesetDetails, error) {
+	logger := log.With().
+		Str("action", "getTerraformChangeset").
+		Str("planfile", planfile).
+		Stringer("stack", run.Stack.Dir).
+		Logger()
+
+	if filepath.IsAbs(planfile) {
+		return nil, errors.E(clitest.ErrCloudInvalidTerraformPlanFilePath, "path must be relative to the running stack")
+	}
+
+	absPlanFilePath := filepath.Join(run.Stack.HostDir(c.cfg()), planfile)
+	_, err := os.Lstat(absPlanFilePath)
+	if err != nil {
+		return nil, errors.E(err, "checking plan file")
+	}
+
+	renderedPlan, err := c.runTerraformShow(run, planfile, "-no-color")
+	if err != nil {
+		logger.Warn().Err(err).Msg("failed to synchronize the ASCII plan output")
+	}
+
+	var newJSONPlanData []byte
+	jsonPlanData, err := c.runTerraformShow(run, planfile, "-no-color", "-json")
+	if err == nil {
+		newJSONPlanData, err = sanitizeJSONPlan([]byte(jsonPlanData))
+		if err != nil {
+			logger.Warn().Err(err).Msg("failed to sanitize the JSON plan output")
+		}
+	} else {
+		logger.Warn().Err(err).Msg("failed to synchronize the JSON plan output")
+	}
+
+	if renderedPlan == "" && len(newJSONPlanData) == 0 {
+		return nil, nil
+	}
+
+	return &cloud.ChangesetDetails{
+		Provisioner:    "terraform",
+		ChangesetASCII: renderedPlan,
+		ChangesetJSON:  string(newJSONPlanData),
+	}, nil
+}
+
+func sanitizeJSONPlan(jsonPlanBytes []byte) ([]byte, error) {
+	var oldPlan tfjson.Plan
+	err := json.Unmarshal([]byte(jsonPlanBytes), &oldPlan)
+	if err != nil {
+		return nil, errors.E(err, "unmarshaling Terraform JSON plan")
+	}
+	err = oldPlan.Validate()
+	if err != nil {
+		return nil, errors.E(err, "validating plan file")
+	}
+
+	const replaceWith = "__terramate_redacted__"
+	newPlan, err := sanitize.SanitizePlanWithValue(&oldPlan, replaceWith)
+	if err != nil {
+		return nil, errors.E(err)
+	}
+	newJSONPlanData, err := json.Marshal(newPlan)
+	if err != nil {
+		return nil, errors.E(err, "failed to marshal sanitized Terraform JSON plan")
+	}
+	return newJSONPlanData, nil
+}
+
+func (c *cli) runTerraformShow(run runContext, planfile string, flags ...string) (string, error) {
+	var stdout, stderr bytes.Buffer
+
+	args := []string{
+		"show",
+	}
+	args = append(args, flags...)
+	args = append(args, planfile)
+
+	const tfShowTimeout = 5 * time.Second
+	ctx, cancel := context.WithTimeout(context.Background(), tfShowTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "terraform", args...)
+	cmd.Dir = run.Stack.Dir.HostPath(c.rootdir())
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	logger := log.With().
+		Str("action", "runTerraformShow").
+		Str("planfile", planfile).
+		Stringer("stack", run.Stack.Dir).
+		Str("command", cmd.String()).
+		Logger()
+
+	err := cmd.Run()
+	if err != nil {
+		logger.Error().Str("stderr", stderr.String()).Msg("command stderr")
+		return "", errors.E(clitest.ErrCloudTerraformPlanFile, "executing: %s", cmd.String())
+	}
+
+	return stdout.String(), nil
+}

--- a/cmd/terramate/cli/github/event.go
+++ b/cmd/terramate/cli/github/event.go
@@ -7,25 +7,18 @@ import (
 	"encoding/json"
 	"os"
 	"time"
-
-	"github.com/terramate-io/terramate/printer"
 )
 
 // GetEventPRUpdatedAt returns the updated_at field from the file at `eventPath`.
 // The file is expected to be a JSON file containing the GitHub event for a pull
 // request.
-func GetEventPRUpdatedAt(eventPath string) *time.Time {
+func GetEventPRUpdatedAt(eventPath string) (*time.Time, error) {
 	event, err := getEventFromPath(eventPath)
 	if err != nil {
-		printer.Stderr.WarnWithDetails("unable to read github event", err)
-		return nil
+		return nil, err
 	}
 
-	if event != nil {
-		return event.PullRequest.UpdatedAt
-	}
-
-	return nil
+	return event.PullRequest.UpdatedAt, nil
 }
 
 type event struct {

--- a/cmd/terramate/cli/github/event_test.go
+++ b/cmd/terramate/cli/github/event_test.go
@@ -28,12 +28,13 @@ func TestGetEventFromPath(t *testing.T) {
 }
 
 func TestGetEventPRUpdatedAt(t *testing.T) {
-	if updatedAt := GetEventPRUpdatedAt(validGithubEventPath); updatedAt == nil {
-		t.Fatal("updatedAt is nil, expected not nil")
+	updatedAt, err := GetEventPRUpdatedAt(validGithubEventPath)
+	if err != nil {
+		t.Fatalf("error is not nil, expected nil")
 	}
 
 	const wantUpdatedAt = "2024-02-09 12:38:32 +0000 UTC"
-	if updatedAt := GetEventPRUpdatedAt(validGithubEventPath); updatedAt.String() != wantUpdatedAt {
+	if updatedAt.String() != wantUpdatedAt {
 		t.Errorf("updatedAt is not equal to wantUpdatedAt, got: %s", updatedAt.String())
 	}
 }

--- a/cmd/terramate/e2etests/cloud/interop/testdata/interop-stacks/basic-terraform/main.tf
+++ b/cmd/terramate/e2etests/cloud/interop/testdata/interop-stacks/basic-terraform/main.tf
@@ -1,0 +1,9 @@
+/**
+ * Copyright 2023 Terramate GmbH
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+resource "local_file" "foo" {
+  content  = "hello world"
+  filename = "${path.module}/foo.bar"
+}

--- a/cmd/terramate/e2etests/cloud/interop/testdata/interop-stacks/basic-terraform/stack.tm.hcl
+++ b/cmd/terramate/e2etests/cloud/interop/testdata/interop-stacks/basic-terraform/stack.tm.hcl
@@ -1,0 +1,8 @@
+// Copyright 2023 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+stack {
+  name        = "basic-terraform"
+  description = "basic-terraform"
+  id          = "44444444-2691-48dc-b418-e966f7e1441c"
+}


### PR DESCRIPTION
## What this PR does / why we need it:

Submit per stack preview progress (status updates + changeset) to TMC

* As the commands are running, their respective status changes are submitted to TMC
* If a command has a changeset, the changset is submitted to TMC
* The preview status for a stack is determined by the exit code of the preview command and whether the terraform plan had changes
* Abort preview when env var `GITHUB_EVENT_PATH` is missing
  * The `GITHUB_EVENT_PATH` environment variable is used to determine the `updated_at` field of the pull request. If the variable is missing, the preview should be aborted. However the run command should still be executed (wtih cloud features disabled).


Depends on https://github.com/terramate-io/terramate/pull/1436

## Which issue(s) this PR fixes:

## Special notes for your reviewer:

* The fake http transport was enhanced to support different behaviour for different HTTP endpoints

## Does this PR introduce a user-facing change?
```
No.
```
