### PR TITLE
docs: fix documentation typos in tm_* functions

### DIFF
--- a/docs/cli/code-generation/functions/tm_can.md
+++ b/docs/cli/code-generation/functions/tm_can.md
@@ -26,7 +26,7 @@ variable "timestamp" {
 
   validation {
     # formatdate fails if the second argument is not a valid timestamp
-    condition     = can(formatdate("", var.timestamp))
+    condition     = tm_can(formatdate("", var.timestamp))
     error_message = "The timestamp argument requires a valid RFC 3339 timestamp."
   }
 }

--- a/docs/cli/code-generation/functions/tm_cidrsubnet.md
+++ b/docs/cli/code-generation/functions/tm_cidrsubnet.md
@@ -27,8 +27,8 @@ additional bits added to the prefix.
 This function accepts both IPv6 and IPv4 prefixes, and the result always uses
 the same addressing scheme as the given prefix.
 
-Unlike the related function [`tm_cidrsubnets`](./tm_cidrsubnets.md), `cidrsubnet`
-allows you to give a specific network number to use. `cidrsubnets` can allocate
+Unlike the related function [`tm_cidrsubnets`](./tm_cidrsubnets.md), `tm_cidrsubnet`
+allows you to give a specific network number to use. `tm_cidrsubnets` can allocate
 multiple network addresses at once, but numbers them automatically starting
 with zero.
 

--- a/docs/cli/code-generation/functions/tm_coalescelist.md
+++ b/docs/cli/code-generation/functions/tm_coalescelist.md
@@ -25,7 +25,7 @@ tm_coalescelist([], ["c", "d"])
 ]
 ```
 
-To perform the `coalescelist` operation with a list of lists, use the `...`
+To perform the `tm_coalescelist` operation with a list of lists, use the `...`
 symbol to expand the outer list as arguments:
 
 ```sh

