### PR TITLE
fix: use PR info from event when available, otherwise API

### DIFF
--- a/cmd/terramate/cli/cloud.go
+++ b/cmd/terramate/cli/cloud.go
@@ -21,6 +21,7 @@ import (
 	"github.com/terramate-io/terramate/cloud/preview"
 	"github.com/terramate-io/terramate/cloud/stack"
 	"github.com/terramate-io/terramate/cmd/terramate/cli/clitest"
+	tmgithub "github.com/terramate-io/terramate/cmd/terramate/cli/github"
 
 	"github.com/terramate-io/terramate/cmd/terramate/cli/out"
 	"github.com/terramate-io/terramate/config"
@@ -56,6 +57,7 @@ type cloudConfig struct {
 		// stackPreviews is a map of stack.ID to stackPreview.ID
 		stackPreviews               map[string]string
 		reviewRequest               *cloud.ReviewRequest
+		prFromGHAEvent              *github.PullRequest
 		metadata                    *cloud.DeploymentMetadata
 		technology, technologyLayer string
 	}
@@ -499,47 +501,71 @@ func (c *cli) detectCloudMetadata() {
 			Msg("failed to retrieve commit information from GitHub API")
 	}
 
-	if pull, found, err := getGithubPR(githubClient, r.Owner, r.Name, headCommit); err == nil {
-		if !found {
-			logger.Warn().
-				Msg("no pull request associated with HEAD commit")
-
-			return
-		}
-
-		logger.Debug().
-			Str("pull_request_url", pull.GetHTMLURL()).
-			Msg("using pull request url")
-
-		setGithubPRMetadata(md, pull)
-
-		reviews, err := listGithubPullReviews(githubClient, r.Owner, r.Name, pull.GetNumber())
-		if err != nil {
-			logger.Warn().
-				Err(err).
-				Msg("failed to retrieve PR reviews")
-		}
-
-		checks, err := listGithubChecks(githubClient, r.Owner, r.Name, headCommit)
-		if err != nil {
-			logger.Warn().
-				Err(err).
-				Msg("failed to retrieve PR reviews")
-		}
-
-		merged := false
-		if pull.GetState() == "closed" {
-			merged, err = isGithubPRMerged(githubClient, r.Owner, r.Name, pull.GetNumber())
-			if err != nil {
-				logger.Warn().
-					Err(err).
-					Msg("failed to retrieve PR merged status")
-			}
-		}
-
-		c.cloud.run.reviewRequest = c.newReviewRequest(pull, reviews, checks, merged)
-
+	var prNumber int
+	prFromEvent, err := tmgithub.GetEventPR()
+	if err != nil {
+		logger.Debug().Err(err).Msg("unable to get pull_request details from GITHUB_EVENT_PATH")
 	} else {
+		logger.Debug().Err(err).Msg("got pull_request details from GITHUB_EVENT_PATH")
+		c.cloud.run.prFromGHAEvent = prFromEvent
+		prNumber = prFromEvent.GetNumber()
+	}
+
+	pull, err := getGithubPRByNumberOrCommit(githubClient, ghToken, r.Owner, r.Name, prNumber, headCommit)
+	if err != nil {
+		printer.Stderr.WarnWithDetails(
+			sprintf("failed to retrieve pull request (number: %d, commit: %s)", prNumber, headCommit),
+			err)
+		return
+	}
+
+	logger.Debug().
+		Str("pull_request_url", pull.GetHTMLURL()).
+		Msg("using pull request url")
+
+	setGithubPRMetadata(md, pull)
+
+	reviews, err := listGithubPullReviews(githubClient, r.Owner, r.Name, pull.GetNumber())
+	if err != nil {
+		logger.Warn().
+			Err(err).
+			Msg("failed to retrieve PR reviews")
+	}
+
+	checks, err := listGithubChecks(githubClient, r.Owner, r.Name, headCommit)
+	if err != nil {
+		logger.Warn().Err(err).Msg("failed to retrieve PR reviews")
+	}
+
+	merged := false
+	if pull.GetState() == "closed" {
+		merged, err = isGithubPRMerged(githubClient, r.Owner, r.Name, pull.GetNumber())
+		if err != nil {
+			logger.Warn().Err(err).Msg("failed to retrieve PR merged status")
+		}
+	}
+
+	c.cloud.run.reviewRequest = c.newReviewRequest(pull, reviews, checks, merged)
+}
+
+func getGithubPRByNumberOrCommit(githubClient *github.Client, ghToken, owner, repo string, number int, commit string) (*github.PullRequest, error) {
+	logger := log.With().
+		Str("github_repository", owner+"/"+repo).
+		Str("commit", commit).
+		Logger()
+
+	if number != 0 {
+		// fetch by number
+		pull, err := getGithubPRByNumber(githubClient, owner, repo, number)
+		if err != nil {
+			return nil, err
+		}
+		return pull, nil
+	}
+
+	// fetch by commit
+	pull, found, err := getGithubPRByCommit(githubClient, owner, repo, commit)
+	if err != nil {
 		if errors.IsKind(err, githubErrNotFound) {
 			if ghToken == "" {
 				logger.Warn().Msg("The GITHUB_TOKEN environment variable needs to be exported for private repositories.")
@@ -554,7 +580,14 @@ func (c *cli) detectCloudMetadata() {
 				Err(err).
 				Msg("failed to retrieve pull requests associated with HEAD")
 		}
+		return nil, err
 	}
+	if !found {
+		logger.Warn().Msg("no pull request associated with HEAD commit")
+		return nil, err
+	}
+
+	return pull, nil
 }
 
 func getGithubCommit(ghClient *github.Client, owner, repo, commit string) (*github.RepositoryCommit, error) {
@@ -569,8 +602,21 @@ func getGithubCommit(ghClient *github.Client, owner, repo, commit string) (*gith
 	return rcommit, nil
 }
 
+func getGithubPRByNumber(ghClient *github.Client, owner string, repo string, number int) (*github.PullRequest, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultGithubTimeout)
+	defer cancel()
+
+	pull, _, err := ghClient.PullRequests.Get(ctx, owner, repo, number)
+	if err != nil {
+		return nil, err
+	}
+
+	return pull, nil
+
+}
+
 // returns nil, nil if there was no PR associated with commit
-func getGithubPR(ghClient *github.Client, owner, repo, commit string) (*github.PullRequest, bool, error) {
+func getGithubPRByCommit(ghClient *github.Client, owner, repo, commit string) (*github.PullRequest, bool, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultGithubTimeout)
 	defer cancel()
 

--- a/cmd/terramate/cli/github/event.go
+++ b/cmd/terramate/cli/github/event.go
@@ -6,60 +6,30 @@ package github
 import (
 	"encoding/json"
 	"os"
-	"time"
 
+	"github.com/google/go-github/v58/github"
 	"github.com/terramate-io/terramate/errors"
 )
 
-type eventPullRequest struct {
-	UpdatedAt *time.Time `json:"updated_at"`
-}
-type event struct {
-	PullRequest *eventPullRequest `json:"pull_request"`
-}
+// GetEventPR returns the pull request event from the file at GITHUB_EVENT_PATH.
+func GetEventPR() (*github.PullRequest, error) {
+	githubEventPath, ok := os.LookupEnv("GITHUB_EVENT_PATH")
+	if !ok {
+		return nil, errors.E("missing GITHUB_EVENT_PATH")
+	}
 
-// GetEventPRUpdatedAt returns the updated_at field from the file at `eventPath`.
-// The file is expected to be a JSON file containing the GitHub event for a pull
-// request.
-func GetEventPRUpdatedAt(eventPath string) (*time.Time, error) {
-	event, err := getEventFromPath(eventPath)
+	data, err := os.ReadFile(githubEventPath)
 	if err != nil {
 		return nil, err
 	}
-
-	if err := event.validate(); err != nil {
+	var event github.PullRequestEvent
+	if err := json.Unmarshal(data, &event); err != nil {
 		return nil, err
 	}
 
-	return event.PullRequest.UpdatedAt, nil
-}
-
-func (e *event) validate() error {
-	if e == nil {
-		return errors.E("missing `event` in github event")
+	if event.PullRequest == nil {
+		return nil, errors.E("event does not contain a pull request")
 	}
 
-	if e.PullRequest == nil {
-		return errors.E("missing `pull_request` in github event")
-	}
-
-	if e.PullRequest.UpdatedAt == nil {
-		return errors.E("missing `pull_request.updated_at` in github event")
-	}
-
-	return nil
-}
-
-func getEventFromPath(eventPath string) (*event, error) {
-	bytes, err := os.ReadFile(eventPath)
-	if err != nil {
-		return nil, err
-	}
-
-	var parsedEvent event
-	if err := json.Unmarshal(bytes, &parsedEvent); err != nil {
-		return nil, err
-	}
-
-	return &parsedEvent, nil
+	return event.PullRequest, nil
 }


### PR DESCRIPTION
## What this PR does / why we need it:

Read PR information from the GHA pull_request event when available, otherwise
fall back to the Github API.

## Which issue(s) this PR fixes:

## Special notes for your reviewer:

The fallback only happens when building the ReviewRequest object in
detectCloudMetadata().

There is no fallback for `preview.updated_at`.

## Does this PR introduce a user-facing change?
```
No.
```
