### PR TITLE
refactor!: remove terramate.config.git.default_branch_base_ref attr.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 
 ### Changed
 
-- (**Breaking Change**) The code generation of HCL and plain files was disallowed inside dot directories.
+- (**BREAKING CHANGE**) Removes the option `terramate.config.git.default_branch_base_ref`.
+- (**BREAKING CHANGE**) The code generation of HCL and plain files was disallowed inside dot directories.
 
 ## v0.5.5
 

--- a/cmd/terramate/cli/project.go
+++ b/cmd/terramate/cli/project.go
@@ -30,9 +30,8 @@ type project struct {
 		localDefaultBranchCommit  string
 		remoteDefaultBranchCommit string
 
-		baseRefConfigured bool
-		remoteConfigured  bool
-		branchConfigured  bool
+		remoteConfigured bool
+		branchConfigured bool
 
 		repoChecks stack.RepoChecks
 	}
@@ -142,15 +141,13 @@ func (p *project) isDefaultBranch() bool {
 
 // defaultBaseRef returns the baseRef for the current git environment.
 func (p *project) defaultBaseRef() string {
-	git := p.gitcfg()
 	if p.isDefaultBranch() &&
 		p.remoteDefaultCommit() == p.headCommit() {
-		_, err := p.git.wrapper.RevParse(git.DefaultBranchBaseRef)
+		_, err := p.git.wrapper.RevParse(defaultBranchBaseRef)
 		if err == nil {
-			return git.DefaultBranchBaseRef
+			return defaultBranchBaseRef
 		}
 	}
-
 	return p.defaultBranchRef()
 }
 
@@ -158,12 +155,11 @@ func (p *project) defaultBaseRef() string {
 func (p *project) defaultLocalBaseRef() string {
 	git := p.gitcfg()
 	if p.isDefaultBranch() {
-		_, err := p.git.wrapper.RevParse(git.DefaultBranchBaseRef)
+		_, err := p.git.wrapper.RevParse(defaultBranchBaseRef)
 		if err == nil {
-			return git.DefaultBranchBaseRef
+			return defaultBranchBaseRef
 		}
 	}
-
 	return git.DefaultBranch
 }
 
@@ -200,11 +196,6 @@ func (p *project) setDefaults() error {
 	}
 
 	gitOpt := cfg.Terramate.Config.Git
-
-	p.git.baseRefConfigured = gitOpt.DefaultBranchBaseRef != ""
-	if !p.git.baseRefConfigured {
-		gitOpt.DefaultBranchBaseRef = defaultBranchBaseRef
-	}
 
 	p.git.branchConfigured = gitOpt.DefaultBranch != ""
 	if !p.git.branchConfigured {

--- a/hcl/hcl.go
+++ b/hcl/hcl.go
@@ -132,9 +132,6 @@ type RunEnv struct {
 
 // GitConfig represents Terramate Git configuration.
 type GitConfig struct {
-	// DefaultBranchBaseRef is the baseRef when in default branch.
-	DefaultBranchBaseRef string
-
 	// DefaultBranch is the default branch.
 	DefaultBranch string
 
@@ -1801,17 +1798,6 @@ func parseGitConfig(cfg *RootConfig, gitBlock *ast.MergedBlock) error {
 			}
 
 			git.DefaultRemote = value.AsString()
-
-		case "default_branch_base_ref":
-			if value.Type() != cty.String {
-				errs.Append(attrErr(attr,
-					"terramate.config.git.defaultBranchBaseRef is not a string but %q",
-					value.Type().FriendlyName(),
-				))
-
-				continue
-			}
-			git.DefaultBranchBaseRef = value.AsString()
 
 		case "check_untracked":
 			if err := checkSafeguardConfigConflict(cfg, attr); err != nil {

--- a/hcl/hcl_test.go
+++ b/hcl/hcl_test.go
@@ -770,7 +770,6 @@ func TestHCLParserRootConfig(t *testing.T) {
 								git {
 									default_branch          = "trunk"
 									default_remote          = "upstream"
-									default_branch_base_ref = "HEAD~2"
 									check_untracked         = false
 									check_uncommitted       = false
 									check_remote            = false
@@ -785,12 +784,11 @@ func TestHCLParserRootConfig(t *testing.T) {
 					Terramate: &hcl.Terramate{
 						Config: &hcl.RootConfig{
 							Git: &hcl.GitConfig{
-								DefaultBranch:        "trunk",
-								DefaultRemote:        "upstream",
-								DefaultBranchBaseRef: "HEAD~2",
-								CheckUntracked:       false,
-								CheckUncommitted:     false,
-								CheckRemote:          hcl.CheckIsFalse,
+								DefaultBranch:    "trunk",
+								DefaultRemote:    "upstream",
+								CheckUntracked:   false,
+								CheckUncommitted: false,
+								CheckRemote:      hcl.CheckIsFalse,
 							},
 						},
 					},


### PR DESCRIPTION
## What this PR does / why we need it:

Removes the configuration `terramate.config.git.default_branch_base_ref`.

## Which issue(s) this PR fixes:


## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
yes, it's a breaking change.
```