--- a/docs/cli/code-generation/functions/tm_csvdecode.md
+++ b/docs/cli/code-generation/functions/tm_csvdecode.md
@@ -71,7 +71,7 @@ resource "aws_instance" "example" {
 ```
 
 The `for` expression in our `for_each` argument transforms the list produced
-by `csvdecode` into a map using the `local_id` as a key, which tells
+by `tm_csvdecode` into a map using the `local_id` as a key, which tells
 Terraform to use the `local_id` value to track each instance it creates.
 Terraform will create and manage the following instance addresses:
 
@@ -89,7 +89,7 @@ If there is no reasonable value you can use as a unique identifier in your CSV
 then you could instead use
 [the `count` meta-argument](https://developer.hashicorp.com/terraform/language/meta-arguments/count)
 to define an object for each CSV row, with each one identified by its index into
-the list returned by `csvdecode`. However, in that case any future updates to
+the list returned by `tm_csvdecode`. However, in that case any future updates to
 the CSV may be disruptive if they change the positions of particular objects in
 the list. We recommend using `for_each` with a unique id column to make
 behavior more predictable on future changes.

--- a/docs/cli/code-generation/functions/tm_filemd5.md
+++ b/docs/cli/code-generation/functions/tm_filemd5.md
@@ -10,6 +10,6 @@ description: |-
 `tm_filemd5` is a variant of [`tm_md5`](./tm_md5.md)
 that hashes the contents of a given file rather than a literal string.
 
-This is similar to `tm_md5(file(filename))`, but
+This is similar to `tm_md5(tm_file(filename))`, but
 because [`tm_file`](./tm_file.md) accepts only UTF-8 text it cannot be used to
 create hashes for binary files.

--- a/docs/cli/code-generation/functions/tm_filesha1.md
+++ b/docs/cli/code-generation/functions/tm_filesha1.md
@@ -10,6 +10,6 @@ description: |-
 `tm_filesha1` is a variant of [`tm_sha1`](./tm_sha1.md)
 that hashes the contents of a given file rather than a literal string.
 
-This is similar to `tm_sha1(file(filename))`, but
+This is similar to `tm_sha1(tm_file(filename))`, but
 because [`tm_file`](./tm_file.md) accepts only UTF-8 text it cannot be used to
 create hashes for binary files.

--- a/docs/cli/code-generation/functions/tm_filesha256.md
+++ b/docs/cli/code-generation/functions/tm_filesha256.md
@@ -10,6 +10,6 @@ description: |-
 `tm_filesha256` is a variant of [`tm_sha256`](./tm_sha256.md)
 that hashes the contents of a given file rather than a literal string.
 
-This is similar to `tm_sha256(file(filename))`, but
+This is similar to `tm_sha256(tm_file(filename))`, but
 because [`tm_file`](./tm_file.md) accepts only UTF-8 text it cannot be used to
 create hashes for binary files.

--- a/docs/cli/code-generation/functions/tm_filesha512.md
+++ b/docs/cli/code-generation/functions/tm_filesha512.md
@@ -10,6 +10,6 @@ description: |-
 `tm_filesha512` is a variant of [`tm_sha512`](./tm_sha512.md)
 that hashes the contents of a given file rather than a literal string.
 
-This is similar to `tm_sha512(file(filename))`, but
+This is similar to `tm_sha512(tm_file(filename))`, but
 because [`tm_file`](./tm_file.md) accepts only UTF-8 text it cannot be used to
 create hashes for binary files.

--- a/docs/cli/code-generation/functions/tm_format.md
+++ b/docs/cli/code-generation/functions/tm_format.md
@@ -8,7 +8,7 @@ description: |-
 # `tm_format` Function
 
 The `tm_format` function produces a string by formatting a number of other values according
-to a specification string. It is similar to The `tm_printf` function in C, and
+to a specification string. It is similar to The `printf` function in C, and
 other similar functions in other programming languages.
 
 ```hcl

--- a/docs/cli/code-generation/functions/tm_formatdate.md
+++ b/docs/cli/code-generation/functions/tm_formatdate.md
@@ -5,7 +5,7 @@ description: The tm_formatdate function converts a timestamp into a different ti
 
 # `tm_formatdate` Function
 
-`formatdate` converts a timestamp into a different time format.
+`tm_formatdate` converts a timestamp into a different time format.
 
 ```hcl
 tm_formatdate(spec, timestamp)
@@ -13,7 +13,7 @@ tm_formatdate(spec, timestamp)
 
 In the Terraform language, timestamps are conventionally represented as
 strings using [RFC 3339](https://tools.ietf.org/html/rfc3339)
-"Date and Time format" syntax. `formatdate` requires the `timestamp` argument
+"Date and Time format" syntax. `tm_formatdate` requires the `timestamp` argument
 to be a string conforming to this syntax.
 
 ## Examples

--- a/docs/cli/code-generation/functions/tm_indent.md
+++ b/docs/cli/code-generation/functions/tm_indent.md
@@ -20,7 +20,7 @@ This function is useful for inserting a multi-line string into an
 already-indented context in another string:
 
 ```sh
-tm_"  items: ${indent(2, "[\n  foo,\n  bar,\n]\n")}"
+tm_indent(2, "  items: ${"[\n  foo,\n  bar,\n]\n"}")
   items: [
     foo,
     bar,

--- a/docs/cli/code-generation/functions/tm_jsonencode.md
+++ b/docs/cli/code-generation/functions/tm_jsonencode.md
@@ -24,7 +24,7 @@ This function maps **Terramate language values** to JSON values in the following
 | Null value     | `null`    |
 
 Since the JSON format cannot fully represent all of the Terramate language
-types, passing the `jsonencode` result to `jsondecode` will not produce an
+types, passing the `tm_jsonencode` result to `tm_jsondecode` will not produce an
 identical value, but the automatic type conversion rules mean that this is
 rarely a problem in practice.
 

--- a/docs/cli/code-generation/functions/tm_matchkeys.md
+++ b/docs/cli/code-generation/functions/tm_matchkeys.md
@@ -15,7 +15,7 @@ list.
 tm_matchkeys(valueslist, keyslist, searchset)
 ```
 
-`matchkeys` identifies the indexes in `keyslist` that are equal to elements of
+`tm_matchkeys` identifies the indexes in `keyslist` that are equal to elements of
 `searchset`, and then constructs a new list by taking those same indexes from
 `valueslist`. Both `valueslist` and `keyslist` must be the same length.
 
@@ -65,6 +65,6 @@ the instances by matching one of the resource attributes:
 ]
 ```
 
-Since the signature of `matchkeys` is complicated and not immediately clear to
+Since the signature of `tm_matchkeys` is complicated and not immediately clear to
 the reader when used in configuration, prefer to use `for` expressions where
 possible to maximize readability.

--- a/docs/cli/code-generation/functions/tm_one.md
+++ b/docs/cli/code-generation/functions/tm_one.md
@@ -8,8 +8,8 @@ description: |-
 # `tm_one` Function
 
 `tm_one` takes a list, set, or tuple value with either zero or one elements.
-If the collection is empty, `one` returns `null`. Otherwise, `one` returns
-the first element. If there are two or more elements then `one` will return
+If the collection is empty, `tm_one` returns `null`. Otherwise, `tm_one` returns
+the first element. If there are two or more elements then `tm_one` will return
 an error.
 
 This is a specialized function intended for the common situation where a
@@ -31,7 +31,7 @@ resource "aws_instance" "example" {
 }
 
 output "instance_ip_address" {
-  value = one(aws_instance.example[*].private_ip)
+  value = tm_one(aws_instance.example[*].private_ip)
 }
 ```
 
@@ -71,7 +71,7 @@ output "instance_ip_address" {
 
 In this case we can see that The `tm_one` function is, in a sense, the opposite
 of applying `[*]` to a primitive-typed value. Splat can convert a possibly-null
-value into a zero-or-one list, and `one` can reverse that to return to a
+value into a zero-or-one list, and `tm_one` can reverse that to return to a
 primitive value that might be null.
 
 ## Examples
@@ -94,7 +94,7 @@ either zero or one elements.
 The `tm_one` function can be particularly helpful in situations where you have a
 set that you know has only zero or one elements. Set values don't support
 indexing, so it's not valid to write `var.set[0]` to extract the "first"
-element of a set, but if you know that there's only one item then `one` can
+element of a set, but if you know that there's only one item then `tm_one` can
 isolate and return that single item:
 
 ```sh

--- a/docs/cli/code-generation/functions/tm_parseint.md
+++ b/docs/cli/code-generation/functions/tm_parseint.md
@@ -17,7 +17,7 @@ Bases 37 and higher use lowercase latin letters and then uppercase latin
 letters.
 
 If the given string contains any non-digit characters or digit characters that
-are too large for the given base then `parseint` will produce an error.
+are too large for the given base then `tm_parseint` will produce an error.
 
 ## Examples
 

--- a/docs/cli/code-generation/functions/tm_range.md
+++ b/docs/cli/code-generation/functions/tm_range.md
@@ -112,7 +112,7 @@ variable "name_counts" {
 locals {
   expanded_names = {
     for name, count in var.name_counts : name => [
-      for i in range(count) : format("%s%02d", name, i)
+      for i in tm_range(count) : format("%s%02d", name, i)
     ]
   }
 }

--- a/docs/cli/code-generation/functions/tm_regex.md
+++ b/docs/cli/code-generation/functions/tm_regex.md
@@ -15,7 +15,7 @@ to a string and returns the matching substrings.
 tm_regex(pattern, string)
 ```
 
-The return type of `regex` depends on the capture groups, if any, in the
+The return type of `tm_regex` depends on the capture groups, if any, in the
 pattern:
 
 - If the pattern has no capture groups at all, the result is a single string
@@ -28,7 +28,7 @@ pattern:
 
 It's not valid to mix both named and unnamed capture groups in the same pattern.
 
-If the given pattern does not match at all, the `regex` raises an error. To
+If the given pattern does not match at all, the `tm_regex` raises an error. To
 _test_ whether a given pattern matches a string, use
 [`tm_regexall`](./tm_regexall.md) and test that the result has length greater than
 zero.

--- a/docs/cli/code-generation/functions/tm_regexall.md
+++ b/docs/cli/code-generation/functions/tm_regexall.md
@@ -17,7 +17,7 @@ tm_regexall(pattern, string)
 
 `tm_regexall` is a variant of [`tm_regex`](./tm_regex.md) and uses the same pattern
 syntax. For any given input to `tm_regex`, `tm_regexall` returns a list of whatever
-type `regex` would've returned, with one element per match. That is:
+type `tm_regex` would've returned, with one element per match. That is:
 
 - If the pattern has no capture groups at all, the result is a list of
   strings.

--- a/docs/cli/code-generation/functions/tm_rsadecrypt.md
+++ b/docs/cli/code-generation/functions/tm_rsadecrypt.md
@@ -26,6 +26,6 @@ negotiated out-of-band.
 ## Examples
 
 ```sh
-tm_rsadecrypt(filebase64("${path.module}/ciphertext"), file("privatekey.pem"))
+tm_rsadecrypt(tm_filebase64("${path.module}/ciphertext"), tm_file("privatekey.pem"))
 Hello, world!
 ```

--- a/docs/cli/code-generation/functions/tm_setsubtract.md
+++ b/docs/cli/code-generation/functions/tm_setsubtract.md
@@ -26,7 +26,7 @@ toset([
 ### Set Difference (Symmetric Difference)
 
 ```sh
-tm_setunion(setsubtract(["a", "b", "c"], ["a", "c", "d"]), setsubtract(["a", "c", "d"], ["a", "b", "c"]))
+tm_setunion(tm_setsubtract(["a", "b", "c"], ["a", "c", "d"]), tm_setsubtract(["a", "c", "d"], ["a", "b", "c"]))
 toset([
   "b",
   "d",

--- a/docs/cli/code-generation/functions/tm_ternary.md
+++ b/docs/cli/code-generation/functions/tm_ternary.md
@@ -9,7 +9,7 @@ description: |
 
 This function is a replacement for HCL ternary operator `a ? b : c`. It circumvent
 some limitations, like both expressions of the ternary producing values of the
-same type. The `tm_tm_ternary` function is not even limited to returning actual
+same type. The `tm_ternary` function is not even limited to returning actual
 values, it can also return expressions. Only the first boolean parameter must
 be fully evaluated. If it is true, the first expression is returned, if it is
 false the second expression is returned.

--- a/docs/cli/code-generation/functions/tm_textdecodebase64.md
+++ b/docs/cli/code-generation/functions/tm_textdecodebase64.md
@@ -37,4 +37,4 @@ Hello World
 * [`tm_textencodebase64`](./tm_textencodebase64.md) performs the opposite operation,
   applying target encoding and then Base64 to a string.
 * [`tm_base64decode`](./tm_base64decode.md) is effectively a shorthand for
-  `textdecodebase64` where the character encoding is fixed as `UTF-8`.
+  `tm_textdecodebase64` where the character encoding is fixed as `UTF-8`.

--- a/docs/cli/code-generation/functions/tm_timeadd.md
+++ b/docs/cli/code-generation/functions/tm_timeadd.md
@@ -14,7 +14,7 @@ tm_timeadd(timestamp, duration)
 
 In the Terraform language, timestamps are conventionally represented as
 strings using [RFC 3339](https://tools.ietf.org/html/rfc3339)
-"Date and Time format" syntax. `timeadd` requires the `timestamp` argument
+"Date and Time format" syntax. `tm_timeadd` requires the `timestamp` argument
 to be a string conforming to this syntax.
 
 `duration` is a string representation of a time difference, consisting of

--- a/docs/cli/code-generation/functions/tm_timestamp.md
+++ b/docs/cli/code-generation/functions/tm_timestamp.md
@@ -11,7 +11,7 @@ description: |-
 
 In the Terraform language, timestamps are conventionally represented as
 strings using [RFC 3339](https://tools.ietf.org/html/rfc3339)
-"Date and Time format" syntax, and so `timestamp` returns a string
+"Date and Time format" syntax, and so `tm_timestamp` returns a string
 in this format.
 
 The result of this function will change every second, so using this function

--- a/docs/cli/code-generation/functions/tm_try.md
+++ b/docs/cli/code-generation/functions/tm_try.md
@@ -25,8 +25,8 @@ the configuration:
 locals {
   raw_value = yamldecode(file("${path.module}/example.yaml"))
   normalized_value = {
-    name   = tostring(try(local.raw_value.name, null))
-    groups = try(local.raw_value.groups, [])
+    name   = tostring(tm_try(local.raw_value.name, null))
+    groups = tm_try(local.raw_value.groups, [])
   }
 }
 ```
@@ -44,7 +44,7 @@ variable "example" {
 }
 
 locals {
-  example = try(
+  example = tm_try(
     [tostring(var.example)],
     tolist(var.example),
   )
@@ -58,11 +58,11 @@ assume that `local.example` is always a list.
 
 This second example contains two expressions that can both potentially fail.
 For example, if `var.example` were set to `{}` then it could be converted to
-neither a string nor a list. If `try` exhausts all of the given expressions
+neither a string nor a list. If `tm_try` exhausts all of the given expressions
 without any succeeding, it will return an error describing all of the problems
 it encountered.
 
-We strongly suggest using `try` only in special local values whose expressions
+We strongly suggest using `tm_try` only in special local values whose expressions
 perform normalization, so that the error handling is confined to a single
 location in the module and the rest of the module can just use straightforward
 references to the normalized structure and thus be more readable for future

--- a/docs/cli/code-generation/functions/tm_urlencode.md
+++ b/docs/cli/code-generation/functions/tm_urlencode.md
@@ -26,6 +26,6 @@ tm_urlencode("Hello World!")
 Hello+World%21
 tm_urlencode("☃")
 %E2%98%83
-tm_"http://example.com/search?q=${urlencode("terraform urlencode")}"
+tm_urlencode("http://example.com/search?q=${"terraform urlencode"}")
 http://example.com/search?q=terraform+urlencode
 ```

--- a/docs/cli/code-generation/functions/tm_yamldecode.md
+++ b/docs/cli/code-generation/functions/tm_yamldecode.md
@@ -34,7 +34,7 @@ usually need to worry about exactly what type is produced for a given value,
 and can just use the result in an intuitive way.
 
 Note though that the mapping above is ambiguous -- several different source
-types map to the same target type -- and so round-tripping through `yamldecode`
+types map to the same target type -- and so round-tripping through `tm_yamldecode`
 and then `yamlencode` cannot produce an identical result.
 
 YAML is a complex language and it supports a number of possibilities that the
@@ -43,7 +43,7 @@ supports only a subset of YAML 1.2, with restrictions including the following:
 
 - Although aliases to earlier anchors are supported, cyclic data structures
   (where a reference to a collection appears inside that collection) are not.
-  If `yamldecode` detects such a structure then it will return an error.
+  If `tm_yamldecode` detects such a structure then it will return an error.
 
 - Only the type tags shown in the above table (or equivalent alternative
   representations of those same tags) are supported. Any other tags will

--- a/docs/cli/code-generation/functions/tm_yamlencode.md
+++ b/docs/cli/code-generation/functions/tm_yamlencode.md
@@ -64,7 +64,7 @@ tm_yamlencode({"foo":[1, {"a":"b","c":"d"}, 3], "bar": "baz"})
 - 3
 ```
 
-`yamlencode` always uses YAML's "block style" for mappings and sequences, unless
+`tm_yamlencode` always uses YAML's "block style" for mappings and sequences, unless
 the mapping or sequence is empty. To generate flow-style YAML, use
 [`tm_jsonencode`](./tm_jsonencode.md) instead: YAML flow-style is a superset
 of JSON syntax.


### PR DESCRIPTION
## What this PR does / why we need it:

This PR addresses typos in the functions documentation section at Terramate docs ([link](https://terramate.io/docs/cli/code-generation/functions)). It mostly deals with the missing `tm_` prefix, but also some examples are mistyped.

## Does this PR introduce a user-facing change?
yes, on the docs website
