### PR TITLE
feat(scripts): add cloud_sync_preview + cloud_sync_layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
   stack drift details from script jobs.
 - Add --cloud-sync-layer to allow users to specify a preview layer, e.g.: `stg`, `prod` etc.
   - This is useful when users want to preview changes in a specific terraform workspace.
+- Add `--cloud-sync-layer` and `--cloud-sync-preview` to `script` block, this would allow users to synchronize previews to Terramate Cloud via script jobs.
 
 ### Fixed
 

--- a/cloud/preview/preview.go
+++ b/cloud/preview/preview.go
@@ -3,7 +3,11 @@
 
 package preview
 
-import "github.com/terramate-io/terramate/errors"
+import (
+	"unicode"
+
+	"github.com/terramate-io/terramate/errors"
+)
 
 // StackStatus is the status of a stack in a preview run
 type StackStatus string
@@ -30,6 +34,26 @@ const ErrInvalidStackStatus = errors.Kind("invalid stack status")
 
 func (p StackStatus) String() string {
 	return string(p)
+}
+
+// Layer represents a cloud sync layer e.g. "dev", "staging", "prod" etc.
+type Layer string
+
+// String returns the string representation of the layer
+func (l Layer) String() string {
+	return string(l)
+}
+
+// Validate validates the cloud sync layer (only alphanumeric characters and
+// hyphens are allowed). An empty string is also allowed.
+func (l Layer) Validate() error {
+	for _, c := range string(l) {
+		if !unicode.IsLetter(c) && !unicode.IsDigit(c) && c != '-' {
+			return errors.E("invalid --cloud-sync-layer, only alphanumeric characters and hyphens are allowed")
+		}
+	}
+
+	return nil
 }
 
 // Validate validates the stack status

