### PR TITLE
refactor: move success exit handling to task

### DIFF
--- a/cmd/terramate/cli/script_run.go
+++ b/cmd/terramate/cli/script_run.go
@@ -107,11 +107,7 @@ func (c *cli) runScript() {
 
 	c.prepareScriptCloudDeploymentSync(runs)
 
-	isSuccessExit := func(exitCode int) bool {
-		return exitCode == 0
-	}
-
-	err := c.runAll(runs, isSuccessExit, runAllOptions{
+	err := c.runAll(runs, runAllOptions{
 		Quiet:           c.parsedArgs.Quiet,
 		DryRun:          c.parsedArgs.Script.Run.DryRun,
 		ScriptRun:       true,


### PR DESCRIPTION
## What this PR does / why we need it:

refactor: move success exit handling to task

The `isSuccessExit` is a property of an individual task, not of the runAll. This refactoring was identified while implementing the upcoming preview functionality in scripts.

## Which issue(s) this PR fixes:

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
No.

```
