### PR TITLE
fix(tmc): --cloud-status feature overwrite deployment UUID.

### DIFF
--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -202,6 +202,9 @@ func (c *Client) CreateDeploymentStacks(
 	deploymentUUID UUID,
 	deploymentStacksPayload DeploymentStacksPayloadRequest,
 ) (DeploymentStacksResponse, error) {
+	if deploymentUUID == "" {
+		panic(errors.E(errors.ErrInternal, "deploymentUUID must not be empty"))
+	}
 	err := deploymentStacksPayload.Validate()
 	if err != nil {
 		return DeploymentStacksResponse{}, errors.E(err, "failed to prepare the request")

--- a/cmd/terramate/cli/cloud.go
+++ b/cmd/terramate/cli/cloud.go
@@ -845,15 +845,13 @@ func (c *cli) loadCredential() error {
 		Str("tmc_url", cloudURL).
 		Logger()
 
-	c.cloud = cloudConfig{
-		client: &cloud.Client{
-			BaseURL:    cloudURL,
-			IDPKey:     idpkey(),
-			HTTPClient: &c.httpClient,
-			Logger:     &clientLogger,
-		},
-		output: c.output,
+	c.cloud.client = &cloud.Client{
+		BaseURL:    cloudURL,
+		IDPKey:     idpkey(),
+		HTTPClient: &c.httpClient,
+		Logger:     &clientLogger,
 	}
+	c.cloud.output = c.output
 
 	// checks if this client version can communicate with Terramate Cloud.
 	ctx, cancel := context.WithTimeout(context.Background(), defaultCloudTimeout)


### PR DESCRIPTION
## What this PR does / why we need it:

When using `--cloud-sync-deployment` and `--cloud-status` the latter flag reset the `c.cloud` field and then losing the computed deployment UUID.

## Which issue(s) this PR fixes:
none

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
no because --cloud-status with run is not released.
But v0.5.0 release candidates are unable to create deployments with `--cloud-status` flag set.
```
