### PR TITLE
chore: remove git safeguards from list

### DIFF
--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -1602,7 +1602,6 @@ func (c *cli) printStacks() {
 	if err != nil {
 		fatal("Unable to list stacks", err)
 	}
-	c.gitFileSafeguards(false)
 
 	c.printStacksList(report.Stacks, c.parsedArgs.List.Why, c.parsedArgs.List.RunOrder)
 }


### PR DESCRIPTION
## What this PR does / why we need it:

Remove git safeguards warnings from `terramate list` command.

## Which issue(s) this PR fixes:

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
Yes, the git safeguard warnings from `terramate list` have been removed.

```