--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -15,13 +15,13 @@ import (
 	"strconv"
 	"strings"
 	"time"
-	"unicode"
 
 	"github.com/google/uuid"
 	hhcl "github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/terramate-io/go-checkpoint"
 	"github.com/terramate-io/terramate/cloud"
+	"github.com/terramate-io/terramate/cloud/preview"
 	cloudstack "github.com/terramate-io/terramate/cloud/stack"
 	"github.com/terramate-io/terramate/cmd/terramate/cli/cliconfig"
 	"github.com/terramate-io/terramate/cmd/terramate/cli/clitest"
@@ -157,18 +157,18 @@ type cliSpec struct {
 	} `cmd:"" help:"List stacks"`
 
 	Run struct {
-		CloudStatus                string         `help:"Filter by status. Example: --cloud-status=unhealthy"`
-		CloudSyncDeployment        bool           `default:"false" help:"Enable synchronization of stack execution with the Terramate Cloud"`
-		CloudSyncDriftStatus       bool           `default:"false" help:"Enable drift detection and synchronization with the Terramate Cloud"`
-		CloudSyncPreview           bool           `default:"false" help:"Enable synchronization of review request previews to Terramate Cloud"`
-		CloudSyncLayer             cloudSyncLayer `default:"" help:"Layer to use for synchronizing previews to Terramate Cloud e.g. stg, prod etc."`
-		CloudSyncTerraformPlanFile string         `default:"" help:"Enable sync of Terraform plan file"`
-		DebugPreviewURL            string         `default:"" help:"Debug preview URL"`
-		ContinueOnError            bool           `default:"false" help:"Continue executing in other stacks in case of error"`
-		NoRecursive                bool           `default:"false" help:"Do not recurse into child stacks"`
-		DryRun                     bool           `default:"false" help:"Plan the execution but do not execute it"`
-		Reverse                    bool           `default:"false" help:"Reverse the order of execution"`
-		Eval                       bool           `default:"false" help:"Evaluate command line arguments as HCL strings"`
+		CloudStatus                string        `help:"Filter by status. Example: --cloud-status=unhealthy"`
+		CloudSyncDeployment        bool          `default:"false" help:"Enable synchronization of stack execution with the Terramate Cloud"`
+		CloudSyncDriftStatus       bool          `default:"false" help:"Enable drift detection and synchronization with the Terramate Cloud"`
+		CloudSyncPreview           bool          `default:"false" help:"Enable synchronization of review request previews to Terramate Cloud"`
+		CloudSyncLayer             preview.Layer `default:"" help:"Layer to use for synchronizing previews to Terramate Cloud e.g. stg, prod etc."`
+		CloudSyncTerraformPlanFile string        `default:"" help:"Enable sync of Terraform plan file"`
+		DebugPreviewURL            string        `default:"" help:"Debug preview URL"`
+		ContinueOnError            bool          `default:"false" help:"Continue executing in other stacks in case of error"`
+		NoRecursive                bool          `default:"false" help:"Do not recurse into child stacks"`
+		DryRun                     bool          `default:"false" help:"Plan the execution but do not execute it"`
+		Reverse                    bool          `default:"false" help:"Reverse the order of execution"`
+		Eval                       bool          `default:"false" help:"Evaluate command line arguments as HCL strings"`
 
 		// Note: 0 is not the real default value here, this is just a workaround.
 		// Kong doesn't support having 0 as the default value in case the flag isn't set, but K in case it's set without a value.
@@ -736,22 +736,6 @@ func (s *kongParallelFlag) Decode(ctx *kong.DecodeContext) error {
 	}
 
 	s.Value = defaultParallelRunCount
-
-	return nil
-}
-
-type cloudSyncLayer string
-
-func (csl cloudSyncLayer) String() string {
-	return string(csl)
-}
-
-func (csl cloudSyncLayer) Validate() error {
-	for _, c := range csl {
-		if !unicode.IsLetter(c) && !unicode.IsDigit(c) && c != '-' {
-			return errors.E("invalid --cloud-sync-layer, only alphanumeric characters and hyphens are allowed")
-		}
-	}
 
 	return nil
 }

--- a/cmd/terramate/cli/run.go
+++ b/cmd/terramate/cli/run.go
@@ -18,6 +18,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/terramate-io/terramate/cloud"
+	"github.com/terramate-io/terramate/cloud/preview"
 	"github.com/terramate-io/terramate/config"
 	"github.com/terramate-io/terramate/errors"
 	"github.com/terramate-io/terramate/printer"
@@ -65,7 +66,7 @@ type stackRunTask struct {
 	CloudSyncDeployment        bool
 	CloudSyncDriftStatus       bool
 	CloudSyncPreview           bool
-	CloudSyncLayer             string
+	CloudSyncLayer             preview.Layer
 	CloudSyncTerraformPlanFile string
 }
 
@@ -154,7 +155,7 @@ func (c *cli) runOnStacks() {
 					CloudSyncDriftStatus:       c.parsedArgs.Run.CloudSyncDriftStatus,
 					CloudSyncPreview:           c.parsedArgs.Run.CloudSyncPreview,
 					CloudSyncTerraformPlanFile: c.parsedArgs.Run.CloudSyncTerraformPlanFile,
-					CloudSyncLayer:             c.parsedArgs.Run.CloudSyncLayer.String(),
+					CloudSyncLayer:             c.parsedArgs.Run.CloudSyncLayer,
 				},
 			},
 		}

