### PR TITLE
chore: add basic tests for metadata.

### DIFF
--- a/cloud/testserver/deployments.go
+++ b/cloud/testserver/deployments.go
@@ -57,6 +57,14 @@ func PostDeployment(store *cloudstore.Data, w http.ResponseWriter, r *http.Reque
 		return
 	}
 
+	// NOTE(i4k): The metadata is not required but must be present in all test cases.
+	err = validateMetadata(rPayload.Metadata)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		writeErr(w, err)
+		return
+	}
+
 	stackCommands := map[string]string{}
 
 	// deployment commit_sha is not required but must be present in all test cases.

--- a/cloud/testserver/drifts.go
+++ b/cloud/testserver/drifts.go
@@ -88,6 +88,13 @@ func PostDrift(store *cloudstore.Data, w http.ResponseWriter, r *http.Request, p
 		return
 	}
 
+	// NOTE(i4k): metadata is not required but must be present in all test cases
+	if err := validateMetadata(payload.Metadata); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		writeErr(w, err)
+		return
+	}
+
 	st, _, found := store.GetStackByMetaID(org, payload.Stack.MetaID)
 	if !found {
 		st = cloudstore.Stack{

--- a/cloud/testserver/metadata.go
+++ b/cloud/testserver/metadata.go
@@ -1,0 +1,42 @@
+// Copyright 2024 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+package testserver
+
+import (
+	"github.com/terramate-io/terramate/cloud"
+	"github.com/terramate-io/terramate/errors"
+)
+
+func validateMetadata(metadata *cloud.DeploymentMetadata) error {
+	if metadata == nil {
+		return errors.E("metadata is required")
+	}
+	// at least git metadata must be present
+	if err := validateGitMetadata(metadata.GitMetadata); err != nil {
+		return errors.E(err, "validating git metadata")
+	}
+	return nil
+}
+
+func validateGitMetadata(metadata cloud.GitMetadata) error {
+	if metadata.GitCommitSHA == "" {
+		return errors.E(`field "git_commit_sha" is required`)
+	}
+	if metadata.GitCommitTitle == "" {
+		return errors.E(`field "git_commit_title" is required`)
+	}
+
+	// NOTE(i4k): The "git_commit_description" is not validated because it can be empty.
+
+	if metadata.GitCommitAuthorName == "" {
+		return errors.E(`field "git_commit_author_name" is required`)
+	}
+	if metadata.GitCommitAuthorEmail == "" {
+		return errors.E(`field "git_commit_author_email" is required`)
+	}
+	if metadata.GitCommitAuthorTime == nil || metadata.GitCommitAuthorTime.IsZero() {
+		return errors.E(`field "git_commit_author_time" is required`)
+	}
+	return nil
+}

--- a/cloud/types.go
+++ b/cloud/types.go
@@ -154,12 +154,7 @@ type (
 	// It's marshaled as a flat hashmap of values.
 	// Note: no sensitive information must be stored here because it could be logged.
 	DeploymentMetadata struct {
-		GitCommitSHA         string     `json:"git_commit_sha,omitempty"`
-		GitCommitAuthorName  string     `json:"git_commit_author_name,omitempty"`
-		GitCommitAuthorEmail string     `json:"git_commit_author_email,omitempty"`
-		GitCommitAuthorTime  *time.Time `json:"git_commit_author_time,omitempty"`
-		GitCommitTitle       string     `json:"git_commit_title,omitempty"`
-		GitCommitDescription string     `json:"git_commit_description,omitempty"`
+		GitMetadata
 
 		GithubPullRequestAuthorLogin      string `json:"github_pull_request_author_login,omitempty"`
 		GithubPullRequestAuthorAvatarURL  string `json:"github_pull_request_author_avatar_url,omitempty"`
@@ -216,6 +211,16 @@ type (
 		GithubActionsRunAttempt            string `json:"github_actions_run_attempt,omitempty"`
 		GithubActionsWorkflowName          string `json:"github_actions_workflow_name,omitempty"`
 		GithubActionsWorkflowRef           string `json:"github_actions_workflow_ref,omitempty"`
+	}
+
+	// GitMetadata are the git related metadata.
+	GitMetadata struct {
+		GitCommitSHA         string     `json:"git_commit_sha,omitempty"`
+		GitCommitAuthorName  string     `json:"git_commit_author_name,omitempty"`
+		GitCommitAuthorEmail string     `json:"git_commit_author_email,omitempty"`
+		GitCommitAuthorTime  *time.Time `json:"git_commit_author_time,omitempty"`
+		GitCommitTitle       string     `json:"git_commit_title,omitempty"`
+		GitCommitDescription string     `json:"git_commit_description,omitempty"`
 	}
 
 	// ReviewRequest is the review_request object.

--- a/cmd/terramate/cli/cloud.go
+++ b/cmd/terramate/cli/cloud.go
@@ -444,7 +444,9 @@ func (c *cli) detectCloudMetadata() {
 
 	headCommit := c.prj.headCommit()
 
-	c.cloud.run.metadata = &cloud.DeploymentMetadata{GitCommitSHA: headCommit}
+	c.cloud.run.metadata = &cloud.DeploymentMetadata{}
+	c.cloud.run.metadata.GitCommitSHA = headCommit
+
 	md := c.cloud.run.metadata
 
 	defer func() {

--- a/cmd/terramate/e2etests/cloud/run_cloud_config_test.go
+++ b/cmd/terramate/e2etests/cloud/run_cloud_config_test.go
@@ -83,9 +83,6 @@ func TestCloudConfig(t *testing.T) {
 					}
 				}`,
 			},
-			want: RunExpected{
-				Status: 0,
-			},
 		},
 		{
 			name: "cloud organization env var overrides value from config",
@@ -178,8 +175,13 @@ func TestCloudConfig(t *testing.T) {
 			env = append(env, "TMC_API_URL=http://"+l.Addr().String())
 			tm := NewCLI(t, s.RootDir(), env...)
 
+			// This is required for collecting basic git metadata
+			// NOTE(i4k): As the repo is not real, this requires passing --disable-safeguards=git-out-of-sync
+			s.Git().SetRemoteURL("origin", testRemoteRepoURL)
+
 			cmd := []string{
 				"run",
+				"--disable-safeguards=git-out-of-sync",
 				"--quiet",
 				"--cloud-sync-deployment",
 				"--", HelperPath, "true",

--- a/cmd/terramate/e2etests/cloud/run_cloud_drift_test.go
+++ b/cmd/terramate/e2etests/cloud/run_cloud_drift_test.go
@@ -34,6 +34,18 @@ type expectedDriftStackPayloadRequest struct {
 	ChangesetASCIIRegexes []string
 }
 
+var expectedMetadata *cloud.DeploymentMetadata
+
+func init() {
+	expectedMetadata = &cloud.DeploymentMetadata{
+		GitMetadata: cloud.GitMetadata{
+			GitCommitAuthorName:  "terramate tests",
+			GitCommitAuthorEmail: "terramate@mineiros.io",
+			GitCommitTitle:       "all stacks committed",
+		},
+	}
+}
+
 func TestCLIRunWithCloudSyncDriftStatus(t *testing.T) {
 	t.Parallel()
 	type want struct {
@@ -81,13 +93,14 @@ func TestCLIRunWithCloudSyncDriftStatus(t *testing.T) {
 					{
 						DriftStackPayloadRequest: cloud.DriftStackPayloadRequest{
 							Stack: cloud.Stack{
-								Repository:    "local",
+								Repository:    normalizedTestRemoteRepo,
 								DefaultBranch: "main",
 								Path:          "/stack",
 								MetaName:      "stack",
 								MetaID:        "stack",
 							},
-							Status: drift.Failed,
+							Status:   drift.Failed,
+							Metadata: expectedMetadata,
 						},
 					},
 				},
@@ -109,19 +122,19 @@ func TestCLIRunWithCloudSyncDriftStatus(t *testing.T) {
 					{
 						DriftStackPayloadRequest: cloud.DriftStackPayloadRequest{
 							Stack: cloud.Stack{
-								Repository:    "local",
+								Repository:    normalizedTestRemoteRepo,
 								DefaultBranch: "main",
 								Path:          "/s1",
 								MetaName:      "s1",
 								MetaID:        "s1",
 							},
-							Status: drift.Failed,
+							Status:   drift.Failed,
+							Metadata: expectedMetadata,
 						},
 					},
 				},
 			},
 		},
-
 		{
 			name: "both failed stacks and continueOnError",
 			layout: []string{
@@ -139,25 +152,27 @@ func TestCLIRunWithCloudSyncDriftStatus(t *testing.T) {
 					{
 						DriftStackPayloadRequest: cloud.DriftStackPayloadRequest{
 							Stack: cloud.Stack{
-								Repository:    "local",
+								Repository:    normalizedTestRemoteRepo,
 								DefaultBranch: "main",
 								Path:          "/s1",
 								MetaName:      "s1",
 								MetaID:        "s1",
 							},
-							Status: drift.Failed,
+							Status:   drift.Failed,
+							Metadata: expectedMetadata,
 						},
 					},
 					{
 						DriftStackPayloadRequest: cloud.DriftStackPayloadRequest{
 							Stack: cloud.Stack{
-								Repository:    "local",
+								Repository:    normalizedTestRemoteRepo,
 								DefaultBranch: "main",
 								Path:          "/s1/s2",
 								MetaName:      "s2",
 								MetaID:        "s2",
 							},
-							Status: drift.Failed,
+							Status:   drift.Failed,
+							Metadata: expectedMetadata,
 						},
 					},
 				},
@@ -182,25 +197,27 @@ func TestCLIRunWithCloudSyncDriftStatus(t *testing.T) {
 					{
 						DriftStackPayloadRequest: cloud.DriftStackPayloadRequest{
 							Stack: cloud.Stack{
-								Repository:    "local",
+								Repository:    normalizedTestRemoteRepo,
 								DefaultBranch: "main",
 								Path:          "/s1",
 								MetaName:      "s1",
 								MetaID:        "s1",
 							},
-							Status: drift.Failed,
+							Status:   drift.Failed,
+							Metadata: expectedMetadata,
 						},
 					},
 					{
 						DriftStackPayloadRequest: cloud.DriftStackPayloadRequest{
 							Stack: cloud.Stack{
-								Repository:    "local",
+								Repository:    normalizedTestRemoteRepo,
 								DefaultBranch: "main",
 								Path:          "/s1/s2",
 								MetaName:      "s2",
 								MetaID:        "s2",
 							},
-							Status: drift.OK,
+							Status:   drift.OK,
+							Metadata: expectedMetadata,
 						},
 					},
 				},
@@ -217,13 +234,14 @@ func TestCLIRunWithCloudSyncDriftStatus(t *testing.T) {
 					{
 						DriftStackPayloadRequest: cloud.DriftStackPayloadRequest{
 							Stack: cloud.Stack{
-								Repository:    "local",
+								Repository:    normalizedTestRemoteRepo,
 								DefaultBranch: "main",
 								Path:          "/stack",
 								MetaName:      "stack",
 								MetaID:        "stack",
 							},
-							Status: drift.Drifted,
+							Status:   drift.Drifted,
+							Metadata: expectedMetadata,
 						},
 					},
 				},
@@ -247,13 +265,14 @@ func TestCLIRunWithCloudSyncDriftStatus(t *testing.T) {
 					{
 						DriftStackPayloadRequest: cloud.DriftStackPayloadRequest{
 							Stack: cloud.Stack{
-								Repository:    "local",
+								Repository:    normalizedTestRemoteRepo,
 								DefaultBranch: "main",
 								Path:          "/parent/child",
 								MetaName:      "child",
 								MetaID:        "child",
 							},
-							Status: drift.OK,
+							Status:   drift.OK,
+							Metadata: expectedMetadata,
 						},
 					},
 				},
@@ -271,25 +290,27 @@ func TestCLIRunWithCloudSyncDriftStatus(t *testing.T) {
 					{
 						DriftStackPayloadRequest: cloud.DriftStackPayloadRequest{
 							Stack: cloud.Stack{
-								Repository:    "local",
+								Repository:    normalizedTestRemoteRepo,
 								DefaultBranch: "main",
 								Path:          "/s1",
 								MetaName:      "s1",
 								MetaID:        "s1",
 							},
-							Status: drift.Drifted,
+							Status:   drift.Drifted,
+							Metadata: expectedMetadata,
 						},
 					},
 					{
 						DriftStackPayloadRequest: cloud.DriftStackPayloadRequest{
 							Stack: cloud.Stack{
-								Repository:    "local",
+								Repository:    normalizedTestRemoteRepo,
 								DefaultBranch: "main",
 								Path:          "/s1/s2",
 								MetaName:      "s2",
 								MetaID:        "s2",
 							},
-							Status: drift.Drifted,
+							Status:   drift.Drifted,
+							Metadata: expectedMetadata,
 						},
 					},
 				},
@@ -314,13 +335,14 @@ func TestCLIRunWithCloudSyncDriftStatus(t *testing.T) {
 					{
 						DriftStackPayloadRequest: cloud.DriftStackPayloadRequest{
 							Stack: cloud.Stack{
-								Repository:    "local",
+								Repository:    normalizedTestRemoteRepo,
 								DefaultBranch: "main",
 								Path:          "/s1",
 								MetaName:      "s1",
 								MetaID:        "s1",
 							},
-							Status: drift.Drifted,
+							Status:   drift.Drifted,
+							Metadata: expectedMetadata,
 						},
 					},
 				},
@@ -346,13 +368,14 @@ func TestCLIRunWithCloudSyncDriftStatus(t *testing.T) {
 					{
 						DriftStackPayloadRequest: cloud.DriftStackPayloadRequest{
 							Stack: cloud.Stack{
-								Repository:    "local",
+								Repository:    normalizedTestRemoteRepo,
 								DefaultBranch: "main",
 								Path:          "/s1",
 								MetaName:      "s1",
 								MetaID:        "s1",
 							},
-							Status: drift.Drifted,
+							Status:   drift.Drifted,
+							Metadata: expectedMetadata,
 						},
 					},
 				},
@@ -388,7 +411,7 @@ func TestCLIRunWithCloudSyncDriftStatus(t *testing.T) {
 					{
 						DriftStackPayloadRequest: cloud.DriftStackPayloadRequest{
 							Stack: cloud.Stack{
-								Repository:    "local",
+								Repository:    normalizedTestRemoteRepo,
 								DefaultBranch: "main",
 								Path:          "/s1",
 								MetaName:      "s1",
@@ -399,6 +422,7 @@ func TestCLIRunWithCloudSyncDriftStatus(t *testing.T) {
 								Provisioner:   "terraform",
 								ChangesetJSON: loadJSONPlan(t, "testdata/cloud-sync-drift-plan-file/sanitized.plan.json"),
 							},
+							Metadata: expectedMetadata,
 						},
 						ChangesetASCIIRegexes: []string{
 							`Terraform used the selected providers to generate the following execution`,
@@ -408,7 +432,7 @@ func TestCLIRunWithCloudSyncDriftStatus(t *testing.T) {
 					{
 						DriftStackPayloadRequest: cloud.DriftStackPayloadRequest{
 							Stack: cloud.Stack{
-								Repository:    "local",
+								Repository:    normalizedTestRemoteRepo,
 								DefaultBranch: "main",
 								Path:          "/s1/s2",
 								MetaName:      "s2",
@@ -419,6 +443,7 @@ func TestCLIRunWithCloudSyncDriftStatus(t *testing.T) {
 								Provisioner:   "terraform",
 								ChangesetJSON: loadJSONPlan(t, "testdata/cloud-sync-drift-plan-file/sanitized.plan.json"),
 							},
+							Metadata: expectedMetadata,
 						},
 						ChangesetASCIIRegexes: []string{
 							`Terraform used the selected providers to generate the following execution`,
@@ -449,13 +474,14 @@ func TestCLIRunWithCloudSyncDriftStatus(t *testing.T) {
 					{
 						DriftStackPayloadRequest: cloud.DriftStackPayloadRequest{
 							Stack: cloud.Stack{
-								Repository:    "local",
+								Repository:    normalizedTestRemoteRepo,
 								DefaultBranch: "trunk",
 								Path:          "/stack",
 								MetaName:      "stack",
 								MetaID:        "stack",
 							},
-							Status: drift.Drifted,
+							Status:   drift.Drifted,
+							Metadata: expectedMetadata,
 						},
 					},
 				},
@@ -497,7 +523,13 @@ func TestCLIRunWithCloudSyncDriftStatus(t *testing.T) {
 				env = append(env, "TMC_API_URL=http://"+addr)
 				cli := NewCLI(t, filepath.Join(s.RootDir(), filepath.FromSlash(tc.workingDir)), env...)
 				cli.PrependToPath(filepath.Dir(TerraformTestPath))
-				runflags := []string{"run", "--quiet", "--cloud-sync-drift-status"}
+				s.Git().SetRemoteURL("origin", testRemoteRepoURL)
+				runflags := []string{
+					"run",
+					"--disable-safeguards=git-out-of-sync",
+					"--quiet",
+					"--cloud-sync-drift-status",
+				}
 				if isParallel {
 					runflags = append(runflags, "--parallel")
 					tc.want.run.IgnoreStdout = true
@@ -529,18 +561,23 @@ func assertRunDrifts(t *testing.T, cloudData *cloudstore.Data, tmcAddr string, e
 	assert.NoError(t, err)
 
 	if len(expectedDrifts) != len(res) {
-		t.Errorf("expected %d drifts but found %d: %+v", len(expectedDrifts), len(res), res)
+		t.Fatalf("expected %d drifts but found %d: %+v", len(expectedDrifts), len(res), res)
 	}
 
 	for i, expected := range expectedDrifts {
 		got := res[i]
-		// TODO(i4k): skip checking interpolated commands for now because of the hack
-		// for making the --eval work with the helper binary in a portable way.
-		// We can't portably predict the command because when using --eval the
-		// whole argument list is interpolated, including the program name, and then
-		// on Windows it requires a special escaped string.
-		// See variable `HelperPathAsHCL`.
-		if diff := cmp.Diff(got, expected.DriftStackPayloadRequest, cmpopts.IgnoreFields(cloud.DriftStackPayloadRequest{}, "Command", "Details", "StartedAt", "FinishedAt")); diff != "" {
+		if diff := cmp.Diff(got, expected.DriftStackPayloadRequest,
+			// Ignore hard to predict fields
+			// They are validated (for existence) in the testserver anyway.
+			cmpopts.IgnoreFields(cloud.GitMetadata{}, "GitCommitSHA", "GitCommitAuthorTime"),
+
+			// TODO(i4k): skip checking interpolated commands for now because of the hack
+			// for making the --eval work with the helper binary in a portable way.
+			// We can't portably predict the command because when using --eval the
+			// whole argument list is interpolated, including the program name, and then
+			// on Windows it requires a special escaped string.
+			// See variable `HelperPathAsHCL`.
+			cmpopts.IgnoreFields(cloud.DriftStackPayloadRequest{}, "Command", "Details", "StartedAt", "FinishedAt")); diff != "" {
 			t.Logf("want: %+v", expectedDrifts)
 			t.Logf("got: %+v", got)
 			t.Fatal(diff)

--- a/cmd/terramate/e2etests/cloud/run_cloud_signal_test.go
+++ b/cmd/terramate/e2etests/cloud/run_cloud_signal_test.go
@@ -120,7 +120,12 @@ func TestCLIRunWithCloudSyncDeploymentWithSignals(t *testing.T) {
 				runid := uuid.String()
 				cli.AppendEnv = []string{"TM_TEST_RUN_ID=" + runid}
 
-				runflags := []string{"--cloud-sync-deployment"}
+				s.Git().SetRemoteURL("origin", testRemoteRepoURL)
+
+				runflags := []string{
+					"--disable-safeguards=git-out-of-sync",
+					"--cloud-sync-deployment",
+				}
 				if isParallel {
 					runflags = append(runflags, "--parallel")
 					tc.want.run.IgnoreStdout = true
@@ -181,13 +186,14 @@ func TestCLIRunWithCloudSyncDriftStatusWithSignals(t *testing.T) {
 					{
 						DriftStackPayloadRequest: cloud.DriftStackPayloadRequest{
 							Stack: cloud.Stack{
-								Repository:    "local",
+								Repository:    normalizedTestRemoteRepo,
 								DefaultBranch: "main",
 								Path:          "/s1",
 								MetaName:      "s1",
 								MetaID:        "s1",
 							},
-							Status: drift.Failed,
+							Status:   drift.Failed,
+							Metadata: expectedMetadata,
 						},
 					},
 				},
@@ -215,7 +221,11 @@ func TestCLIRunWithCloudSyncDriftStatusWithSignals(t *testing.T) {
 				env = append(env, "TMC_API_URL=http://"+addr)
 
 				cli := NewCLI(t, filepath.Join(s.RootDir(), filepath.FromSlash(tc.workingDir)), env...)
-				runflags := []string{"--cloud-sync-drift-status"}
+				s.Git().SetRemoteURL("origin", testRemoteRepoURL)
+				runflags := []string{
+					"--disable-safeguards=git-out-of-sync",
+					"--cloud-sync-drift-status",
+				}
 				if isParallel {
 					runflags = append(runflags, "--parallel")
 					tc.want.run.IgnoreStdout = true

--- a/cmd/terramate/e2etests/cloud/run_cloud_uimode_test.go
+++ b/cmd/terramate/e2etests/cloud/run_cloud_uimode_test.go
@@ -1323,6 +1323,13 @@ func TestCloudSyncUIMode(t *testing.T) {
 					}
 					s.BuildTree(layout)
 					s.Git().CommitAll("created stacks")
+					if subcase.cmd[0] == "run" {
+						// allows for testing the metadata collection.
+						s.Git().SetRemoteURL("origin", testRemoteRepoURL)
+						cmd := []string{"run", "--disable-safeguards=git-out-of-sync"}
+						cmd = append(cmd, subcase.cmd[1:]...)
+						subcase.cmd = cmd
+					}
 					tm := NewCLI(t, s.RootDir(), env...)
 					tm.LogLevel = zerolog.WarnLevel.String()
 					AssertRunResult(t, tm.Run(subcase.cmd...), subcase.want)


### PR DESCRIPTION
## What this PR does / why we need it:

The `metadata` is optional but we were lacking tests for their collection in Terramate.
This improves the situation by checking for at least the `git` metadata in the testserver.
Note: this does not change Terramate behavior, just tests.

## Which issue(s) this PR fixes:
none

## Special notes for your reviewer:

In order to enable the metadata collection we need to set a remote git URL but it cannot be a `github.com` url because if so it will try to collect Github metadata and fail.


## Does this PR introduce a user-facing change?
```
no
```
