### PR TITLE
fix: ensure order of script commands is preserved after sorting

### DIFF
--- a/run/order.go
+++ b/run/order.go
@@ -4,6 +4,7 @@
 package run
 
 import (
+	"cmp"
 	"fmt"
 	"os"
 	"path"
@@ -37,7 +38,7 @@ func Sort[S ~[]E, E any](root *config.Root, items S, getStack func(E) *config.St
 		return getStack(s).Dir.String()
 	}
 
-	slices.SortFunc(items, func(a, b E) int {
+	slices.SortStableFunc(items, func(a, b E) int {
 		return strings.Compare(getStack(a).Dir.String(), getStack(b).Dir.String())
 	})
 
@@ -97,17 +98,8 @@ func Sort[S ~[]E, E any](root *config.Root, items S, getStack func(E) *config.St
 		orderLookup[s.Dir.String()] = idx
 	}
 
-	slices.SortFunc(items, func(a, b E) int {
-		// TODO: Replace with cmp.Compare once we upgrade Go version.
-		i := orderLookup[getStackDir(a)]
-		j := orderLookup[getStackDir(b)]
-		if i == j {
-			return 0
-		} else if i < j {
-			return -1
-		} else {
-			return 1
-		}
+	slices.SortStableFunc(items, func(a, b E) int {
+		return cmp.Compare(orderLookup[getStackDir(a)], orderLookup[getStackDir(b)])
 	})
 
 	return "", nil

--- a/run/order_test.go
+++ b/run/order_test.go
@@ -1,0 +1,67 @@
+// Copyright 2023 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+package run_test
+
+import (
+	"path"
+	"slices"
+	"testing"
+
+	"github.com/madlambda/spells/assert"
+	"github.com/terramate-io/terramate/config"
+	"github.com/terramate-io/terramate/project"
+	"github.com/terramate-io/terramate/run"
+	"github.com/terramate-io/terramate/test/sandbox"
+)
+
+func TestStableSortOrder(t *testing.T) {
+	t.Parallel()
+	s := sandbox.NoGit(t, true)
+	s.BuildTree([]string{
+		"s:s1",
+		"s:s1/s2",
+		"s:s1/s2/s3",
+		"s:s1/s2/s3/s4",
+		"s:s1/s2/s3/s4/s5",
+	})
+
+	root, err := config.LoadRoot(s.RootDir())
+	assert.NoError(t, err)
+
+	type item struct {
+		index int
+		stack *config.Stack
+	}
+	var items []item
+
+	// We define 5 stacks, due to parent relationship there is an implicit ordering between them. s1 -> s5.
+	stackOrder := []string{"s1/s2/s3/s4/s5", "s1/s2/s3/s4", "s1/s2/s3", "s1/s2", "s1"}
+
+	// For each stack, we add 100 numbered items, starting at s5 -> s1.
+	for _, sname := range stackOrder {
+		s, err := config.LoadStack(root, project.NewPath(path.Join("/", sname)))
+		assert.NoError(t, err)
+
+		for i := 0; i < 100; i++ {
+			items = append(items, item{index: i + 123, stack: s})
+		}
+	}
+
+	// We do a topological sorting of the items.
+	getStack := func(item item) *config.Stack { return item.stack }
+	_, err = run.Sort(root, items, getStack)
+	assert.NoError(t, err)
+
+	slices.Reverse(stackOrder)
+
+	// We expect the items in order of s1 -> s5 after sorting, so the stack order is reversed,
+	// but ordering within each stack is preserved (0 -> 100).
+	for i, sname := range stackOrder {
+		for j := 0; j < 100; j++ {
+			got := items[i*100+j]
+			assert.EqualStrings(t, sname, got.stack.RelPath(), "matrix: %v %v", i, j)
+			assert.EqualInts(t, j+123, got.index)
+		}
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/terramate-io/terramate/blob/main/CONTRIBUTING.md
2. If the PR is unfinished, mark it as draft: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request
3. Please update the PR title using the Conventional Commits convention: https://www.conventionalcommits.org/en/v1.0.0/
    Example: feat: add support for XYZ.
-->

## What this PR does / why we need it:
I noticed that the change to the `run.Sort()` of script commands I made in #1413 does not use stable sorting, which as far as I understand, could lead to script commands being executed in the wrong order. However, I was not able to reproduce this with a test case. I still think it's a good idea to use stable sort here.


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Keep it empty if not applicable.
-->

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
<!--
If no, just write "no" in the block below.
If yes, please explain the change and update documentation and the CHANGELOG.md file accordingly.
-->
```
no
```
