### PR TITLE
feat: add script.name attribute.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 - Add `terramate.config.generate.hcl_magic_header_comment_style` option for setting the generated comment style.
 - Add support for formatting specific files and stdin (`terramate fmt [file...]` or `terramate fmt -`).
 - Add `--cloud-status=status` flag to both `terramate run` and `terramate script run`.
+- Add `script.name` attribute. 
+  The commands `terramate script info`, `terramate script list` and `terramate script tree` were 
+  updated to show the script name (when available).
 - Add `--cloud-sync-preview` flag to `terramate run` to sync the preview to Terramate Cloud.
 
 ### Fixed

--- a/cmd/terramate/cli/script_list.go
+++ b/cmd/terramate/cli/script_list.go
@@ -34,7 +34,10 @@ func (c *cli) printScriptList() {
 		entry := entries[name]
 
 		c.output.MsgStdOut("%v", name)
-		c.output.MsgStdOut("  %v", formatScriptDescription(entry.ScriptCfg))
+		if entry.ScriptCfg.Name != nil {
+			c.output.MsgStdOut("  Name: %v", nameTruncation(exprString(entry.ScriptCfg.Name.Expr)))
+		}
+		c.output.MsgStdOut("  Description: %v", exprString(entry.ScriptCfg.Description.Expr))
 
 		c.output.MsgStdOut("  Defined at %v", entry.Dir)
 
@@ -48,7 +51,7 @@ func (c *cli) printScriptList() {
 
 func addParentScriptListEntries(cfg *config.Tree, entries scriptListMap) {
 	for _, sc := range cfg.Node.Scripts {
-		scriptname := sc.Name()
+		scriptname := sc.AccessorName()
 		defcount := 1
 		olddef := entries[scriptname]
 		if olddef != nil {
@@ -72,7 +75,7 @@ func addChildScriptListEntries(cfg *config.Tree, entries scriptListMap) {
 	for _, k := range sortedKeys(cfg.Children) {
 		childCfg := cfg.Children[k]
 		for _, sc := range childCfg.Node.Scripts {
-			scriptname := sc.Name()
+			scriptname := sc.AccessorName()
 
 			olddef := entries[scriptname]
 			if olddef != nil {

--- a/cmd/terramate/cli/script_tree.go
+++ b/cmd/terramate/cli/script_tree.go
@@ -75,15 +75,19 @@ func (node *scriptsTreeNode) format(w io.Writer, prefix string, parentScripts []
 	}
 
 	for _, sc := range node.Scripts {
-		desc := formatScriptDescription(sc)
-		fmt.Fprintln(w, blockPrefix+"* "+scriptColor(sc.Name()+": "+desc))
+		desc := exprString(sc.Description.Expr)
+		fmt.Fprintln(w, blockPrefix+"* "+scriptColor(sc.AccessorName()+": "))
+		if sc.Name != nil {
+			fmt.Fprintln(w, blockPrefix+"  "+scriptColor("  name: "+nameTruncation(exprString(sc.Name.Expr))))
+		}
+		fmt.Fprintln(w, blockPrefix+"  "+scriptColor("  description: "+desc))
 	}
 
 	if node.IsStack {
 		for _, p := range parentScripts {
 			found := slices.ContainsFunc(node.Scripts,
 				func(a *hcl.Script) bool {
-					return a.Name() == p
+					return a.AccessorName() == p
 				})
 			if !found {
 				fmt.Fprintln(w, blockPrefix+parentScriptColor("~ "+p))
@@ -92,8 +96,8 @@ func (node *scriptsTreeNode) format(w io.Writer, prefix string, parentScripts []
 	}
 
 	for _, e := range node.Scripts {
-		if !slices.Contains(parentScripts, e.Name()) {
-			parentScripts = append(parentScripts, e.Name())
+		if !slices.Contains(parentScripts, e.AccessorName()) {
+			parentScripts = append(parentScripts, e.AccessorName())
 		}
 	}
 

--- a/cmd/terramate/e2etests/core/script_list_test.go
+++ b/cmd/terramate/e2etests/core/script_list_test.go
@@ -41,7 +41,7 @@ func TestScriptList(t *testing.T) {
 	mkExpected := func(name, path string, count int) string {
 		if count != 0 {
 			return fmt.Sprintf(`%s
-  "%s at /%s"
+  Description: "%s at /%s"
   Defined at /%s
     (+%d more)
 
@@ -50,7 +50,7 @@ func TestScriptList(t *testing.T) {
 		}
 
 		return fmt.Sprintf(`%s
-  "%s at /%s"
+  Description: "%s at /%s"
   Defined at /%s
 
 `, name, name, path, path)

--- a/docs/cli/orchestration/scripts.md
+++ b/docs/cli/orchestration/scripts.md
@@ -80,7 +80,8 @@ script "command" "subcommand" { # any level of subcommands is supported
 provide to the `terramate script run` command in order to execute the script:
 `terramate script run command subcommand`. You can define any number of labels.
 - Attributes and Blocks Reference of the `script` block
-  - `description` *(optional)* - A description of the jobs being executed
+  - `name` *(optional)* - A name for the jobs being executed (maximum of 128 chars)
+  - `description` *(required)* - A description of the jobs being executed
   - `job` *(required)* - One or more blocks each defining a sequence of commands to be executed in the script.
   Jobs are executed in the order of definition.
       

--- a/hcl/hcl_script.go
+++ b/hcl/hcl_script.go
@@ -36,15 +36,25 @@ type ScriptJob struct {
 	Commands *Commands // Commands is a list of executable commands
 }
 
+// ScriptName is a human readable name of a script.
+type ScriptName ast.Attribute
+
 // ScriptDescription is human readable description of a script
 type ScriptDescription ast.Attribute
 
 // Script represents a parsed script block
 type Script struct {
 	Range       info.Range
-	Labels      []string           // Labels of the script block used for grouping scripts
+	Labels      []string // Labels of the script block used for grouping scripts
+	Name        *ScriptName
 	Description *ScriptDescription // Description is a human readable description of a script
 	Jobs        []*ScriptJob       // Job represents the command(s) part of this script
+}
+
+// NewScriptName returns a *ScriptName encapsulating an ast.Attribute
+func NewScriptName(attr ast.Attribute) *ScriptName {
+	name := ScriptName(attr)
+	return &name
 }
 
 // NewScriptDescription returns a *ScriptDescription encapsulating an ast.Attribute
@@ -65,8 +75,8 @@ func NewScriptCommands(attr ast.Attribute) *Commands {
 	return &cmds
 }
 
-// Name returns the formatted script name
-func (sc *Script) Name() string {
+// AccessorName returns the name traversal for accessing the script.
+func (sc *Script) AccessorName() string {
 	var b strings.Builder
 	for i, e := range sc.Labels {
 		if i != 0 {
@@ -93,6 +103,8 @@ func (p *TerramateParser) parseScriptBlock(block *ast.Block) (*Script, error) {
 
 	for _, attr := range block.Attributes {
 		switch attr.Name {
+		case "name":
+			parsedScript.Name = NewScriptName(attr)
 		case "description":
 			parsedScript.Description = NewScriptDescription(attr)
 		default:


### PR DESCRIPTION
## What this PR does / why we need it:

Add an optional `script.name` attribute. This is purely a cosmetic change.
Now the commands `terramate script info`, `terramate script list` and `terramate script tree` show the name if available. Example below:

<img width="600" alt="Screenshot 2024-02-22 at 19 17 28" src="https://github.com/terramate-io/terramate/assets/251478/9c6bee8b-fad5-43c3-bc02-d7100a8567fd">
<img width="524" alt="Screenshot 2024-02-22 at 19 17 51" src="https://github.com/terramate-io/terramate/assets/251478/49bd6a34-141b-4513-9cbe-aee47b80f60e">
<img width="524" alt="Screenshot 2024-02-22 at 19 18 09" src="https://github.com/terramate-io/terramate/assets/251478/a7017fdc-1a25-4c3d-bc65-8655521704e2">


## Which issue(s) this PR fixes:

none

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
yes, a new script.name attr added.
```
