### PR TITLE
chore(cloud): remove unused github.Client.

### DIFF
--- a/cmd/terramate/cli/cloud_credential_github.go
+++ b/cmd/terramate/cli/cloud_credential_github.go
@@ -109,8 +109,7 @@ func (g *githubOIDC) Refresh() (err error) {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultGithubTimeout)
 	defer cancel()
 
-	client := github.Client{}
-	token, err := client.OIDCToken(ctx, github.OIDCVars{
+	token, err := github.OIDCToken(ctx, github.OIDCVars{
 		ReqURL:   g.reqURL,
 		ReqToken: g.reqToken,
 	})


### PR DESCRIPTION
## What this PR does / why we need it:

The `github.Client.BaseURL`, `github.Client.Token` and `github.Client.httpClient` are unused since https://github.com/terramate-io/terramate/pull/1391
then the `github.Client` type is not needed anymore. Now we use the `go-github/v58/github.Client` for everything else.

## Which issue(s) this PR fixes:
none

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
no
```
