### PR TITLE
feat: add support for parallel run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 - Add support for formatting specific files and stdin (`terramate fmt [file...]` or `terramate fmt -`).
 - Add `--cloud-status=status` flag to both `terramate run` and `terramate script run`.
 - Add `--cloud-sync-preview` flag to `terramate run` to sync the preview to Terramate Cloud.
+- Allow to run independent stacks in parallel for faster deployments and better utilization of system resources in general.
+  - Add `--parallel` (short `-j`) option to `terramate run` and `terramate script run`.
+  - `--parallel=N` limits the number of concurrent runs to `N`, otherwise a sensible default limit is chosen.
+  - Ordering constraints between stacks are still respected, i.e. `before`/`after`, parent before sub-folders.
 
 ### Fixed
 

--- a/cmd/terramate/cli/cloud_sync_drift.go
+++ b/cmd/terramate/cli/cloud_sync_drift.go
@@ -13,14 +13,14 @@ import (
 	"github.com/terramate-io/terramate/errors"
 )
 
-func (c *cli) cloudSyncDriftStatus(run runContext, res runResult, err error) {
+func (c *cli) cloudSyncDriftStatus(run stackCloudRun, res runResult, err error) {
 	st := run.Stack
 
 	logger := log.With().
 		Str("action", "cloudSyncDriftStatus").
 		Stringer("stack", st.Dir).
 		Int("exit_code", res.ExitCode).
-		Strs("command", run.Cmd).
+		Strs("command", run.Task.Cmd).
 		Err(err).
 		Logger()
 
@@ -70,7 +70,7 @@ func (c *cli) cloudSyncDriftStatus(run runContext, res runResult, err error) {
 		Metadata:   c.cloud.run.metadata,
 		StartedAt:  res.StartedAt,
 		FinishedAt: res.FinishedAt,
-		Command:    run.Cmd,
+		Command:    run.Task.Cmd,
 	})
 
 	if err != nil {

--- a/cmd/terramate/cli/cloud_sync_terraform_plan.go
+++ b/cmd/terramate/cli/cloud_sync_terraform_plan.go
@@ -20,7 +20,7 @@ import (
 	"github.com/terramate-io/terramate/errors"
 )
 
-func (c *cli) getTerraformChangeset(run runContext, planfile string) (*cloud.ChangesetDetails, error) {
+func (c *cli) getTerraformChangeset(run stackCloudRun, planfile string) (*cloud.ChangesetDetails, error) {
 	logger := log.With().
 		Str("action", "getTerraformChangeset").
 		Str("planfile", planfile).
@@ -87,7 +87,7 @@ func sanitizeJSONPlan(jsonPlanBytes []byte) ([]byte, error) {
 	return newJSONPlanData, nil
 }
 
-func (c *cli) runTerraformShow(run runContext, planfile string, flags ...string) (string, error) {
+func (c *cli) runTerraformShow(run stackCloudRun, planfile string, flags ...string) (string, error) {
 	var stdout, stderr bytes.Buffer
 
 	args := []string{

--- a/cmd/terramate/cli/run.go
+++ b/cmd/terramate/cli/run.go
@@ -24,6 +24,8 @@ import (
 	prj "github.com/terramate-io/terramate/project"
 	runutil "github.com/terramate-io/terramate/run"
 	"github.com/terramate-io/terramate/run/dag"
+	"github.com/terramate-io/terramate/scheduler"
+	"github.com/terramate-io/terramate/scheduler/resource"
 	"github.com/terramate-io/terramate/stack"
 )
 
@@ -39,10 +41,22 @@ const (
 	ErrRunCommandNotFound errors.Kind = "command not found"
 )
 
-// runContext declares a stack run context.
-type runContext struct {
+// stackRun contains a list of tasks to be run per stack.
+type stackRun struct {
 	Stack *config.Stack
-	Cmd   []string
+	Tasks []stackRunTask
+}
+
+// stackCloudRun is a stackRun, but with a single task, because the cloud API only supports
+// a single command per stack for any operation (deploy, drift, preview).
+type stackCloudRun struct {
+	Stack *config.Stack
+	Task  stackRunTask
+}
+
+// stackRunTask declares a stack run context.
+type stackRunTask struct {
+	Cmd []string
 
 	ScriptIdx    int
 	ScriptJobIdx int
@@ -91,20 +105,6 @@ func (c *cli) runOnStacks() {
 		}
 	}
 
-	reason, err := runutil.Sort(c.cfg(), stacks,
-		func(s *config.SortableStack) *config.Stack { return s.Stack })
-	if err != nil {
-		if errors.IsKind(err, dag.ErrCycleDetected) {
-			fatal(sprintf("cycle detected: %s", reason), err)
-		} else {
-			fatal("failed to plan execution", err)
-		}
-	}
-
-	if c.parsedArgs.Run.Reverse {
-		config.ReverseStacks(stacks)
-	}
-
 	if c.parsedArgs.Run.CloudSyncDeployment && c.parsedArgs.Run.CloudSyncDriftStatus {
 		fatal(sprintf("--cloud-sync-deployment conflicts with --cloud-sync-drift-status"), nil)
 	}
@@ -135,18 +135,23 @@ func (c *cli) runOnStacks() {
 		return exitCode == 0
 	}
 
-	var runs []runContext
+	var runs []stackRun
+	var err error
 	for _, st := range stacks {
-		run := runContext{
-			Stack:                      st.Stack,
-			Cmd:                        c.parsedArgs.Run.Command,
-			CloudSyncDeployment:        c.parsedArgs.Run.CloudSyncDeployment,
-			CloudSyncDriftStatus:       c.parsedArgs.Run.CloudSyncDriftStatus,
-			CloudSyncPreview:           c.parsedArgs.Run.CloudSyncPreview,
-			CloudSyncTerraformPlanFile: c.parsedArgs.Run.CloudSyncTerraformPlanFile,
+		run := stackRun{
+			Stack: st.Stack,
+			Tasks: []stackRunTask{
+				{
+					Cmd:                        c.parsedArgs.Run.Command,
+					CloudSyncDeployment:        c.parsedArgs.Run.CloudSyncDeployment,
+					CloudSyncDriftStatus:       c.parsedArgs.Run.CloudSyncDriftStatus,
+					CloudSyncPreview:           c.parsedArgs.Run.CloudSyncPreview,
+					CloudSyncTerraformPlanFile: c.parsedArgs.Run.CloudSyncTerraformPlanFile,
+				},
+			},
 		}
 		if c.parsedArgs.Run.Eval {
-			run.Cmd, err = c.evalRunArgs(run.Stack, run.Cmd)
+			run.Tasks[0].Cmd, err = c.evalRunArgs(run.Stack, run.Tasks[0].Cmd)
 			if err != nil {
 				fatal("unable to evaluate command", err)
 			}
@@ -155,7 +160,10 @@ func (c *cli) runOnStacks() {
 	}
 
 	if c.parsedArgs.Run.CloudSyncDeployment {
-		c.createCloudDeployment(runs)
+		// This will just select all runs, since the CloudSyncDeployment was set just above.
+		// Still, it's convenient to re-use this function here.
+		deployRuns := selectCloudStackTasks(runs, isDeploymentTask)
+		c.createCloudDeployment(deployRuns)
 	}
 
 	if c.parsedArgs.Run.CloudSyncDriftStatus ||
@@ -166,26 +174,32 @@ func (c *cli) runOnStacks() {
 	}
 
 	if c.parsedArgs.Run.CloudSyncPreview && c.cloudEnabled() {
-		c.cloud.run.stackPreviews = c.createCloudPreview(runs)
+		// See comment above.
+		previewRuns := selectCloudStackTasks(runs, isPreviewTask)
+		c.cloud.run.stackPreviews = c.createCloudPreview(previewRuns)
 	}
 
 	err = c.runAll(runs, isSuccessExit, runAllOptions{
 		Quiet:           c.parsedArgs.Quiet,
 		DryRun:          c.parsedArgs.Run.DryRun,
+		Reverse:         c.parsedArgs.Run.Reverse,
 		ScriptRun:       false,
 		ContinueOnError: c.parsedArgs.Run.ContinueOnError,
+		Parallel:        c.parsedArgs.Run.Parallel.Value,
 	})
 	if err != nil {
 		fatal("one or more commands failed", err)
 	}
 }
 
-// RunAllOptions define named flags for RunAll
+// runAllOptions define named flags for runAll
 type runAllOptions struct {
 	Quiet           bool
 	DryRun          bool
+	Reverse         bool
 	ScriptRun       bool
 	ContinueOnError bool
+	Parallel        int
 }
 
 // runAll will execute the list of RunStack definitions. A RunStack defines the
@@ -200,11 +214,46 @@ type runAllOptions struct {
 // If SIGINT is sent 3x then Terramate will send a SIGKILL to the currently
 // running process and abort the execution of all subsequent stacks.
 func (c *cli) runAll(
-	runs []runContext,
+	runs []stackRun,
 	isSuccessCode func(exitCode int) bool,
 	opts runAllOptions,
 ) error {
-	errs := errors.L()
+	// Construct a DAG from the list of stackRuns, based on the implicit and
+	// explicit dependencies between stacks.
+	d, reason, err := runutil.BuildDAGFromStacks(c.cfg(), runs,
+		func(run stackRun) *config.Stack { return run.Stack })
+	if err != nil {
+		if errors.IsKind(err, dag.ErrCycleDetected) {
+			fatal(sprintf("cycle detected: %s", reason), err)
+		} else {
+			fatal("failed to plan execution", err)
+		}
+	}
+
+	// This context is used to cancel execution mid-progress and skip pending runs.
+	// It will not abort any already started runs.
+	cancelCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// This context is used to kill running processes.
+	killCtx, kill := context.WithCancel(context.Background())
+	defer kill()
+
+	// Select a scheduling strategy for the DAG nodes.
+	var sched scheduler.S[stackRun]
+	acquireResource := func() {}
+	releaseResource := func() {}
+
+	if opts.Parallel > 1 {
+		sched = scheduler.NewParallel(d, opts.Reverse)
+
+		rg := resource.NewBounded(opts.Parallel)
+		// Acquire can fail, but not with context.Background().
+		acquireResource = func() { _ = rg.Acquire(context.Background()) }
+		releaseResource = func() { rg.Release() }
+	} else {
+		sched = scheduler.NewSequential(d, opts.Reverse)
+	}
 
 	// we load/check the env of all stacks beforehand then no stack is executed
 	// if the environment is not correct for all of them.
@@ -218,99 +267,23 @@ func (c *cli) runAll(
 	signal.Notify(signals, os.Interrupt)
 	defer signal.Reset(os.Interrupt)
 
-	cmds := make(chan *exec.Cmd)
-	defer close(cmds)
-
 	continueOnError := opts.ContinueOnError
-	results := startCmdConsumer(cmds)
+
 	printPrefix := "terramate:"
 	if !opts.ScriptRun && opts.DryRun {
 		printPrefix = fmt.Sprintf("%s (dry-run)", printPrefix)
 	}
 
-	for i, run := range runs {
-		cmdStr := strings.Join(run.Cmd, " ")
-		logger := log.With().
-			Str("cmd", cmdStr).
-			Stringer("stack", run.Stack).
-			Logger()
-
-		if opts.ScriptRun {
-			printScriptCommand(c.stderr, run)
-		}
-
-		c.cloudSyncBefore(run)
-
-		environ := newEnvironFrom(stackEnvs[run.Stack.Dir])
-		cmdPath, err := runutil.LookPath(run.Cmd[0], environ)
-		if err != nil {
-			c.cloudSyncAfter(run, runResult{ExitCode: -1}, errors.E(ErrRunCommandNotFound, err))
-			errs.Append(errors.E(err, "running `%s` in stack %s", cmdStr, run.Stack.Dir))
-			if continueOnError {
-				continue
-			}
-			c.cloudSyncCancelStacks(runs[i+1:])
-			return errs.AsError()
-		}
-
-		if !opts.Quiet && !opts.ScriptRun {
-			printer.Stderr.Println(printPrefix + " Entering stack in " + run.Stack.String())
-			printer.Stderr.Println(printPrefix + " Executing command " + strconv.Quote(cmdStr))
-		}
-
-		if opts.DryRun {
-			continue
-		}
-
-		cmd := exec.Command(cmdPath, run.Cmd[1:]...)
-		cmd.Dir = run.Stack.HostDir(c.cfg())
-		cmd.Env = environ
-
-		stdout := c.stdout
-		stderr := c.stderr
-
-		logSyncWait := func() {}
-		if c.cloudEnabled() && (run.CloudSyncDeployment || run.CloudSyncPreview) {
-			logSyncer := cloud.NewLogSyncer(func(logs cloud.CommandLogs) {
-				c.syncLogs(&logger, run, logs)
-			})
-			stdout = logSyncer.NewBuffer(cloud.StdoutLogChannel, c.stdout)
-			stderr = logSyncer.NewBuffer(cloud.StderrLogChannel, c.stderr)
-
-			logSyncWait = logSyncer.Wait
-		}
-
-		cmd.Stdin = c.stdin
-		cmd.Stdout = stdout
-		cmd.Stderr = stderr
-
-		startTime := time.Now().UTC()
-
-		if err := cmd.Start(); err != nil {
-			endTime := time.Now().UTC()
-
-			logSyncWait()
-
-			res := runResult{
-				ExitCode:   -1,
-				StartedAt:  &startTime,
-				FinishedAt: &endTime,
-			}
-			c.cloudSyncAfter(run, res, errors.E(err, ErrRunFailed))
-			errs.Append(errors.E(err, "running %s (at stack %s)", cmd, run.Stack.Dir))
-			if continueOnError {
-				continue
-			}
-			c.cloudSyncCancelStacks(runs[i+1:])
-			return errs.AsError()
-		}
-
-		cmds <- cmd
+	go func() {
 		interruptions := 0
-		cmdIsRunning := true
 
-		for cmdIsRunning {
+		logger := log.With().Logger()
+
+		for {
 			select {
+			case <-killCtx.Done():
+				return
+
 			case sig := <-signals:
 				interruptions++
 
@@ -319,28 +292,138 @@ func (c *cli) runAll(
 					Int("interruptions", interruptions).
 					Msg("received interruption signal")
 
+				logger.Info().Msg("interrupting execution of further stacks")
+				cancel()
+
 				if interruptions >= 3 {
-					logger.Info().Msg("interrupted 3x times or more, killing child process")
-
-					if err := cmd.Process.Kill(); err != nil {
-						logger.Debug().Err(err).Msg("unable to send kill signal to child process")
-					}
-
-					endTime := time.Now().UTC()
-
-					logSyncWait()
-
-					res := runResult{
-						ExitCode:   -1,
-						StartedAt:  &startTime,
-						FinishedAt: &endTime,
-					}
-					c.cloudSyncAfter(run, res, errors.E(ErrRunCanceled))
-					c.cloudSyncCancelStacks(runs[i+1:])
-					return errors.E(ErrRunCanceled, "execution aborted by CTRL-C (3x)")
+					logger.Info().Msg("interrupted 3x times or more, killing child processes")
+					kill()
+					return
 				}
-			case result := <-results:
+			}
+		}
+	}()
+
+	err = sched.Run(func(run stackRun) error {
+		errs := errors.L()
+
+		for _, task := range run.Tasks {
+			// For cloud sync, we always assume that there's a single task per stack.
+			cloudRun := stackCloudRun{Stack: run.Stack, Task: task}
+
+			select {
+			case <-cancelCtx.Done():
+				c.cloudSyncAfter(cloudRun, runResult{ExitCode: -1}, errors.E(ErrRunCanceled))
+				continue
+			default:
+			}
+
+			cmdStr := strings.Join(task.Cmd, " ")
+			logger := log.With().
+				Str("cmd", cmdStr).
+				Stringer("stack", run.Stack).
+				Logger()
+
+			if opts.ScriptRun {
+				printScriptCommand(c.stderr, run.Stack, task)
+			}
+
+			c.cloudSyncBefore(cloudRun)
+
+			environ := newEnvironFrom(stackEnvs[run.Stack.Dir])
+			cmdPath, err := runutil.LookPath(task.Cmd[0], environ)
+			if err != nil {
+				c.cloudSyncAfter(cloudRun, runResult{ExitCode: -1}, errors.E(ErrRunCommandNotFound, err))
+				errs.Append(errors.E(err, "running `%s` in stack %s", cmdStr, run.Stack.Dir))
+				if continueOnError {
+					continue
+				}
+
+				cancel()
+				return errs.AsError()
+			}
+
+			if !opts.Quiet && !opts.ScriptRun {
+				printer.Stderr.Println(printPrefix + " Entering stack in " + run.Stack.String())
+				printer.Stderr.Println(printPrefix + " Executing command " + strconv.Quote(cmdStr))
+			}
+
+			if opts.DryRun {
+				continue
+			}
+
+			cmd := exec.Command(cmdPath, task.Cmd[1:]...)
+			cmd.Dir = run.Stack.HostDir(c.cfg())
+			cmd.Env = environ
+
+			stdout := c.stdout
+			stderr := c.stderr
+
+			logSyncWait := func() {}
+			if c.cloudEnabled() && (task.CloudSyncDeployment || task.CloudSyncPreview) {
+				logSyncer := cloud.NewLogSyncer(func(logs cloud.CommandLogs) {
+					c.syncLogs(&logger, run, logs)
+				})
+				stdout = logSyncer.NewBuffer(cloud.StdoutLogChannel, c.stdout)
+				stderr = logSyncer.NewBuffer(cloud.StderrLogChannel, c.stderr)
+
+				logSyncWait = logSyncer.Wait
+			}
+
+			cmd.Stdin = c.stdin
+			cmd.Stdout = stdout
+			cmd.Stderr = stderr
+
+			acquireResource()
+
+			startTime := time.Now().UTC()
+
+			if err := cmd.Start(); err != nil {
+				endTime := time.Now().UTC()
+
+				releaseResource()
 				logSyncWait()
+
+				res := runResult{
+					ExitCode:   -1,
+					StartedAt:  &startTime,
+					FinishedAt: &endTime,
+				}
+				c.cloudSyncAfter(cloudRun, res, errors.E(err, ErrRunFailed))
+				errs.Append(errors.E(err, "running %s (at stack %s)", cmd, run.Stack.Dir))
+				if continueOnError {
+					continue
+				}
+
+				cancel()
+				return errs.AsError()
+			}
+
+			resultc := makeResultChannel(cmd)
+
+			select {
+			case <-killCtx.Done():
+				if err := cmd.Process.Kill(); err != nil {
+					logger.Debug().Err(err).Msg("unable to send kill signal to child process")
+				}
+
+				endTime := time.Now().UTC()
+
+				releaseResource()
+				logSyncWait()
+
+				res := runResult{
+					ExitCode:   -1,
+					StartedAt:  &startTime,
+					FinishedAt: &endTime,
+				}
+				c.cloudSyncAfter(cloudRun, res, errors.E(ErrRunCanceled))
+				return errors.E(ErrRunCanceled, "execution aborted by CTRL-C (3x)")
+
+			case result := <-resultc:
+				releaseResource()
+				logSyncWait()
+
 				var err error
 				if !isSuccessCode(result.cmd.ProcessState.ExitCode()) {
 					err = errors.E(result.err, ErrRunFailed, "running %s (in %s)", result.cmd, run.Stack.Dir)
@@ -362,24 +445,25 @@ func (c *cli) runAll(
 				}
 				logMsg.Msg("command execution finished")
 
-				c.cloudSyncAfter(run, res, err)
-				cmdIsRunning = false
+				c.cloudSyncAfter(cloudRun, res, err)
+			}
+
+			err = errs.AsError()
+			if err != nil && !continueOnError {
+				logger.Info().Msg("interrupting execution of further stacks")
+
+				cancel()
+				return err
 			}
 		}
 
-		err = errs.AsError()
-		if interruptions > 0 || (err != nil && !continueOnError) {
-			logger.Info().Msg("interrupting execution of further stacks")
+		return errs.AsError()
+	})
 
-			c.cloudSyncCancelStacks(runs[i+1:])
-			return errs.AsError()
-		}
-	}
-
-	return errs.AsError()
+	return err
 }
 
-func (c *cli) syncLogs(logger *zerolog.Logger, run runContext, logs cloud.CommandLogs) {
+func (c *cli) syncLogs(logger *zerolog.Logger, run stackRun, logs cloud.CommandLogs) {
 	data, _ := json.Marshal(logs)
 	logger.Debug().RawJSON("logs", data).Msg("synchronizing logs")
 	ctx, cancel := context.WithTimeout(context.Background(), defaultCloudTimeout)
@@ -400,22 +484,20 @@ type cmdResult struct {
 	finishedAt *time.Time
 }
 
-func startCmdConsumer(cmds <-chan *exec.Cmd) <-chan cmdResult {
-	results := make(chan cmdResult)
+func makeResultChannel(cmd *exec.Cmd) <-chan cmdResult {
+	resultc := make(chan cmdResult)
 	go func() {
-		for cmd := range cmds {
-			err := cmd.Wait()
-			endTime := time.Now().UTC()
+		err := cmd.Wait()
+		endTime := time.Now().UTC()
 
-			results <- cmdResult{
-				cmd:        cmd,
-				err:        err,
-				finishedAt: &endTime,
-			}
+		resultc <- cmdResult{
+			cmd:        cmd,
+			err:        err,
+			finishedAt: &endTime,
 		}
-		close(results)
+		close(resultc)
 	}()
-	return results
+	return resultc
 }
 
 func newEnvironFrom(stackEnviron []string) []string {
@@ -425,7 +507,7 @@ func newEnvironFrom(stackEnviron []string) []string {
 	return environ
 }
 
-func (c *cli) loadAllStackEnvs(runs []runContext) (map[prj.Path]runutil.EnvVars, error) {
+func (c *cli) loadAllStackEnvs(runs []stackRun) (map[prj.Path]runutil.EnvVars, error) {
 	errs := errors.L()
 	stackEnvs := map[prj.Path]runutil.EnvVars{}
 	for _, run := range runs {
@@ -440,12 +522,12 @@ func (c *cli) loadAllStackEnvs(runs []runContext) (map[prj.Path]runutil.EnvVars,
 	return stackEnvs, nil
 }
 
-func (c *cli) createCloudPreview(runs []runContext) map[string]string {
+func (c *cli) createCloudPreview(runs []stackCloudRun) map[string]string {
 	previewRuns := make([]cloud.RunContext, len(runs))
 	for i, run := range runs {
 		previewRuns[i] = cloud.RunContext{
 			Stack: run.Stack,
-			Cmd:   run.Cmd,
+			Cmd:   run.Task.Cmd,
 		}
 	}
 

--- a/cmd/terramate/e2etests/cloud/run_cloud_signal_test.go
+++ b/cmd/terramate/e2etests/cloud/run_cloud_signal_test.go
@@ -56,7 +56,7 @@ func TestCLIRunWithCloudSyncDeploymentWithSignals(t *testing.T) {
 		},
 		{
 			name:    "canceled subsequent stacks",
-			layout:  []string{"s:s1", "s:s2"},
+			layout:  []string{"s:s1", "s:s1/s2"},
 			runMode: SleepRun,
 			want: want{
 				run: RunExpected{
@@ -65,62 +65,76 @@ func TestCLIRunWithCloudSyncDeploymentWithSignals(t *testing.T) {
 					IgnoreStderr: true,
 				},
 				events: eventsResponse{
-					"s1": []string{"pending", "running", "failed"},
-					"s2": []string{"pending", "canceled"},
+					"s1":    []string{"pending", "running", "failed"},
+					"s1/s2": []string{"pending", "canceled"},
 				},
 			},
 		},
 	} {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
 
-			cloudData, err := cloudstore.LoadDatastore(testserverJSONFile)
-			assert.NoError(t, err)
-			addr := startFakeTMCServer(t, cloudData)
-
-			s := sandbox.New(t)
-			var genIdsLayout []string
-			ids := []string{}
-			if !tc.skipIDGen {
-				for _, layout := range tc.layout {
-					if layout[0] == 's' {
-						if strings.Contains(layout, "id=") {
-							t.Fatalf("testcases should not contain stack IDs but found %s", layout)
-						}
-						id := strings.ToLower(strings.Replace(layout[2:]+"-id-"+t.Name(), "/", "-", -1))
-						if len(id) > 64 {
-							id = id[:64]
-						}
-						ids = append(ids, id)
-						layout += ":id=" + id
-					}
-					genIdsLayout = append(genIdsLayout, layout)
-				}
-			} else {
-				genIdsLayout = tc.layout
+		for _, isParallel := range []bool{false, true} {
+			tc := tc
+			isParallel := isParallel
+			name := tc.name
+			if isParallel {
+				name += "-parallel"
 			}
 
-			s.BuildTree(genIdsLayout)
-			s.Git().CommitAll("all stacks committed")
-			env := RemoveEnv(os.Environ(), "CI")
-			env = append(env, "TMC_API_URL=http://"+addr)
+			t.Run(name, func(t *testing.T) {
+				t.Parallel()
 
-			cli := NewCLI(t, filepath.Join(s.RootDir(), filepath.FromSlash(tc.workingDir)), env...)
-			uuid, err := uuid.NewRandom()
-			assert.NoError(t, err)
-			runid := uuid.String()
-			cli.AppendEnv = []string{"TM_TEST_RUN_ID=" + runid}
+				cloudData, err := cloudstore.LoadDatastore(testserverJSONFile)
+				assert.NoError(t, err)
+				addr := startFakeTMCServer(t, cloudData)
 
-			runflags := []string{"--cloud-sync-deployment"}
-			runflags = append(runflags, tc.runflags...)
+				s := sandbox.New(t)
+				var genIdsLayout []string
+				ids := []string{}
+				if !tc.skipIDGen {
+					for _, layout := range tc.layout {
+						if layout[0] == 's' {
+							if strings.Contains(layout, "id=") {
+								t.Fatalf("testcases should not contain stack IDs but found %s", layout)
+							}
+							id := strings.ToLower(strings.Replace(layout[2:]+"-id-"+t.Name(), "/", "-", -1))
+							if len(id) > 64 {
+								id = id[:64]
+							}
+							ids = append(ids, id)
+							layout += ":id=" + id
+						}
+						genIdsLayout = append(genIdsLayout, layout)
+					}
+				} else {
+					genIdsLayout = tc.layout
+				}
 
-			fixture := cli.NewRunFixture(tc.runMode, s.RootDir(), runflags...)
-			fixture.Command = tc.cmd // if empty, uses the runFixture default cmd.
-			result := fixture.Run()
-			AssertRunResult(t, result, tc.want.run)
-			assertRunEvents(t, cloudData, runid, ids, tc.want.events)
-		})
+				s.BuildTree(genIdsLayout)
+				s.Git().CommitAll("all stacks committed")
+				env := RemoveEnv(os.Environ(), "CI")
+				env = append(env, "TMC_API_URL=http://"+addr)
+
+				cli := NewCLI(t, filepath.Join(s.RootDir(), filepath.FromSlash(tc.workingDir)), env...)
+				uuid, err := uuid.NewRandom()
+				assert.NoError(t, err)
+				runid := uuid.String()
+				cli.AppendEnv = []string{"TM_TEST_RUN_ID=" + runid}
+
+				runflags := []string{"--cloud-sync-deployment"}
+				if isParallel {
+					runflags = append(runflags, "--parallel")
+					tc.want.run.IgnoreStdout = true
+					tc.want.run.IgnoreStderr = true
+				}
+				runflags = append(runflags, tc.runflags...)
+
+				fixture := cli.NewRunFixture(tc.runMode, s.RootDir(), runflags...)
+				fixture.Command = tc.cmd // if empty, uses the runFixture default cmd.
+				result := fixture.Run()
+				AssertRunResult(t, result, tc.want.run)
+				assertRunEvents(t, cloudData, runid, ids, tc.want.events)
+			})
+		}
 	}
 }
 
@@ -155,7 +169,7 @@ func TestCLIRunWithCloudSyncDriftStatusWithSignals(t *testing.T) {
 		},
 		{
 			name:    "skipped subsequent stacks",
-			layout:  []string{"s:s1:id=s1", "s:s2:id=s2"},
+			layout:  []string{"s:s1:id=s1", "s:s1/s2:id=s2"},
 			runMode: SleepRun,
 			want: want{
 				run: RunExpected{
@@ -180,31 +194,43 @@ func TestCLIRunWithCloudSyncDriftStatusWithSignals(t *testing.T) {
 			},
 		},
 	} {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
-			cloudData, err := cloudstore.LoadDatastore(testserverJSONFile)
-			assert.NoError(t, err)
-			addr := startFakeTMCServer(t, cloudData)
+		for _, isParallel := range []bool{false, true} {
+			tc := tc
+			isParallel := isParallel
+			name := tc.name
+			if isParallel {
+				name += "-parallel"
+			}
+			t.Run(name, func(t *testing.T) {
+				cloudData, err := cloudstore.LoadDatastore(testserverJSONFile)
+				assert.NoError(t, err)
+				addr := startFakeTMCServer(t, cloudData)
 
-			s := sandbox.New(t)
+				s := sandbox.New(t)
 
-			s.BuildTree(tc.layout)
-			s.Git().CommitAll("all stacks committed")
+				s.BuildTree(tc.layout)
+				s.Git().CommitAll("all stacks committed")
 
-			env := RemoveEnv(os.Environ(), "CI")
-			env = append(env, "TMC_API_URL=http://"+addr)
+				env := RemoveEnv(os.Environ(), "CI")
+				env = append(env, "TMC_API_URL=http://"+addr)
 
-			cli := NewCLI(t, filepath.Join(s.RootDir(), filepath.FromSlash(tc.workingDir)), env...)
-			runflags := []string{"--cloud-sync-drift-status"}
-			runflags = append(runflags, tc.runflags...)
+				cli := NewCLI(t, filepath.Join(s.RootDir(), filepath.FromSlash(tc.workingDir)), env...)
+				runflags := []string{"--cloud-sync-drift-status"}
+				if isParallel {
+					runflags = append(runflags, "--parallel")
+					tc.want.run.IgnoreStdout = true
+					tc.want.run.IgnoreStderr = true
+				}
+				runflags = append(runflags, tc.runflags...)
 
-			fixture := cli.NewRunFixture(tc.runMode, s.RootDir(), runflags...)
-			fixture.Command = tc.cmd // if empty, uses the runFixture default cmd.
-			minStartTime := time.Now().UTC()
-			result := fixture.Run()
-			maxEndTime := time.Now().UTC()
-			AssertRunResult(t, result, tc.want.run)
-			assertRunDrifts(t, cloudData, addr, tc.want.drifts, minStartTime, maxEndTime)
-		})
+				fixture := cli.NewRunFixture(tc.runMode, s.RootDir(), runflags...)
+				fixture.Command = tc.cmd // if empty, uses the runFixture default cmd.
+				minStartTime := time.Now().UTC()
+				result := fixture.Run()
+				maxEndTime := time.Now().UTC()
+				AssertRunResult(t, result, tc.want.run)
+				assertRunDrifts(t, cloudData, addr, tc.want.drifts, minStartTime, maxEndTime)
+			})
+		}
 	}
 }

--- a/cmd/terramate/e2etests/core/run_parallel_test.go
+++ b/cmd/terramate/e2etests/core/run_parallel_test.go
@@ -1,0 +1,72 @@
+// Copyright 2023 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+package core_test
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/madlambda/spells/assert"
+	. "github.com/terramate-io/terramate/cmd/terramate/e2etests/internal/runner"
+
+	"github.com/terramate-io/terramate/test/sandbox"
+)
+
+func TestParallelFibonacci(t *testing.T) {
+	t.Parallel()
+
+	type testcase struct {
+		Name      string
+		FibN      int
+		WantValue int
+	}
+
+	for _, tc := range []testcase{
+		{
+			Name:      "fib(7)",
+			FibN:      7,
+			WantValue: 13,
+		},
+	} {
+		t.Run(tc.Name, func(t *testing.T) {
+			layout := makeFibLayout(tc.FibN)
+
+			s := sandbox.NoGit(t, true)
+			s.BuildTree(layout)
+
+			tmcli := NewCLI(t, s.RootDir())
+
+			res := tmcli.Run("run", "--quiet", "--parallel", "--", HelperPath, "fibonacci")
+			AssertRunResult(t, res, RunExpected{})
+
+			b, err := os.ReadFile(s.RootDir() + fmt.Sprintf("/fib.%v/fib.txt", tc.FibN))
+			assert.NoError(t, err)
+			got, err := strconv.ParseInt(string(b), 10, 64)
+			assert.NoError(t, err)
+
+			assert.EqualInts(t, tc.WantValue, int(got))
+		})
+	}
+}
+
+func makeFibLayout(n int) []string {
+	mkStack := func(i int) string {
+		if i == 0 {
+			return `s:fib.0`
+		} else if i == 1 {
+			return `s:fib.1`
+		} else {
+			return fmt.Sprintf(`s:fib.%v:after=["../fib.%v", "../fib.%v"]`, i, i-1, i-2)
+		}
+	}
+
+	layout := make([]string, n+1)
+	for i := 0; i <= n; i++ {
+		layout[i] = mkStack(i)
+	}
+
+	return layout
+}

--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	go.lsp.dev/protocol v0.12.0
 	go.lsp.dev/uri v0.3.0
 	golang.org/x/exp v0.0.0-20231110203233-9a3e6036ecaa
+	golang.org/x/sync v0.4.0
 )
 
 require (
@@ -137,7 +138,6 @@ require (
 	go.uber.org/zap v1.21.0 // indirect
 	golang.org/x/mod v0.14.0 // indirect
 	golang.org/x/oauth2 v0.13.0 // indirect
-	golang.org/x/sync v0.4.0 // indirect
 	golang.org/x/term v0.15.0 // indirect
 	golang.org/x/time v0.0.0-20220224211638-0e9765cccd65 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect

--- a/scheduler/doc.go
+++ b/scheduler/doc.go
@@ -1,0 +1,6 @@
+// Copyright 2023 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+// Package scheduler defines schedulers to execute functions on DAGs based on a
+// specific scheduling strategy.
+package scheduler

--- a/scheduler/parallel.go
+++ b/scheduler/parallel.go
@@ -1,0 +1,113 @@
+// Copyright 2023 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+package scheduler
+
+import (
+	"sync"
+	"sync/atomic"
+
+	"github.com/terramate-io/terramate/errors"
+	"github.com/terramate-io/terramate/run/dag"
+)
+
+// Parallel is a parallel scheduler implementing the scheduler.S interface.
+type Parallel[V any] struct {
+	wg *sync.WaitGroup
+	d  *dag.DAG[V]
+
+	state map[dag.ID]*parallelNodeState
+
+	errsMtx sync.Mutex
+	errs    errors.List
+}
+
+// NewParallel creates a new parallel scheduler for the given DAG.
+func NewParallel[V any](d *dag.DAG[V], reverse bool) *Parallel[V] {
+	s := &Parallel[V]{
+		wg:    &sync.WaitGroup{},
+		d:     d,
+		state: map[dag.ID]*parallelNodeState{},
+	}
+
+	ids := d.IDs()
+
+	// Pass 1 - Create node state
+	for _, id := range ids {
+		s.state[id] = &parallelNodeState{id: id}
+	}
+
+	// Pass 2 - Add forward edges
+	if !reverse {
+		for id, st := range s.state {
+			for _, pid := range d.AncestorsOf(id) {
+				pst := s.state[pid]
+				pst.successors = append(pst.successors, st)
+				st.nRequiredPredecessors++
+			}
+		}
+	} else {
+		for id, st := range s.state {
+			for _, pid := range d.AncestorsOf(id) {
+				pst := s.state[pid]
+				st.successors = append(st.successors, pst)
+				pst.nRequiredPredecessors++
+			}
+		}
+	}
+
+	return s
+}
+
+// Run executes the given function on each node of the DAG.
+// Nodes are run in parallel, but no node is visted until all its precessors are done.
+func (s *Parallel[V]) Run(f Func[V]) error {
+	for _, st := range s.state {
+		// Start at root nodes (nodes without any predecessors).
+		if st.nRequiredPredecessors == 0 {
+			s.visitNode(st, f)
+		}
+	}
+
+	s.wg.Wait()
+	return s.errs.AsError()
+}
+
+type parallelNodeState struct {
+	id                    dag.ID
+	successors            []*parallelNodeState
+	nReadyPredecessors    atomic.Int64
+	nRequiredPredecessors int64
+}
+
+func (s *Parallel[V]) visitNode(st *parallelNodeState, f Func[V]) {
+	s.forkTask(func() {
+		v, _ := s.d.Node(st.id)
+
+		if err := f(v); err != nil {
+			// We collect the errors, but continue. It's up to the caller to cancel the context and skip
+			// the function body.
+			s.errsMtx.Lock()
+			defer s.errsMtx.Unlock()
+			s.errs.Append(err)
+		}
+
+		st.nReadyPredecessors.Store(0)
+
+		for _, succ := range st.successors {
+			// Join paths
+			c := succ.nReadyPredecessors.Add(1)
+			if c >= succ.nRequiredPredecessors {
+				s.visitNode(succ, f)
+			}
+		}
+	})
+}
+
+func (s *Parallel[V]) forkTask(body func()) {
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+		body()
+	}()
+}

--- a/scheduler/resource/bounded.go
+++ b/scheduler/resource/bounded.go
@@ -1,0 +1,34 @@
+// Copyright 2023 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+package resource
+
+import (
+	"context"
+
+	"golang.org/x/sync/semaphore"
+)
+
+// Bounded is a bounded resource.
+type Bounded struct {
+	sem *semaphore.Weighted
+}
+
+// NewBounded creates a new bounded resource that can be acquired n times concurrently.
+func NewBounded(n int) *Bounded {
+	return &Bounded{
+		sem: semaphore.NewWeighted(int64(n)),
+	}
+}
+
+// Acquire acquires the resource. If the resource is already acquired n times,
+// wait until another one is released.
+func (r *Bounded) Acquire(ctx context.Context) bool {
+	err := r.sem.Acquire(ctx, 1)
+	return err == nil
+}
+
+// Release a previously acquired resource.
+func (r *Bounded) Release() {
+	r.sem.Release(1)
+}

--- a/scheduler/resource/doc.go
+++ b/scheduler/resource/doc.go
@@ -1,0 +1,5 @@
+// Copyright 2023 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+// Package resource defines different concurrent access strategies for resources.
+package resource

--- a/scheduler/resource/resource.go
+++ b/scheduler/resource/resource.go
@@ -1,0 +1,12 @@
+// Copyright 2023 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+package resource
+
+import "context"
+
+// R is the resource interface.
+type R interface {
+	Acquire(ctx context.Context) bool
+	Release()
+}

--- a/scheduler/resource/throttled.go
+++ b/scheduler/resource/throttled.go
@@ -1,0 +1,37 @@
+// Copyright 2023 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+package resource
+
+import (
+	"context"
+	"time"
+)
+
+// Throttled in a rate-limited resource.
+type Throttled struct {
+	ticker *time.Ticker
+}
+
+// NewThrottled creates a resource with the given rate limit.
+func NewThrottled(requestsPerSecond int64) *Throttled {
+	interval := time.Duration(1.0/float64(requestsPerSecond)*1000.0) * time.Millisecond
+	return &Throttled{
+		ticker: time.NewTicker(interval),
+	}
+}
+
+// Acquire can be called concurrently, and blocks callers so that are let through as
+// the rate limit requires.
+func (r *Throttled) Acquire(ctx context.Context) bool {
+	select {
+	case <-ctx.Done():
+		return false
+	case <-r.ticker.C:
+		return true
+	}
+}
+
+// Release for this resource type is no-op.
+func (*Throttled) Release() {
+}

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -1,0 +1,13 @@
+// Copyright 2023 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+package scheduler
+
+// Func is the function type called when visiting nodes of the DAG.
+type Func[V any] func(V) error
+
+// S is the scheduler interface.
+type S[V any] interface {
+	// Run executes a given function by a specific scheduling strategy.
+	Run(Func[V]) error
+}

--- a/scheduler/scheduler_test.go
+++ b/scheduler/scheduler_test.go
@@ -1,0 +1,167 @@
+// Copyright 2023 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+package scheduler_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/madlambda/spells/assert"
+	"github.com/terramate-io/terramate/run/dag"
+	"github.com/terramate-io/terramate/scheduler"
+	"github.com/terramate-io/terramate/scheduler/resource"
+)
+
+func TestSimpleSequential(t *testing.T) {
+	t.Parallel()
+
+	r := resource.NewBounded(5)
+	g := scheduler.NewSequential(makeDAG(), false)
+	ctx := context.Background()
+
+	err := g.Run(func(s string) error {
+		r.Acquire(ctx)
+		defer r.Release()
+		fmt.Println(s)
+		return nil
+	})
+	assert.NoError(t, err)
+}
+
+func TestSimpleParallel(t *testing.T) {
+	t.Parallel()
+
+	r := resource.NewBounded(1)
+	g := scheduler.NewParallel(makeDAG(), false)
+	ctx := context.Background()
+
+	err := g.Run(func(s string) error {
+		r.Acquire(ctx)
+		defer r.Release()
+		fmt.Println(s)
+		return nil
+	})
+	assert.NoError(t, err)
+}
+
+func makeDAG() *dag.DAG[string] {
+	d := dag.New[string]()
+
+	addNode := func(s string, preds []dag.ID) {
+		_ = d.AddNode(
+			dag.ID(s),
+			s,
+			nil,
+			preds,
+		)
+	}
+
+	addNode("z", []dag.ID{"a", "b", "c"})
+	addNode("a", nil)
+	addNode("a/1", []dag.ID{"a"})
+	addNode("a/2", []dag.ID{"a", "a/1"})
+	addNode("a/3", []dag.ID{"a", "a/2"})
+	addNode("b", nil)
+	addNode("b/1", []dag.ID{"b"})
+	addNode("b/2", []dag.ID{"b"})
+	addNode("b/3", []dag.ID{"b"})
+	addNode("c", nil)
+	return d
+}
+
+type gridNode struct {
+	idx  int
+	aIdx int
+	bIdx int
+}
+
+// makeGridDAG builds a DAG for an NxN matrix where A[i][j] has predecessors A[i-1][j] A[i][j-1],
+// unless the respective indices are out of bounds (i.e. for first row and column).
+func makeGridDAG() *dag.DAG[gridNode] {
+	d := dag.New[gridNode]()
+
+	addNode := func(s string, nd gridNode, preds []dag.ID) {
+		_ = d.AddNode(dag.ID(s), nd, nil, preds)
+	}
+
+	for i := 0; i < 10; i++ {
+		for j := 0; j < 10; j++ {
+			var preds []dag.ID
+			id := fmt.Sprintf("%v.%v", i, j)
+			nd := gridNode{idx: i*10 + j}
+
+			if i > 0 {
+				preds = append(preds, dag.ID(fmt.Sprintf("%v.%v", i-1, j)))
+				nd.aIdx = (i-1)*10 + j
+			}
+
+			if j > 0 {
+				preds = append(preds, dag.ID(fmt.Sprintf("%v.%v", i, j-1)))
+				nd.bIdx = i*10 + (j - 1)
+			}
+
+			addNode(id, nd, preds)
+		}
+
+	}
+
+	return d
+}
+
+func TestSequentialGrid(t *testing.T) {
+	t.Parallel()
+
+	d := makeGridDAG()
+	ndarr := make([]int, 10*10)
+
+	g := scheduler.NewSequential(d, false)
+
+	err := g.Run(func(nd gridNode) error {
+		v := 1
+
+		if nd.aIdx != -1 {
+			v += ndarr[nd.aIdx]
+		}
+
+		if nd.bIdx != -1 {
+			v += ndarr[nd.bIdx]
+		}
+
+		ndarr[nd.idx] = v
+		return nil
+	})
+
+	assert.NoError(t, err)
+	assert.EqualInts(t, 272271, ndarr[99], "invalid result")
+}
+
+func TestParallelGrid(t *testing.T) {
+	t.Parallel()
+
+	d := makeGridDAG()
+	ndarr := make([]int, 10*10)
+
+	g := scheduler.NewParallel(d, false)
+
+	err := g.Run(func(nd gridNode) error {
+		v := 1
+
+		if nd.aIdx != -1 {
+			v += ndarr[nd.aIdx]
+		}
+
+		if nd.bIdx != -1 {
+			v += ndarr[nd.bIdx]
+		}
+
+		ndarr[nd.idx] = v
+		return nil
+	})
+
+	// We have a DAG with lots of ordering constraints, then we incrementally compute values that depend on already
+	// computed predecessor values. If the parallel processing violates order, we will end up with a wrong result.
+	assert.NoError(t, err)
+	assert.EqualInts(t, 272271, ndarr[99], "invalid result")
+}

--- a/scheduler/sequential.go
+++ b/scheduler/sequential.go
@@ -1,0 +1,40 @@
+// Copyright 2023 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+package scheduler
+
+import (
+	"slices"
+
+	"github.com/terramate-io/terramate/errors"
+	"github.com/terramate-io/terramate/run/dag"
+)
+
+// Sequential is a sequential scheduler implementing the scheduler.S interface.
+type Sequential[V any] struct {
+	d       *dag.DAG[V]
+	reverse bool
+}
+
+// NewSequential creates a new sequential scheduler for the given DAG.
+func NewSequential[V any](d *dag.DAG[V], reverse bool) *Sequential[V] {
+	return &Sequential[V]{d: d, reverse: reverse}
+}
+
+// Run executes the given function on each node of the DAG.
+// Nodes are run sequentially by their topological order.
+func (s *Sequential[V]) Run(f Func[V]) error {
+	errs := errors.L()
+
+	order := s.d.Order()
+	if s.reverse {
+		slices.Reverse(order)
+	}
+
+	for _, id := range order {
+		v, _ := s.d.Node(id)
+		errs.Append(f(v))
+	}
+
+	return errs.AsError()
+}

--- a/stack/manager.go
+++ b/stack/manager.go
@@ -289,7 +289,7 @@ rangeStacks:
 
 // AddWantedOf returns all wanted stacks from the given stacks.
 func (m *Manager) AddWantedOf(scopeStacks config.List[*config.SortableStack]) (config.List[*config.SortableStack], error) {
-	wantsDag := dag.New()
+	wantsDag := dag.New[*config.Stack]()
 	allstacks, err := config.LoadAllStacks(m.root.Tree())
 	if err != nil {
 		return nil, errors.E(err, "loading all stacks")
@@ -347,8 +347,7 @@ func (m *Manager) AddWantedOf(scopeStacks config.List[*config.SortableStack]) (c
 
 	for len(pending) > 0 {
 		id := pending[0]
-		node, _ := wantsDag.Node(id)
-		s := node.(*config.Stack)
+		s, _ := wantsDag.Node(id)
 
 		addStack(s)
 		pending = pending[1:]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/terramate-io/terramate/blob/main/CONTRIBUTING.md
2. If the PR is unfinished, mark it as draft: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request
3. Please update the PR title using the Conventional Commits convention: https://www.conventionalcommits.org/en/v1.0.0/
    Example: feat: add support for XYZ.
-->

## What this PR does / why we need it:
This PR adds a new option flag `--parallel` (short `-j`) to `terramate run / script run` to run independent stacks in parallel. Ordering constraints (parent/child folders, `before`/`after`) are still respected.
The number of concurrent runs can be set explicitly with `--parallel=N`. By default, N=5.
There is no grouping of command output for parallel runs, so output lines may be printed interleaved.

The goal of this is to speed up running multiple stacks.

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Keep it empty if not applicable.
-->

## Special notes for your reviewer:
* To adapt some tests to work with `--parallel`, explicit ordering has been added between stacks. In some cases, the layout string was modified later, so adding `after=[...]` did not always work. For this reason, if there's a required order between s1 and s2, I moved s2 to s1/s2.
* The `resource.Throttled` type is not used by anything yet, I added it just as a proof-of-concept.

## Does this PR introduce a user-facing change?
<!--
If no, just write "no" in the block below.
If yes, please explain the change and update documentation and the CHANGELOG.md file accordingly.
-->
```
Yes, a new flag is added to run and script run.
```
