### PR TITLE
chore: fix github event tests for Windows.

### DIFF
--- a/cmd/terramate/cli/github/event.go
+++ b/cmd/terramate/cli/github/event.go
@@ -11,24 +11,31 @@ import (
 	"github.com/terramate-io/terramate/errors"
 )
 
+// Errors for when the GitHub event cannot be read.
+const (
+	ErrGithubEventPathEnvNotSet errors.Kind = `environment variable "GITHUB_EVENT_PATH" not set`
+	ErrGithubEventUnmarshal     errors.Kind = "failed to unmarshal github event"
+	ErrGithubEventMissingPR     errors.Kind = "event does not contain a pull request"
+)
+
 // GetEventPR returns the pull request event from the file at GITHUB_EVENT_PATH.
 func GetEventPR() (*github.PullRequest, error) {
 	githubEventPath, ok := os.LookupEnv("GITHUB_EVENT_PATH")
 	if !ok {
-		return nil, errors.E("missing GITHUB_EVENT_PATH")
+		return nil, errors.E(ErrGithubEventPathEnvNotSet)
 	}
 
 	data, err := os.ReadFile(githubEventPath)
 	if err != nil {
-		return nil, err
+		return nil, errors.E(err, "failed to read event file")
 	}
 	var event github.PullRequestEvent
 	if err := json.Unmarshal(data, &event); err != nil {
-		return nil, err
+		return nil, errors.E(ErrGithubEventUnmarshal, err)
 	}
 
 	if event.PullRequest == nil {
-		return nil, errors.E("event does not contain a pull request")
+		return nil, errors.E(ErrGithubEventMissingPR)
 	}
 
 	return event.PullRequest, nil

--- a/cmd/terramate/cli/github/event_test.go
+++ b/cmd/terramate/cli/github/event_test.go
@@ -1,14 +1,18 @@
 // Copyright 2024 Terramate GmbH
 // SPDX-License-Identifier: MPL-2.0
 
-package github
+package github_test
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/madlambda/spells/assert"
+	"github.com/terramate-io/terramate/cmd/terramate/cli/github"
 	"github.com/terramate-io/terramate/errors"
+	"github.com/terramate-io/terramate/test"
+	errtest "github.com/terramate-io/terramate/test/errors"
 )
 
 const validGithubEventPath = "./testdata/event_pull_request.json"
@@ -24,6 +28,8 @@ func TestGetEventPR(t *testing.T) {
 		headSHA   string
 		draft     bool
 	}
+
+	nonExistentEventFile := filepath.Join(test.NonExistingDir(t), "event_pull_request.json")
 
 	type testcase struct {
 		name string
@@ -50,17 +56,17 @@ func TestGetEventPR(t *testing.T) {
 		{
 			name: "non existent path",
 			env: map[string]string{
-				"GITHUB_EVENT_PATH": "/tmp/does-not-exist",
+				"GITHUB_EVENT_PATH": nonExistentEventFile,
 			},
 			want: want{
-				err: errors.E("open /tmp/does-not-exist: no such file or directory"),
+				err: os.ErrNotExist,
 			},
 		},
 		{
 			name: "missing env var",
 			env:  map[string]string{},
 			want: want{
-				err: errors.E("missing GITHUB_EVENT_PATH"),
+				err: errors.E(github.ErrGithubEventPathEnvNotSet),
 			},
 		},
 	}
@@ -70,13 +76,14 @@ func TestGetEventPR(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, tc := range testcases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			for k, v := range tc.env {
 				t.Setenv(k, v)
 			}
 
-			pull, err := GetEventPR()
-			assert.EqualErrs(t, tc.want.err, err)
+			pull, err := github.GetEventPR()
+			errtest.Assert(t, err, tc.want.err)
 
 			if tc.want.updatedAt != "" {
 				assert.EqualStrings(t, tc.want.updatedAt, pull.GetUpdatedAt().String())


### PR DESCRIPTION
## What this PR does / why we need it:

Fix failing test below:
```
--- FAIL: TestGetEventPR (0.00s)
    --- FAIL: TestGetEventPR/non_existent_path (0.00s)
        equal.go:123: wanted[open /tmp/does-not-exist: no such file or directory] but got[open /tmp/does-not-exist: The system cannot find the path specified.]
FAIL
```

It can be seen here (if still available): https://github.com/terramate-io/terramate/actions/runs/8072983613/job/22055794565?pr=1490

## Which issue(s) this PR fixes:
none

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
no
```
