### PR TITLE
fix(prefix): set preview status failed when plan fails.

### DIFF
--- a/cmd/terramate/cli/cloud.go
+++ b/cmd/terramate/cli/cloud.go
@@ -320,6 +320,13 @@ func (c *cli) doPreviewAfter(run stackCloudRun, res runResult) {
 			printer.Stderr.WarnWithDetails(
 				sprintf("skipping terraform plan sync for %s", run.Stack.Dir.String()),
 				err)
+
+			printer.Stderr.Warn(
+				sprintf("preview status set to \"failed\" (previously %q) due to failure when generating the "+
+					"changeset details", previewStatus),
+			)
+
+			previewStatus = preview.StackStatusFailed
 		}
 		if changeset != nil {
 			previewChangeset = &cloud.ChangesetDetails{


### PR DESCRIPTION
## What this PR does / why we need it:

Fix an issue in preview status that is not set to `failed` if the plan is not generated.

## Which issue(s) this PR fixes:

none

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
no because previews are not released
```
