### PR TITLE
fix: handle github event parsing gracefully

### DIFF
--- a/cmd/terramate/cli/github/event.go
+++ b/cmd/terramate/cli/github/event.go
@@ -7,7 +7,16 @@ import (
 	"encoding/json"
 	"os"
 	"time"
+
+	"github.com/terramate-io/terramate/errors"
 )
+
+type eventPullRequest struct {
+	UpdatedAt *time.Time `json:"updated_at"`
+}
+type event struct {
+	PullRequest *eventPullRequest `json:"pull_request"`
+}
 
 // GetEventPRUpdatedAt returns the updated_at field from the file at `eventPath`.
 // The file is expected to be a JSON file containing the GitHub event for a pull
@@ -18,13 +27,27 @@ func GetEventPRUpdatedAt(eventPath string) (*time.Time, error) {
 		return nil, err
 	}
 
+	if err := event.validate(); err != nil {
+		return nil, err
+	}
+
 	return event.PullRequest.UpdatedAt, nil
 }
 
-type event struct {
-	PullRequest struct {
-		UpdatedAt *time.Time `json:"updated_at"`
-	} `json:"pull_request"`
+func (e *event) validate() error {
+	if e == nil {
+		return errors.E("missing `event` in github event")
+	}
+
+	if e.PullRequest == nil {
+		return errors.E("missing `pull_request` in github event")
+	}
+
+	if e.PullRequest.UpdatedAt == nil {
+		return errors.E("missing `pull_request.updated_at` in github event")
+	}
+
+	return nil
 }
 
 func getEventFromPath(eventPath string) (*event, error) {

--- a/cmd/terramate/cli/run.go
+++ b/cmd/terramate/cli/run.go
@@ -468,7 +468,7 @@ func (c *cli) createCloudPreview(runs []runContext) map[string]string {
 
 	eventPRUpdatedAt, err := github.GetEventPRUpdatedAt(githubEventPath)
 	if err != nil {
-		printer.Stderr.Warn("unable to parse PR updated_at from GITHUB_EVENT_PATH")
+		printer.Stderr.WarnWithDetails("unable to parse PR updated_at from GITHUB_EVENT_PATH", err)
 		c.disableCloudFeatures(cloudError())
 		return map[string]string{}
 	}


### PR DESCRIPTION
## What this PR does / why we need it:

This should fix the panic in the interop tests.

## Which issue(s) this PR fixes:

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
No.

```
