### PR TITLE
chore: log debug messages when creating preview

### DIFF
--- a/cmd/terramate/cli/cloud.go
+++ b/cmd/terramate/cli/cloud.go
@@ -303,12 +303,10 @@ func (c *cli) doPreviewBefore(run stackCloudRun) {
 		printer.Stderr.ErrorWithDetails("failed to update stack preview", err)
 		return
 	}
-	if !c.parsedArgs.Quiet {
-		printer.Stderr.Println(sprintf("terramate: stack:'%s' preview_status:%s",
-			run.Stack.Name,
-			preview.StackStatusRunning,
-		))
-	}
+	log.Debug().
+		Str("stack_name", run.Stack.Dir.String()).
+		Str("stack_preview_status", preview.StackStatusRunning.String()).
+		Msg("Setting stack preview status")
 }
 
 func (c *cli) doPreviewAfter(run stackCloudRun, res runResult) {
@@ -346,15 +344,14 @@ func (c *cli) doPreviewAfter(run stackCloudRun, res runResult) {
 		return
 	}
 
-	if !c.parsedArgs.Quiet {
-		msg := sprintf("terramate: stack:'%s' preview_status:%s",
-			run.Stack.Dir.String(),
-			previewStatus.String(),
-		)
-		if previewChangeset != nil {
-			msg = sprintf("%s (with changeset)", msg)
-		}
-		printer.Stderr.Println(msg)
+	logger := log.With().
+		Str("stack_name", run.Stack.Dir.String()).
+		Str("stack_preview_status", previewStatus.String()).
+		Logger()
+
+	logger.Debug().Msg("Setting stack preview status")
+	if previewChangeset != nil {
+		logger.Debug().Msg("Sending changelog")
 	}
 }
 
@@ -513,9 +510,9 @@ func (c *cli) detectCloudMetadata() {
 
 	pull, err := getGithubPRByNumberOrCommit(githubClient, ghToken, r.Owner, r.Name, prNumber, headCommit)
 	if err != nil {
-		printer.Stderr.WarnWithDetails(
-			sprintf("failed to retrieve pull request (number: %d, commit: %s)", prNumber, headCommit),
-			err)
+		logger.Debug().Err(err).
+			Int("number", prNumber).
+			Msg("failed to retrieve pull_request")
 		return
 	}
 

--- a/cmd/terramate/cli/run.go
+++ b/cmd/terramate/cli/run.go
@@ -327,6 +327,10 @@ func (c *cli) runAll(
 				printScriptCommand(c.stderr, run.Stack, task)
 			}
 
+			if !opts.Quiet && !opts.ScriptRun {
+				printer.Stderr.Println(printPrefix + " Entering stack in " + run.Stack.String())
+			}
+
 			c.cloudSyncBefore(cloudRun)
 
 			environ := newEnvironFrom(stackEnvs[run.Stack.Dir])
@@ -343,7 +347,6 @@ func (c *cli) runAll(
 			}
 
 			if !opts.Quiet && !opts.ScriptRun {
-				printer.Stderr.Println(printPrefix + " Entering stack in " + run.Stack.String())
 				printer.Stderr.Println(printPrefix + " Executing command " + strconv.Quote(cmdStr))
 			}
 


### PR DESCRIPTION
## What this PR does / why we need it:

* Use debug logs for printing stack preview status update messages.
* Use debug logs when a PR cannot be fetched
* Print the `Entering stack` messages before executing cloud sync logic.

## Which issue(s) this PR fixes:

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
No.
```
