### PR TITLE
feat: add terramate create --all-terragrunt.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 - Add support for formatting specific files and stdin (`terramate fmt [file...]` or `terramate fmt -`).
 - Add `--cloud-status=status` flag to both `terramate run` and `terramate script run`.
 - Add `--cloud-sync-preview` flag to `terramate run` to sync the preview to Terramate Cloud.
+- Improve user experience when using Terramate with existing Terragrunt projects.
+  - Add  `terramate create --all-terragrunt` option, which will automatically create Terramate stacks for each Terraform module.
 - Allow to run independent stacks in parallel for faster deployments and better utilization of system resources in general.
   - Add `--parallel` (short `-j`) option to `terramate run` and `terramate script run`.
   - `--parallel=N` limits the number of concurrent runs to `N`, otherwise a sensible default limit is chosen.

--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -38,6 +38,7 @@ import (
 	"github.com/terramate-io/terramate/modvendor/download"
 	"github.com/terramate-io/terramate/printer"
 	"github.com/terramate-io/terramate/safeguard"
+	"github.com/terramate-io/terramate/tg"
 	"github.com/terramate-io/terramate/versions"
 
 	"github.com/terramate-io/terramate/stack/trigger"
@@ -136,6 +137,7 @@ type cliSpec struct {
 		Before         []string `help:"Add a stack as before"`
 		IgnoreExisting bool     `help:"If the stack already exists do nothing and don't fail"`
 		AllTerraform   bool     `help:"initialize all Terraform directories containing terraform.backend blocks defined"`
+		AllTerragrunt  bool     `help:"initialize all Terragrunt modules"`
 		EnsureStackIds bool     `help:"generate an UUID for the stack.id of all stacks which does not define it"`
 		NoGenerate     bool     `help:"Disable code generation for the newly created stacks"`
 	} `cmd:"" help:"Creates a stack on the project"`
@@ -1207,22 +1209,35 @@ func (c *cli) listStacks(isChanged bool, status cloudstack.FilterStatus) (*stack
 }
 
 func (c *cli) scanCreate() {
-	if c.parsedArgs.Create.EnsureStackIds && c.parsedArgs.Create.AllTerraform {
-		fatal("Invalid args", errors.E("--all-terraform conflicts with --ensure-stack-ids"))
+	scanFlags := 0
+	if c.parsedArgs.Create.AllTerraform {
+		scanFlags++
+	}
+	if c.parsedArgs.Create.AllTerragrunt {
+		scanFlags++
+	}
+	if c.parsedArgs.Create.EnsureStackIds {
+		scanFlags++
 	}
 
-	if !c.parsedArgs.Create.AllTerraform && !c.parsedArgs.Create.EnsureStackIds {
-		fatal(
-			"Invalid args",
-			errors.E("terramate create requires a path or --all-terraform or --ensure-stack-ids"),
-		)
+	if scanFlags == 0 {
+		fatal("Missing args", errors.E("path argument or one of --all-terraform, --all-terragrunt, --ensure-stack-ids must be provided"))
+	}
+
+	if scanFlags > 1 {
+		fatal("Invalid args", errors.E("only one of --all-terraform, --all-terragrunt, --ensure-stack-ids can be provided"))
 	}
 
 	var flagname string
-	if c.parsedArgs.Create.EnsureStackIds {
+	switch {
+	case c.parsedArgs.Create.EnsureStackIds:
 		flagname = "--ensure-stack-ids"
-	} else {
+	case c.parsedArgs.Create.AllTerraform:
 		flagname = "--all-terraform"
+	case c.parsedArgs.Create.AllTerragrunt:
+		flagname = "--all-terragrunt"
+	default:
+		panic(errors.E(errors.ErrInternal, "bug: no flag set"))
 	}
 
 	if c.parsedArgs.Create.ID != "" ||
@@ -1250,16 +1265,56 @@ func (c *cli) scanCreate() {
 		)
 	}
 
-	if c.parsedArgs.Create.AllTerraform {
+	switch flagname {
+	case "--all-terraform":
 		c.initTerraform()
-		return
+	case "--all-terragrunt":
+		c.initTerragrunt()
+	case "--ensure-stack-ids":
+		c.ensureStackID()
+	}
+}
+
+func (c *cli) initTerragrunt() {
+	modules, err := tg.ScanModules(c.rootdir(), prj.PrjAbsPath(c.rootdir(), c.wd()))
+	if err != nil {
+		fatal("scanning for Terragrunt modules", err)
+	}
+	errs := errors.L()
+	for _, mod := range modules {
+		tree, found := c.prj.root.Lookup(mod.Path)
+		if found && tree.IsStack() {
+			continue
+		}
+
+		stackID, err := uuid.NewRandom()
+		dirBasename := filepath.Base(mod.Path.String())
+		if err != nil {
+			fatal("creating stack UUID", err)
+		}
+		stackSpec := config.Stack{
+			Dir:         mod.Path,
+			ID:          stackID.String(),
+			Name:        dirBasename,
+			Description: dirBasename,
+		}
+
+		err = stack.Create(c.cfg(), stackSpec)
+		if err != nil {
+			errs.Append(err)
+			continue
+		}
+
+		printer.Stdout.Println(sprintf("Created stack %s", stackSpec.Dir))
 	}
 
-	c.ensureStackID()
+	if err := errs.AsError(); err != nil {
+		fatal("failed to initialize Terragrunt modules", err)
+	}
 }
 
 func (c *cli) initTerraform() {
-	err := c.initDir(c.wd())
+	err := c.initTerraformDir(c.wd())
 	if err != nil {
 		fatal("failed to initialize some directories", err)
 	}
@@ -1294,7 +1349,7 @@ func (c *cli) initTerraform() {
 	c.output.MsgStdOutV(vendorReport.String())
 }
 
-func (c *cli) initDir(baseDir string) error {
+func (c *cli) initTerraformDir(baseDir string) error {
 	pdir := prj.PrjAbsPath(c.rootdir(), baseDir)
 	var isStack bool
 	tree, found := c.prj.root.Lookup(pdir)
@@ -1315,7 +1370,7 @@ func (c *cli) initDir(baseDir string) error {
 		}
 
 		if f.IsDir() {
-			errs.Append(c.initDir(path))
+			errs.Append(c.initTerraformDir(path))
 			continue
 		}
 
@@ -1355,7 +1410,6 @@ func (c *cli) initDir(baseDir string) error {
 			continue
 		}
 
-		log.Info().Msgf("created stack %s", stackSpec.Dir)
 		c.output.MsgStdOut("Created stack %s", stackSpec.Dir)
 
 		// so other files in the same directory do not trigger stack creation.
@@ -1365,7 +1419,7 @@ func (c *cli) initDir(baseDir string) error {
 }
 
 func (c *cli) createStack() {
-	if c.parsedArgs.Create.AllTerraform || c.parsedArgs.Create.EnsureStackIds {
+	if c.parsedArgs.Create.AllTerraform || c.parsedArgs.Create.EnsureStackIds || c.parsedArgs.Create.AllTerragrunt {
 		c.scanCreate()
 		return
 	}

--- a/cmd/terramate/e2etests/core/create_all_terraform_test.go
+++ b/cmd/terramate/e2etests/core/create_all_terraform_test.go
@@ -1,0 +1,155 @@
+// Copyright 2024 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+package core_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/madlambda/spells/assert"
+	. "github.com/terramate-io/terramate/cmd/terramate/e2etests/internal/runner"
+	"github.com/terramate-io/terramate/stack"
+	errtest "github.com/terramate-io/terramate/test/errors"
+	. "github.com/terramate-io/terramate/test/hclwrite/hclutils"
+	"github.com/terramate-io/terramate/test/sandbox"
+)
+
+func TestCreateWithAllTerraformModuleAtRoot(t *testing.T) {
+	s := sandbox.NoGit(t, true)
+	tfBlock := Block("terraform",
+		Block("backend",
+			Labels("remote"),
+			Str("attr", "value"),
+		),
+	)
+	s.BuildTree([]string{
+		`f:main.tf:` + tfBlock.String(),
+		`f:README.md:# My module`,
+	})
+	tm := NewCLI(t, s.RootDir())
+	AssertRunResult(t,
+		tm.Run("create", "--all-terraform"),
+		RunExpected{
+			Stdout: "Created stack /\n",
+		},
+	)
+	_, err := os.Lstat(filepath.Join(s.RootDir(), stack.DefaultFilename))
+	assert.NoError(t, err)
+}
+
+func TestCreateWithAllTerraformModuleDeepDownInTheTree(t *testing.T) {
+	test := func(t *testing.T, generate bool) {
+		s := sandbox.NoGit(t, true)
+		backendBlock := Block("terraform",
+			Block("backend",
+				Labels("remote"),
+				Str("attr", "value"),
+			))
+
+		providerBlock := Block("provider",
+			Labels("aws"),
+			Str("attr", "1"),
+		)
+
+		mixedBackendProvider := Doc(
+			backendBlock,
+			providerBlock,
+		)
+
+		s.BuildTree([]string{
+			`f:prod/stacks/k8s-stack/deployment.yml:# empty file`,
+			`f:prod/stacks/A/anyfile.tf:` + backendBlock.String(),
+			`f:prod/stacks/A/README.md:# empty`,
+			`f:prod/stacks/B/main.tf:` + providerBlock.String(),
+			`f:prod/stacks/A/other-stack/main.tf:` + mixedBackendProvider.String(),
+			`f:README.md:# My module`,
+			`f:generate.tm:generate_hcl "_generated.tf" {
+			content {
+				test = 1
+			}
+		}`,
+		})
+		tm := NewCLI(t, s.RootDir())
+		args := []string{"create", "--all-terraform"}
+		if !generate {
+			args = append(args, "--no-generate")
+		}
+		AssertRunResult(t,
+			tm.Run(args...),
+			RunExpected{
+				Stdout: nljoin(
+					"Created stack /prod/stacks/A",
+					"Created stack /prod/stacks/A/other-stack",
+					"Created stack /prod/stacks/B",
+				),
+			},
+		)
+
+		for _, path := range []string{
+			"/prod/stacks/A",
+			"/prod/stacks/B",
+			"/prod/stacks/A/other-stack",
+		} {
+			stackPath := filepath.Join(s.RootDir(), path)
+			_, err := os.Lstat(filepath.Join(stackPath, stack.DefaultFilename))
+			assert.NoError(t, err)
+
+			_, err = os.Lstat(filepath.Join(stackPath, "_generated.tf"))
+			if generate {
+				assert.NoError(t, err)
+			} else {
+				errtest.Assert(t, err, os.ErrNotExist)
+			}
+		}
+	}
+
+	t.Run("with generation", func(t *testing.T) {
+		test(t, true)
+	})
+
+	t.Run("without generation", func(t *testing.T) {
+		test(t, false)
+	})
+}
+
+func TestCreateWithAllTerraformSkipActualStacks(t *testing.T) {
+	s := sandbox.NoGit(t, true)
+	tfBlock := Block("terraform",
+		Block("backend",
+			Labels("remote"),
+			Str("attr", "value"),
+		),
+	)
+	s.BuildTree([]string{
+		`s:stack`,
+		`f:stack/main.tf:` + tfBlock.String(),
+		`f:README.md:# My module`,
+	})
+	tm := NewCLI(t, s.RootDir())
+	AssertRun(t, tm.Run("create", "--all-terraform"))
+}
+
+func TestCreateWithAllTerraformDetectModulesInsideStacks(t *testing.T) {
+	s := sandbox.NoGit(t, true)
+	backendContent := Block("terraform",
+		Block("backend",
+			Labels("remote"),
+			Str("attr", "value"),
+		)).String()
+
+	s.BuildTree([]string{
+		`s:stack`,
+		`f:stack/main.tf:` + backendContent,
+		`f:stack/hidden/module/inside/stack/main.tf:` + backendContent,
+		`f:README.md:# My module`,
+	})
+	tm := NewCLI(t, s.RootDir())
+	AssertRunResult(t,
+		tm.Run("create", "--all-terraform"),
+		RunExpected{
+			Stdout: "Created stack /stack/hidden/module/inside/stack\n",
+		},
+	)
+}

--- a/cmd/terramate/e2etests/core/create_all_terragrunt_test.go
+++ b/cmd/terramate/e2etests/core/create_all_terragrunt_test.go
@@ -1,0 +1,212 @@
+// Copyright 2024 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+package core_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	. "github.com/terramate-io/terramate/cmd/terramate/e2etests/internal/runner"
+	"github.com/terramate-io/terramate/test/hclwrite"
+	. "github.com/terramate-io/terramate/test/hclwrite/hclutils"
+	"github.com/terramate-io/terramate/test/sandbox"
+	"github.com/terramate-io/terramate/tg"
+)
+
+func TestCreateAllTerragrunt(t *testing.T) {
+	type testcase struct {
+		name   string
+		layout []string
+		wd     string
+		want   RunExpected
+	}
+
+	hclfile := func(name string, content *hclwrite.Block) string {
+		return "f:" + name + ":" + content.String()
+	}
+
+	for _, tc := range []testcase{
+		{
+			// maybe user's version of terragrunt is incompatible with Terramate implementation.
+			name: "invalid terragrunt configuration",
+			layout: []string{
+				hclfile("terragrunt.hcl", Block("terraform",
+					Str("source", "github.com/some/repo"),
+					Str("unknown_field", "test"),
+				)),
+			},
+			want: RunExpected{
+				StderrRegex: string(tg.ErrParsing),
+				Status:      1,
+			},
+		},
+		{
+			name: "terragrunt module at root",
+			layout: []string{
+				hclfile("terragrunt.hcl", Block("terraform",
+					Str("source", "github.com/some/repo"),
+				)),
+			},
+			want: RunExpected{
+				Stdout: nljoin("Created stack /"),
+			},
+		},
+		{
+			name: "terragrunt module at /dir but terraform.source imported from /_common",
+			layout: []string{
+				hclfile("dir/terragrunt.hcl", Block("include",
+					Labels("envcommon"),
+					Str("path", "../_common/module.hcl"),
+				)),
+				hclfile("_common/module.hcl", Block("terraform",
+					Str("source", "github.com/some/repo"),
+				)),
+			},
+			want: RunExpected{
+				Stdout: "Created stack /dir\n",
+			},
+		},
+		{
+			name: "terragrunt module at /dir merged with terraform block from root",
+			layout: []string{
+				hclfile("dir/terragrunt.hcl", Doc(
+					Block("include",
+						Labels("root"),
+						Expr("path", "find_in_parent_folders()"),
+					),
+					Block("terraform",
+						Str("source", "github.com/some/repo"),
+					)),
+				),
+				hclfile("terragrunt.hcl", Block("terraform",
+					Block("extra_arguments",
+						Labels("common_vars"),
+						Expr("commands", "get_terraform_commands_that_need_vars()"),
+					)),
+				),
+			},
+			want: RunExpected{
+				Stdout: "Created stack /dir\n",
+			},
+		},
+		{
+			name: "multiple siblings terragrunt modules using same TF module",
+			layout: []string{
+				hclfile("mod1/terragrunt.hcl", Block("include",
+					Labels("envcommon"),
+					Str("path", "../_common/mod1.hcl"),
+				)),
+				hclfile("mod2/terragrunt.hcl", Block("include",
+					Labels("envcommon"),
+					Str("path", "../_common/mod1.hcl"),
+				)),
+				hclfile("mod3/terragrunt.hcl", Block("include",
+					Labels("envcommon"),
+					Str("path", "../_common/mod1.hcl"),
+				)),
+				hclfile("_common/mod1.hcl", Block("terraform",
+					Str("source", "github.com/some/repo"),
+				)),
+			},
+			want: RunExpected{
+				Stdout: nljoin(
+					"Created stack /mod1",
+					"Created stack /mod2",
+					"Created stack /mod3",
+				),
+			},
+		},
+		{
+			name: "nested terragrunt modules using same TF module",
+			layout: []string{
+				hclfile("mod1/terragrunt.hcl", Block("include",
+					Labels("envcommon"),
+					Str("path", "../_common/mod.hcl"),
+				)),
+				hclfile("mod1/mod2/terragrunt.hcl", Block("include",
+					Labels("envcommon"),
+					Str("path", "../../_common/mod.hcl"),
+				)),
+				hclfile("mod1/mod2/mod3/terragrunt.hcl", Block("include",
+					Labels("envcommon"),
+					Str("path", "../../../_common/mod.hcl"),
+				)),
+				hclfile("_common/mod.hcl", Block("terraform",
+					Str("source", "github.com/some/repo"),
+				)),
+			},
+			want: RunExpected{
+				Stdout: nljoin(
+					"Created stack /mod1",
+					"Created stack /mod1/mod2",
+					"Created stack /mod1/mod2/mod3",
+				),
+			},
+		},
+		{
+			name: "terragrunt module at /dir merged with terraform module from root",
+			layout: []string{
+				hclfile("dir/terragrunt.hcl", Block("include",
+					Labels("root"),
+					Expr("path", "find_in_parent_folders()"),
+				)),
+				hclfile("terragrunt.hcl", Block("terraform",
+					Str("source", "github.com/some/repo"),
+					Block("extra_arguments",
+						Labels("common_vars"),
+						Expr("commands", "get_terraform_commands_that_need_vars()"),
+					)),
+				),
+			},
+			want: RunExpected{
+				Stdout: nljoin(
+					"Created stack /",
+					"Created stack /dir",
+				),
+			},
+		},
+		{
+			name: "detects Terragrunt module inside Terramate stack",
+			layout: []string{
+				`s:prod/stacks/stack1`,
+				hclfile("prod/stacks/stack1/tg-stack/terragrunt.hcl", Block("terraform",
+					Str("source", "github.com/some/repo"),
+				)),
+			},
+			want: RunExpected{
+				Stdout: nljoin(
+					"Created stack /prod/stacks/stack1/tg-stack",
+				),
+			},
+		},
+		{
+			name: "respects working dir and only creates for child directories",
+			wd:   "prod",
+			layout: []string{
+				hclfile("prod/stack/terragrunt.hcl", Block("terraform",
+					Str("source", "github.com/some/repo"),
+				)),
+				hclfile("dev/stack/terragrunt.hcl", Block("terraform",
+					Str("source", "github.com/some/repo"),
+				)),
+			},
+			want: RunExpected{
+				Stdout: nljoin(
+					"Created stack /prod/stack",
+				),
+			},
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			s := sandbox.NoGit(t, true)
+			s.BuildTree(tc.layout)
+			tm := NewCLI(t, filepath.Join(s.RootDir(), tc.wd))
+			AssertRunResult(t,
+				tm.Run("create", "--all-terragrunt"),
+				tc.want,
+			)
+		})
+	}
+}

--- a/cmd/terramate/e2etests/core/create_test.go
+++ b/cmd/terramate/e2etests/core/create_test.go
@@ -5,8 +5,8 @@ package core_test
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 
@@ -14,11 +14,84 @@ import (
 	"github.com/madlambda/spells/assert"
 	. "github.com/terramate-io/terramate/cmd/terramate/e2etests/internal/runner"
 	"github.com/terramate-io/terramate/project"
-	"github.com/terramate-io/terramate/stack"
 	"github.com/terramate-io/terramate/test"
-	errtest "github.com/terramate-io/terramate/test/errors"
 	"github.com/terramate-io/terramate/test/sandbox"
 )
+
+func TestCreateFailsWithIncompatibleFlags(t *testing.T) {
+	t.Parallel()
+
+	test := func(t *testing.T, stderrRegex string, args ...string) {
+		t.Helper()
+		s := sandbox.NoGit(t, true)
+		root := s.RootEntry()
+		root.CreateDir("stack")
+		cli := NewCLI(t, s.RootDir())
+
+		createArgs := []string{"create"}
+		createArgs = append(createArgs, args...)
+
+		AssertRunResult(t, cli.Run(createArgs...), RunExpected{
+			Status:      1,
+			StderrRegex: stderrRegex,
+		})
+	}
+
+	testIncompatibleFlags := func(t *testing.T, args ...string) {
+		test(t, "Invalid args", args...)
+	}
+
+	t.Run("without required arguments", func(t *testing.T) {
+		test(t, "Missing args")
+	})
+
+	scanFlags := []string{
+		"--all-terraform",
+		"--all-terragrunt",
+		"--ensure-stack-ids",
+	}
+
+	mainFlags := append([]string{
+		"./stack",
+	}, scanFlags...)
+
+	pairs := map[string]struct{}{}
+	for _, flag := range mainFlags {
+		for _, otherFlag := range mainFlags {
+			if flag == otherFlag {
+				continue
+			}
+			args := []string{flag, otherFlag}
+			sort.Strings(args)
+			pairs[strings.Join(args, " ")] = struct{}{}
+		}
+	}
+
+	for pair := range pairs {
+		args := strings.Split(pair, " ")
+		t.Run(fmt.Sprintf("%s conflicts with %s", args[0], args[1]), func(t *testing.T) {
+			testIncompatibleFlags(t, args[0], args[1])
+		})
+	}
+
+	nonScanFlags := []string{
+		"--id=test",
+		"--name=some-stack",
+		"--description=desc",
+		"--after=/test",
+		"--before=/test",
+		"--import=/test",
+		"--ignore-existing",
+	}
+
+	for _, scanFlag := range scanFlags {
+		for _, nonScanFlag := range nonScanFlags {
+			t.Run(fmt.Sprintf("%s conflicts to %s", scanFlag, nonScanFlag), func(t *testing.T) {
+				testIncompatibleFlags(t, scanFlag, nonScanFlag)
+			})
+		}
+	}
+}
 
 func TestCreateStack(t *testing.T) {
 	t.Parallel()
@@ -67,10 +140,6 @@ func TestCreateStack(t *testing.T) {
 			args := []string{"create", stackPath, "--id", stackID}
 			args = append(args, flags...)
 			res := cli.Run(args...)
-
-			t.Logf("run create stack %s", stackPath)
-			t.Logf("stdout: %s", res.Stdout)
-			t.Logf("stderr: %s", res.Stderr)
 
 			want := fmt.Sprintf("Created stack %s\n", stackPath)
 			if stackPath[0] != '/' {
@@ -194,197 +263,6 @@ func TestCreateStackIgnoreExistingFatalOnOtherErrors(t *testing.T) {
 		Status:       1,
 		IgnoreStderr: true,
 	})
-}
-
-func TestCreateFailsWithIncompatibleFlags(t *testing.T) {
-	t.Parallel()
-
-	test := func(t *testing.T, args ...string) {
-		s := sandbox.NoGit(t, true)
-		root := s.RootEntry()
-		root.CreateDir("stack")
-		cli := NewCLI(t, s.RootDir())
-
-		createArgs := []string{"create"}
-		createArgs = append(createArgs, args...)
-
-		AssertRunResult(t, cli.Run(createArgs...), RunExpected{
-			Status:      1,
-			StderrRegex: "incompatible",
-		})
-	}
-
-	t.Run("--all-terraform and path", func(t *testing.T) {
-		test(t, "--all-terraform", "./stack")
-	})
-
-	t.Run("--ensure-stack-ids and path", func(t *testing.T) {
-		test(t, "--ensure-stack-ids", "./stack")
-	})
-
-	t.Run("--all-terraform and --id", func(t *testing.T) {
-		test(t, "--all-terraform", "--id=test")
-	})
-
-	t.Run("--ensure-stack-ids and --id", func(t *testing.T) {
-		test(t, "--ensure-stack-ids", "--id=test")
-	})
-
-	t.Run("--all-terraform and --name", func(t *testing.T) {
-		test(t, "--all-terraform", "--name=some-stack")
-	})
-
-	t.Run("--all-terraform and --description", func(t *testing.T) {
-		test(t, "--all-terraform", "--description=desc")
-	})
-
-	t.Run("--all-terraform and --after", func(t *testing.T) {
-		test(t, "--all-terraform", "--after=/test")
-	})
-
-	t.Run("--all-terraform and --before", func(t *testing.T) {
-		test(t, "--all-terraform", "--before=/test")
-	})
-
-	t.Run("--all-terraform and --import", func(t *testing.T) {
-		test(t, "--all-terraform", "--import=/test")
-	})
-
-	t.Run("--all-terraform and --ignore-existing", func(t *testing.T) {
-		test(t, "--all-terraform", "--ignore-existing")
-	})
-}
-
-func TestCreateWithAllTerraformModuleAtRoot(t *testing.T) {
-	s := sandbox.NoGit(t, true)
-	s.BuildTree([]string{
-		`f:main.tf:terraform {
-			backend "remote" {
-				attr = "value"
-			}
-		}`,
-		`f:README.md:# My module`,
-	})
-	tm := NewCLI(t, s.RootDir())
-	AssertRunResult(t,
-		tm.Run("create", "--all-terraform"),
-		RunExpected{
-			Stdout: "Created stack /\n",
-		},
-	)
-	_, err := os.Lstat(filepath.Join(s.RootDir(), stack.DefaultFilename))
-	assert.NoError(t, err)
-}
-
-func TestCreateWithAllTerraformModuleDeepDownInTheTree(t *testing.T) {
-	testCase := func(t *testing.T, generate bool) {
-		s := sandbox.NoGit(t, true)
-		const backendContent = `terraform {
-		backend "remote" {
-			attr = "value"
-		}
-	}
-
-	`
-
-		const providerContent = `
-		provider "aws" {
-			attr = 1
-		}
-	`
-
-		const mixedBackendProvider = backendContent + providerContent
-
-		s.BuildTree([]string{
-			`f:prod/stacks/k8s-stack/deployment.yml:# empty file`,
-			`f:prod/stacks/A/anyfile.tf:` + backendContent,
-			`f:prod/stacks/A/README.md:# empty`,
-			`f:prod/stacks/B/main.tf:` + providerContent,
-			`f:prod/stacks/A/other-stack/main.tf:` + mixedBackendProvider,
-			`f:README.md:# My module`,
-			`f:generate.tm:generate_hcl "_generated.tf" {
-			content {
-				test = 1
-			}
-		}`,
-		})
-		tm := NewCLI(t, s.RootDir())
-		args := []string{"create", "--all-terraform"}
-		if !generate {
-			args = append(args, "--no-generate")
-		}
-		AssertRunResult(t,
-			tm.Run(args...),
-			RunExpected{
-				Stdout: `Created stack /prod/stacks/A
-Created stack /prod/stacks/A/other-stack
-Created stack /prod/stacks/B
-`,
-			},
-		)
-
-		for _, path := range []string{
-			"/prod/stacks/A",
-			"/prod/stacks/B",
-			"/prod/stacks/A/other-stack",
-		} {
-			stackPath := filepath.Join(s.RootDir(), path)
-			_, err := os.Lstat(filepath.Join(stackPath, stack.DefaultFilename))
-			assert.NoError(t, err)
-
-			_, err = os.Lstat(filepath.Join(stackPath, "_generated.tf"))
-			if generate {
-				assert.NoError(t, err)
-			} else {
-				errtest.Assert(t, err, os.ErrNotExist)
-			}
-		}
-	}
-
-	t.Run("with generation", func(t *testing.T) {
-		testCase(t, true)
-	})
-
-	t.Run("without generation", func(t *testing.T) {
-		testCase(t, false)
-	})
-}
-
-func TestCreateWithAllTerraformSkipActualStacks(t *testing.T) {
-	s := sandbox.NoGit(t, true)
-	s.BuildTree([]string{
-		`s:stack`,
-		`f:stack/main.tf:terraform {
-			backend "remote" {
-				attr = "value"
-			}
-		}`,
-		`f:README.md:# My module`,
-	})
-	tm := NewCLI(t, s.RootDir())
-	AssertRun(t, tm.Run("create", "--all-terraform"))
-}
-
-func TestCreateWithAllTerraformDetectModulesInsideStacks(t *testing.T) {
-	s := sandbox.NoGit(t, true)
-	const backendContent = `terraform {
-		backend "remote" {
-			attr = "value"
-		}
-	}`
-	s.BuildTree([]string{
-		`s:stack`,
-		`f:stack/main.tf:` + backendContent,
-		`f:stack/hidden/module/inside/stack/main.tf:` + backendContent,
-		`f:README.md:# My module`,
-	})
-	tm := NewCLI(t, s.RootDir())
-	AssertRunResult(t,
-		tm.Run("create", "--all-terraform"),
-		RunExpected{
-			Stdout: "Created stack /stack/hidden/module/inside/stack\n",
-		},
-	)
 }
 
 func TestCreateEnsureStackID(t *testing.T) {

--- a/docs/cli/cmdline/create.md
+++ b/docs/cli/cmdline/create.md
@@ -34,15 +34,28 @@ terramate create path/to/stack \
     --no-generate
 ```
 
-Initialize Terramate in an existing Terraform project:
+The `terramate create` supports initializing Terramate stacks in an existing [Terraform](https://www.terraform.io/)
+or [Terragrunt](https://terragrunt.gruntwork.io/) project.
+
+Scan and create stacks for Terraform stacks:
 
 ```bash
 terramate create --all-terraform
 ```
 
-This is helpful when you want to onboard Terramate in an existing
-Terraform project. `--all-terraform` will create a Terramate configuration
-file in every Terraform directory that contains a `terraform.backend` block or `provider` blocks.
+Scan and create stacks for Terragrunt stacks/modules:
+
+```bash
+terramate create --all-terragrunt
+```
+
+This is helpful when you want to onboard Terramate in an existing project. 
+
+The `--all-terraform` will create a Terramate stack file in every Terraform directory that 
+contains a `terraform.backend` block or `provider` blocks.
+
+The `--all-terragrunt` will create a Terramate stack file in every Terragrunt configuration that
+defines a `terraform.source` attribute (it will correctly parse and include other files as needed).
 
 ## Options
 


### PR DESCRIPTION
## What this PR does / why we need it:

Introduces the `terramate create --all-terragrunt` command for initializing Terramate stacks from Terragrunt modules.

## Which issue(s) this PR fixes:
no

## Special notes for your reviewer:

Depends on #1434 

## Does this PR introduce a user-facing change?
```
yes, add a new flag.
```
