### PR TITLE
chore(gha): upgrade MacOS matrix versions.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
 
     strategy:
       matrix:
-        os: ["ubuntu-20.04", "macos-11", "macos-12"]
+        os: ["ubuntu-20.04", "macos-12", "macos-13"]
         go: ["1.21"]
 
     steps:


### PR DESCRIPTION
## What this PR does / why we need it:

MacOS 11 tests are becoming too slow.

## Which issue(s) this PR fixes:
none

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
no
```
