### PR TITLE
fix(cloud): use repository filter in stacks listing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,8 @@ upgrading.
 - Fix `tm_dynamic.attributes` being wrapped many times leading to stack exhaustion when cloning expressions in projects with lots of stacks.
 - Stack ordering not respected in the `script run`.
 - Fix `script.job.command[s]` not handling (typed) lists.
+- Use `repository` filter when listing Terramate Cloud stacks.
+  - It makes the `--cloud-status=<status>` flag faster and potentially less brittle for cases where other repositories have issues.
 
 ## 0.4.4
 

--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -131,9 +131,10 @@ func (c *Client) MemberOrganizations(ctx context.Context) (orgs MemberOrganizati
 
 // StacksByStatus returns all stacks for the given organization.
 // It paginates as needed and returns the total stacks response.
-func (c *Client) StacksByStatus(ctx context.Context, orgUUID UUID, status stack.FilterStatus) ([]StackObject, error) {
+func (c *Client) StacksByStatus(ctx context.Context, orgUUID UUID, repository string, status stack.FilterStatus) ([]StackObject, error) {
 	path := path.Join(StacksPath, string(orgUUID))
 	query := url.Values{}
+	query.Set("repository", repository)
 	if status != stack.NoFilter {
 		query.Set("status", status.String())
 	}

--- a/cloud/cloud_test.go
+++ b/cloud/cloud_test.go
@@ -155,7 +155,12 @@ func TestCommonAPIFailCases(t *testing.T) {
 				ctx, cancel := context.WithTimeout(context.Background(), timeout)
 				defer cancel()
 
-				_, err := sdk.StacksByStatus(ctx, "e4c81294-dcf8-45e2-ba95-25f96514a61b", stack.NoFilter)
+				_, err := sdk.StacksByStatus(
+					ctx,
+					"e4c81294-dcf8-45e2-ba95-25f96514a61b",
+					"dummy/repo",
+					stack.NoFilter,
+				)
 				errtest.Assert(t, err, tc.err)
 			}()
 		})
@@ -514,7 +519,7 @@ func TestCloudStacks(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), timeout)
 			defer cancel()
 
-			stacksResp, err := sdk.StacksByStatus(ctx, cloud.UUID(tc.org), tc.filter)
+			stacksResp, err := sdk.StacksByStatus(ctx, cloud.UUID(tc.org), "dummy/repo", tc.filter)
 			errtest.Assert(t, err, tc.want.err)
 			if err != nil {
 				return

--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -1177,16 +1177,14 @@ func (c *cli) listStacks(isChanged bool, status cloudstack.FilterStatus) (*stack
 
 		ctx, cancel := context.WithTimeout(context.Background(), defaultCloudTimeout)
 		defer cancel()
-		cloudStacks, err := c.cloud.client.StacksByStatus(ctx, c.cloud.run.orgUUID, status)
+		cloudStacks, err := c.cloud.client.StacksByStatus(ctx, c.cloud.run.orgUUID, repository, status)
 		if err != nil {
 			return nil, err
 		}
 
 		cloudStacksMap := map[string]bool{}
 		for _, stack := range cloudStacks {
-			if stack.Repository == repository {
-				cloudStacksMap[stack.MetaID] = true
-			}
+			cloudStacksMap[stack.MetaID] = true
 		}
 
 		localStacks := report.Stacks


### PR DESCRIPTION
## What this PR does / why we need it:

The filtering of stacks by repo is implemented client side instead of using the API filter.
This will make the `--cloud-status` flag faster and less brittle (atm it fails in the case other repositories are returning non-conformant `drift_status`).

## Which issue(s) this PR fixes:
none

## Special notes for your reviewer:

This PR targets `v0.5.0` but I will make another PR backporting it to `v0.4.6`.

## Does this PR introduce a user-facing change?
```
no
```
