### PR TITLE
feat: submit preview logs to TMC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 - Add `terramate.config.generate.hcl_magic_header_comment_style` option for setting the generated comment style.
 - Add support for formatting specific files and stdin (`terramate fmt [file...]` or `terramate fmt -`).
 - Add `--cloud-status=status` flag to both `terramate run` and `terramate script run`.
+- Add `--cloud-sync-preview` flag to `terramate run` to sync the preview to Terramate Cloud.
 
 ### Fixed
 

--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -249,18 +249,23 @@ func (c *Client) SyncCommandLogs(
 	stackID int64,
 	deploymentUUID UUID,
 	logs CommandLogs,
+	stackPreviewID string,
 ) error {
 	err := logs.Validate()
 	if err != nil {
 		return errors.E(err, "failed to prepare the request")
 	}
-	// Endpoint:/v1/stacks/{org_uuid}/{stack_id}/deployments/{deployment_uuid}/logs
-	_, err = Post[EmptyResponse](
-		ctx, c, logs,
-		c.URL(path.Join(
-			StacksPath, string(orgUUID), strconv.Itoa64(stackID), "deployments", string(deploymentUUID), "logs",
-		)),
-	)
+
+	url := c.URL(path.Join(
+		StacksPath, string(orgUUID), strconv.Itoa64(stackID), "deployments", string(deploymentUUID), "logs",
+	))
+
+	// if the command logs are for a stack preview, use the stack preview url.
+	if stackPreviewID != "" {
+		url = c.URL(path.Join(StackPreviewsPath, string(orgUUID), stackPreviewID, "logs"))
+	}
+
+	_, err = Post[EmptyResponse](ctx, c, logs, url)
 	return err
 }
 

--- a/cmd/terramate/cli/cloud.go
+++ b/cmd/terramate/cli/cloud.go
@@ -52,7 +52,8 @@ type cloudConfig struct {
 		runUUID cloud.UUID
 		orgUUID cloud.UUID
 
-		meta2id                     map[string]int64
+		meta2id map[string]int64
+		// stackPreviews is a map of stack.ID to stackPreview.ID
 		stackPreviews               map[string]string
 		reviewRequest               *cloud.ReviewRequest
 		metadata                    *cloud.DeploymentMetadata

--- a/cmd/terramate/cli/run.go
+++ b/cmd/terramate/cli/run.go
@@ -270,7 +270,7 @@ func (c *cli) runAll(
 		stderr := c.stderr
 
 		logSyncWait := func() {}
-		if c.cloudEnabled() && run.CloudSyncDeployment {
+		if c.cloudEnabled() && (run.CloudSyncDeployment || run.CloudSyncPreview) {
 			logSyncer := cloud.NewLogSyncer(func(logs cloud.CommandLogs) {
 				c.syncLogs(&logger, run, logs)
 			})
@@ -385,8 +385,9 @@ func (c *cli) syncLogs(logger *zerolog.Logger, run runContext, logs cloud.Comman
 	ctx, cancel := context.WithTimeout(context.Background(), defaultCloudTimeout)
 	defer cancel()
 	stackID := c.cloud.run.meta2id[run.Stack.ID]
+	stackPreviewID := c.cloud.run.stackPreviews[run.Stack.ID]
 	err := c.cloud.client.SyncCommandLogs(
-		ctx, c.cloud.run.orgUUID, stackID, c.cloud.run.runUUID, logs,
+		ctx, c.cloud.run.orgUUID, stackID, c.cloud.run.runUUID, logs, stackPreviewID,
 	)
 	if err != nil {
 		logger.Warn().Err(err).Msg("failed to sync logs")


### PR DESCRIPTION
## What this PR does / why we need it:

Submit logs generated as part of a preview run to TMC.

## Which issue(s) this PR fixes:

## Special notes for your reviewer:

Depends on https://github.com/terramate-io/terramate/pull/1443

The implementation re-uses the already existing DeploymentLogLines type to submit logs to TMC.

## Does this PR introduce a user-facing change?
```
Yes the logs of a preview run are submitted to TMC.
```