--- a/cmd/terramate/cli/script_run.go
+++ b/cmd/terramate/cli/script_run.go
@@ -99,6 +99,8 @@ func (c *cli) runScript() {
 					if cmd.Options != nil {
 						task.CloudSyncDeployment = cmd.Options.CloudSyncDeployment
 						task.CloudSyncDriftStatus = cmd.Options.CloudSyncDriftStatus
+						task.CloudSyncPreview = cmd.Options.CloudSyncPreview
+						task.CloudSyncLayer = cmd.Options.CloudSyncLayer
 						task.CloudSyncTerraformPlanFile = cmd.Options.CloudSyncTerraformPlan
 					}
 					run.Tasks = append(run.Tasks, task)
@@ -130,7 +132,8 @@ func (c *cli) prepareScriptForCloudSync(runs []stackRun) {
 
 	deployRuns := selectCloudStackTasks(runs, isDeploymentTask)
 	driftRuns := selectCloudStackTasks(runs, isDriftTask)
-	if len(deployRuns) == 0 && len(driftRuns) == 0 {
+	previewRuns := selectCloudStackTasks(runs, isPreviewTask)
+	if len(deployRuns) == 0 && len(driftRuns) == 0 && len(previewRuns) == 0 {
 		return
 	}
 
@@ -168,6 +171,10 @@ func (c *cli) prepareScriptForCloudSync(runs []stackRun) {
 			sortableDriftStacks[i] = &config.SortableStack{Stack: e.Stack}
 		}
 		c.ensureAllStackHaveIDs(sortableDriftStacks)
+	}
+
+	if len(previewRuns) > 0 {
+		c.cloud.run.stackPreviews = c.createCloudPreview(previewRuns)
 	}
 }
 

--- a/cmd/terramate/e2etests/core/run_script_test.go
+++ b/cmd/terramate/e2etests/core/run_script_test.go
@@ -334,7 +334,6 @@ func TestRunScriptOnChangedStacks(t *testing.T) {
 
 	s := sandbox.New(t)
 
-	// stack must run after stack2 but stack2 didn't change.
 	s.BuildTree([]string{
 		terramateConfig,
 		`s:stack`,

--- a/config/script_test.go
+++ b/config/script_test.go
@@ -473,6 +473,90 @@ func TestScriptEval(t *testing.T) {
 			},
 		},
 		{
+			name: "command options with cloud_sync_deployment and cloud_sync_preview",
+			script: hcl.Script{
+				Labels: labels,
+				Description: hcl.NewScriptDescription(
+					makeAttribute(t, "description", `"some description"`)),
+				Jobs: []*hcl.ScriptJob{
+					{
+						Commands: makeCommands(t, `
+						  [
+							["echo", "hello", {
+								cloud_sync_deployment = true
+								cloud_sync_preview = true
+								cloud_sync_terraform_plan_file = "plan_a"
+							}],
+						  ]
+						`),
+					},
+				},
+			},
+			wantErr: errors.E(config.ErrScriptInvalidCmdOptions),
+		},
+		{
+			name: "command options with invalid cloud_sync_layer",
+			script: hcl.Script{
+				Labels: labels,
+				Description: hcl.NewScriptDescription(
+					makeAttribute(t, "description", `"some description"`)),
+				Jobs: []*hcl.ScriptJob{
+					{
+						Commands: makeCommands(t, `
+						  [
+							["echo", "hello", {
+								cloud_sync_preview = true
+								cloud_sync_terraform_plan_file = "plan_a"
+								cloud_sync_layer = "a+b"
+							}],
+						  ]
+						`),
+					},
+				},
+			},
+			wantErr: errors.E(config.ErrScriptInvalidCmdOptions),
+		},
+		{
+			name: "command options with cloud_sync_preview + planfile + layer",
+			script: hcl.Script{
+				Labels: labels,
+				Description: hcl.NewScriptDescription(
+					makeAttribute(t, "description", `"some description"`)),
+				Jobs: []*hcl.ScriptJob{
+					{
+						Commands: makeCommands(t, `
+						  [
+							["echo", "hello", {
+								cloud_sync_preview = true
+								cloud_sync_terraform_plan_file = "plan_a"
+								cloud_sync_layer = "staging"
+							}],
+						  ]
+						`),
+					},
+				},
+			},
+			want: config.Script{
+				Labels:      labels,
+				Description: "some description",
+				Jobs: []config.ScriptJob{
+					{
+						Cmds: []*config.ScriptCmd{
+							{
+								Args: []string{"echo", "hello"},
+								Options: &config.ScriptCmdOptions{
+									CloudSyncDeployment:    false,
+									CloudSyncPreview:       true,
+									CloudSyncLayer:         "staging",
+									CloudSyncTerraformPlan: "plan_a",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "command options",
 			script: hcl.Script{
 				Labels: labels,


### PR DESCRIPTION
## What this PR does / why we need it:

Add `cloud_sync_preview` option to script block.

## Which issue(s) this PR fixes:

## Special notes for your reviewer:

Depends on https://github.com/terramate-io/terramate/pull/1493

## Does this PR introduce a user-facing change?
```
Yes, users will be able to use the `cloud_sync_preview` option in the script block to store previews in TMC.
```
