### PR TITLE
chore: refactor DeploymentLog{s} to CommandLog{s}

### DIFF
--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -242,13 +242,13 @@ func (c *Client) CreateStackDrift(
 	)
 }
 
-// SyncDeploymentLogs sends a batch of deployment logs to Terramate Cloud.
-func (c *Client) SyncDeploymentLogs(
+// SyncCommandLogs sends a batch of command logs to Terramate Cloud.
+func (c *Client) SyncCommandLogs(
 	ctx context.Context,
 	orgUUID UUID,
 	stackID int64,
 	deploymentUUID UUID,
-	logs DeploymentLogs,
+	logs CommandLogs,
 ) error {
 	err := logs.Validate()
 	if err != nil {

--- a/cloud/log_syncer_test.go
+++ b/cloud/log_syncer_test.go
@@ -23,7 +23,7 @@ type (
 	}
 	want struct {
 		output  map[cloud.LogChannel][]byte
-		batches []cloud.DeploymentLogs
+		batches []cloud.CommandLogs
 	}
 	testcase struct {
 		name         string
@@ -54,7 +54,7 @@ func TestCloudLogSyncer(t *testing.T) {
 				output: map[cloud.LogChannel][]byte{
 					cloud.StdoutLogChannel: hugeLine,
 				},
-				batches: []cloud.DeploymentLogs{
+				batches: []cloud.CommandLogs{
 					{
 						{
 							Line:    1,
@@ -77,7 +77,7 @@ func TestCloudLogSyncer(t *testing.T) {
 				output: map[cloud.LogChannel][]byte{
 					cloud.StdoutLogChannel: []byte("terramate cloud is amazing"),
 				},
-				batches: []cloud.DeploymentLogs{
+				batches: []cloud.CommandLogs{
 					{
 						{
 							Line:    1,
@@ -98,7 +98,7 @@ func TestCloudLogSyncer(t *testing.T) {
 				output: map[cloud.LogChannel][]byte{
 					cloud.StdoutLogChannel: []byte("terramate\ncloud\nis\namazing"),
 				},
-				batches: []cloud.DeploymentLogs{
+				batches: []cloud.CommandLogs{
 					{
 						{
 							Line:    1,
@@ -133,7 +133,7 @@ func TestCloudLogSyncer(t *testing.T) {
 				output: map[cloud.LogChannel][]byte{
 					cloud.StdoutLogChannel: []byte("\n"),
 				},
-				batches: []cloud.DeploymentLogs{
+				batches: []cloud.CommandLogs{
 					{
 						{
 							Line:    1,
@@ -154,7 +154,7 @@ func TestCloudLogSyncer(t *testing.T) {
 				output: map[cloud.LogChannel][]byte{
 					cloud.StdoutLogChannel: []byte("terramate\r\ncloud\r\nis\r\namazing"),
 				},
-				batches: []cloud.DeploymentLogs{
+				batches: []cloud.CommandLogs{
 					{
 						{
 							Line:    1,
@@ -193,7 +193,7 @@ func TestCloudLogSyncer(t *testing.T) {
 					cloud.StdoutLogChannel: []byte("A\nB\nE\nF"),
 					cloud.StderrLogChannel: []byte("C\nD\nG\nH"),
 				},
-				batches: []cloud.DeploymentLogs{
+				batches: []cloud.CommandLogs{
 					{
 						{
 							Line:    1,
@@ -252,7 +252,7 @@ func TestCloudLogSyncer(t *testing.T) {
 				output: map[cloud.LogChannel][]byte{
 					cloud.StdoutLogChannel: []byte("A\nB\nC\nD\nE\nF\nG\n"),
 				},
-				batches: []cloud.DeploymentLogs{
+				batches: []cloud.CommandLogs{
 					{
 						{
 							Line:    1,
@@ -323,7 +323,7 @@ func TestCloudLogSyncer(t *testing.T) {
 				output: map[cloud.LogChannel][]byte{
 					cloud.StdoutLogChannel: []byte("first write\nwrite after idle time\nanother\nmultiline\nwrite\nhere"),
 				},
-				batches: []cloud.DeploymentLogs{
+				batches: []cloud.CommandLogs{
 					// first batch is due to sync interval trigger.
 					{
 						{
@@ -377,7 +377,7 @@ func TestCloudLogSyncer(t *testing.T) {
 						'a', 'n', 'o', 't', 'h', 'e', 'r', ' ', 'v', 'a', 'l', 'i', 'd',
 					},
 				},
-				batches: []cloud.DeploymentLogs{
+				batches: []cloud.CommandLogs{
 					{
 						// sync is disabled at first non-utf8 sequence.
 						{
@@ -394,8 +394,8 @@ func TestCloudLogSyncer(t *testing.T) {
 		tc.validate(t)
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			var gotBatches []cloud.DeploymentLogs
-			s := cloud.NewLogSyncerWith(func(logs cloud.DeploymentLogs) {
+			var gotBatches []cloud.CommandLogs
+			s := cloud.NewLogSyncerWith(func(logs cloud.CommandLogs) {
 				gotBatches = append(gotBatches, logs)
 			}, tc.batchSize, tc.syncInterval)
 			var stdoutBuf, stderrBuf bytes.Buffer
@@ -458,20 +458,20 @@ func (tc *testcase) validate(t *testing.T) {
 	}
 }
 
-func compareBatches(t *testing.T, got, want []cloud.DeploymentLogs) {
+func compareBatches(t *testing.T, got, want []cloud.CommandLogs) {
 	assert.EqualInts(t, len(want), len(got), "number of batches mismatch")
 
 	wantStdoutLogs, wantStderrLogs := divideBatches(want)
 	gotStdoutLogs, gotStderrLogs := divideBatches(got)
-	if diff := cmp.Diff(wantStdoutLogs, gotStdoutLogs, cmpopts.IgnoreFields(cloud.DeploymentLog{}, "Timestamp")); diff != "" {
+	if diff := cmp.Diff(wantStdoutLogs, gotStdoutLogs, cmpopts.IgnoreFields(cloud.CommandLog{}, "Timestamp")); diff != "" {
 		t.Fatalf("log stdout mismatch: %s", diff)
 	}
-	if diff := cmp.Diff(wantStderrLogs, gotStderrLogs, cmpopts.IgnoreFields(cloud.DeploymentLog{}, "Timestamp")); diff != "" {
+	if diff := cmp.Diff(wantStderrLogs, gotStderrLogs, cmpopts.IgnoreFields(cloud.CommandLog{}, "Timestamp")); diff != "" {
 		t.Fatalf("log stderr mismatch: %s", diff)
 	}
 }
 
-func divideBatches(batches []cloud.DeploymentLogs) (stdoutLogs, stderrLogs cloud.DeploymentLogs) {
+func divideBatches(batches []cloud.CommandLogs) (stdoutLogs, stderrLogs cloud.CommandLogs) {
 	for _, batch := range batches {
 		for _, log := range batch {
 			if log.Channel == cloud.StdoutLogChannel {

--- a/cloud/testserver/cloudstore/store.go
+++ b/cloud/testserver/cloudstore/store.go
@@ -77,9 +77,9 @@ type (
 	}
 	// DeploymentState is the state of a deployment.
 	DeploymentState struct {
-		StackStatus       map[int64]deployment.Status    `json:"stacks_status"`
-		StackStatusEvents map[int64][]deployment.Status  `json:"stacks_events"`
-		StackLogs         map[int64]cloud.DeploymentLogs `json:"stacks_logs"`
+		StackStatus       map[int64]deployment.Status   `json:"stacks_status"`
+		StackStatusEvents map[int64][]deployment.Status `json:"stacks_events"`
+		StackLogs         map[int64]cloud.CommandLogs   `json:"stacks_logs"`
 	}
 	// Drift model.
 	Drift struct {
@@ -321,7 +321,7 @@ func (d *Data) InsertDeployment(orgID cloud.UUID, deploy Deployment) error {
 	}
 
 	deploy.State.StackStatus = make(map[int64]deployment.Status)
-	deploy.State.StackLogs = make(map[int64]cloud.DeploymentLogs)
+	deploy.State.StackLogs = make(map[int64]cloud.CommandLogs)
 	deploy.State.StackStatusEvents = make(map[int64][]deployment.Status)
 	for _, stackID := range deploy.Stacks {
 		deploy.State.StackStatusEvents[stackID] = append(deploy.State.StackStatusEvents[stackID], deployment.Pending)
@@ -384,7 +384,7 @@ func (d *Data) InsertDeploymentLogs(
 	orgID cloud.UUID,
 	stackMetaID string,
 	deploymentID cloud.UUID,
-	logs cloud.DeploymentLogs,
+	logs cloud.CommandLogs,
 ) error {
 	org, found := d.GetOrg(orgID)
 	if !found {
@@ -405,7 +405,7 @@ func (d *Data) InsertDeploymentLogs(
 }
 
 // GetDeploymentLogs returns the logs of the given deployment.
-func (d *Data) GetDeploymentLogs(orgID cloud.UUID, stackMetaID string, deploymentID cloud.UUID, fromLine int) (cloud.DeploymentLogs, error) {
+func (d *Data) GetDeploymentLogs(orgID cloud.UUID, stackMetaID string, deploymentID cloud.UUID, fromLine int) (cloud.CommandLogs, error) {
 	org, found := d.GetOrg(orgID)
 	if !found {
 		return nil, errors.E(ErrNotExists, "org uuid %s", orgID)

--- a/cloud/testserver/stacks.go
+++ b/cloud/testserver/stacks.go
@@ -357,7 +357,7 @@ func PostDeploymentLogs(store *cloudstore.Data, w http.ResponseWriter, r *http.R
 
 	justClose(r.Body)
 
-	var logs cloud.DeploymentLogs
+	var logs cloud.CommandLogs
 	err = json.Unmarshal(bodyData, &logs)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)

--- a/cloud/types.go
+++ b/cloud/types.go
@@ -267,14 +267,14 @@ type (
 		Stacks []UpdateDeploymentStack `json:"stacks"`
 	}
 
-	// DeploymentLogs represents a batch of log messages.
-	DeploymentLogs []*DeploymentLog
+	// CommandLogs represents a batch of log messages.
+	CommandLogs []*CommandLog
 
 	// LogChannel is an enum-like type for the output channels supported.
 	LogChannel int
 
-	// DeploymentLog represents a single log message.
-	DeploymentLog struct {
+	// CommandLog represents a single log message.
+	CommandLog struct {
 		Line      int64      `json:"log_line"`
 		Timestamp *time.Time `json:"timestamp"`
 		Channel   LogChannel `json:"channel"`
@@ -321,8 +321,8 @@ var (
 	_ = Resource(DriftStackPayloadRequest{})
 	_ = Resource(DriftStackPayloadRequests{})
 	_ = Resource(ChangesetDetails{})
-	_ = Resource(DeploymentLogs{})
-	_ = Resource(DeploymentLog{})
+	_ = Resource(CommandLogs{})
+	_ = Resource(CommandLog{})
 	_ = Resource(EmptyResponse(""))
 )
 
@@ -568,8 +568,8 @@ func (ds UpdateDeploymentStacks) Validate() error { return validateResourceList(
 // Validate the list of deployment stacks response.
 func (ds DeploymentStacksResponse) Validate() error { return validateResourceList(ds...) }
 
-// Validate a deployment log.
-func (l DeploymentLog) Validate() error {
+// Validate a command log.
+func (l CommandLog) Validate() error {
 	if l.Channel == unknownLogChannel {
 		return errors.E(`missing "channel" field`)
 	}
@@ -579,8 +579,8 @@ func (l DeploymentLog) Validate() error {
 	return nil
 }
 
-// Validate a list of deployment logs.
-func (ls DeploymentLogs) Validate() error { return validateResourceList(ls...) }
+// Validate a list of command logs.
+func (ls CommandLogs) Validate() error { return validateResourceList(ls...) }
 func validateResourceList[T Resource](resources ...T) error {
 	for _, resource := range resources {
 		err := resource.Validate()

--- a/cmd/terramate/cli/run.go
+++ b/cmd/terramate/cli/run.go
@@ -254,7 +254,7 @@ func (c *cli) runAll(
 
 		logSyncWait := func() {}
 		if c.cloudEnabled() && run.CloudSyncDeployment {
-			logSyncer := cloud.NewLogSyncer(func(logs cloud.DeploymentLogs) {
+			logSyncer := cloud.NewLogSyncer(func(logs cloud.CommandLogs) {
 				c.syncLogs(&logger, run, logs)
 			})
 			stdout = logSyncer.NewBuffer(cloud.StdoutLogChannel, c.stdout)
@@ -362,13 +362,13 @@ func (c *cli) runAll(
 	return errs.AsError()
 }
 
-func (c *cli) syncLogs(logger *zerolog.Logger, run runContext, logs cloud.DeploymentLogs) {
+func (c *cli) syncLogs(logger *zerolog.Logger, run runContext, logs cloud.CommandLogs) {
 	data, _ := json.Marshal(logs)
 	logger.Debug().RawJSON("logs", data).Msg("synchronizing logs")
 	ctx, cancel := context.WithTimeout(context.Background(), defaultCloudTimeout)
 	defer cancel()
 	stackID := c.cloud.run.meta2id[run.Stack.ID]
-	err := c.cloud.client.SyncDeploymentLogs(
+	err := c.cloud.client.SyncCommandLogs(
 		ctx, c.cloud.run.orgUUID, stackID, c.cloud.run.runUUID, logs,
 	)
 	if err != nil {


### PR DESCRIPTION
## What this PR does / why we need it:

* Rename `DeploymentLog` to `CommandLog`
* Rename `DeploymentLogs` to `CommandLogs`
* Rename `SyncDeploymentLogs` to `SyncCommandLogs`

This refactoring was done to re-use the log syncer for preview runs.

## Which issue(s) this PR fixes:

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
No.

```
