### PR TITLE
feat: provides the preview url at /preview_url.txt

### DIFF
--- a/cloud/types.go
+++ b/cloud/types.go
@@ -287,6 +287,22 @@ type (
 		Message   string     `json:"message"`
 	}
 
+	// ReviewRequestResponsePayload is the review request response payload.
+	ReviewRequestResponsePayload struct {
+		ReviewRequests ReviewRequestResponses `json:"review_requests"`
+		Pagination     PaginatedResult        `json:"paginated_result"`
+	}
+
+	// ReviewRequestResponses is a list of review request responses.
+	ReviewRequestResponses []ReviewRequestResponse
+
+	// ReviewRequestResponse is the response payload for the review request creation.
+	ReviewRequestResponse struct {
+		ID        int64  `json:"review_request_id"`
+		CommitSHA string `json:"commit_sha"`
+		Number    int    `json:"number"`
+	}
+
 	// PaginatedResult represents the pagination object.
 	PaginatedResult struct {
 		Total   int64 `json:"total"`
@@ -332,8 +348,32 @@ var (
 	_ = Resource(CreatePreviewPayloadRequest{})
 	_ = Resource(CreatePreviewResponse{})
 	_ = Resource(UpdateStackPreviewPayloadRequest{})
+	_ = Resource(ReviewRequestResponse{})
+	_ = Resource(ReviewRequestResponses{})
+	_ = Resource(ReviewRequestResponsePayload{})
 	_ = Resource(EmptyResponse(""))
 )
+
+// Validate the review request response payload.
+func (rr ReviewRequestResponsePayload) Validate() error {
+	if err := rr.ReviewRequests.Validate(); err != nil {
+		return err
+	}
+	return rr.Pagination.Validate()
+}
+
+// Validate the ReviewRequestResponse object.
+func (rr ReviewRequestResponse) Validate() error {
+	if rr.ID == 0 {
+		return errors.E(`missing "review_request_id" field`)
+	}
+	return nil
+}
+
+// Validate the list of review request responses.
+func (rrs ReviewRequestResponses) Validate() error {
+	return validateResourceList(rrs...)
+}
 
 // String is a human readable list of organizations associated with a user.
 func (orgs MemberOrganizations) String() string {

--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -160,6 +160,7 @@ type cliSpec struct {
 		CloudSyncDeployment        bool   `default:"false" help:"Enable synchronization of stack execution with the Terramate Cloud"`
 		CloudSyncDriftStatus       bool   `default:"false" help:"Enable drift detection and synchronization with the Terramate Cloud"`
 		CloudSyncPreview           bool   `default:"false" help:"Enable synchronization of review request previews to Terramate Cloud"`
+		DebugPreviewURL            string `default:"" help:"Debug preview URL"`
 		CloudSyncTerraformPlanFile string `default:"" help:"Enable sync of Terraform plan file"`
 		ContinueOnError            bool   `default:"false" help:"Continue executing in other stacks in case of error"`
 		NoRecursive                bool   `default:"false" help:"Do not recurse into child stacks"`

--- a/cmd/terramate/cli/cloud.go
+++ b/cmd/terramate/cli/cloud.go
@@ -52,6 +52,7 @@ type cloudConfig struct {
 
 	run struct {
 		runUUID cloud.UUID
+		orgName string
 		orgUUID cloud.UUID
 
 		meta2id map[string]int64
@@ -182,6 +183,7 @@ func (c *cli) setupCloudConfig() error {
 	orgs := c.cred().organizations()
 
 	useOrgName := c.cloudOrgName()
+	c.cloud.run.orgName = useOrgName
 	if useOrgName != "" {
 		var useOrgUUID cloud.UUID
 		for _, org := range orgs {
@@ -253,6 +255,7 @@ func (c *cli) setupCloudConfig() error {
 			return cloudError()
 		}
 
+		c.cloud.run.orgName = activeOrgs[0].Name
 		c.cloud.run.orgUUID = activeOrgs[0].UUID
 	}
 	return nil

--- a/cmd/terramate/cli/github/event_test.go
+++ b/cmd/terramate/cli/github/event_test.go
@@ -44,8 +44,8 @@ func TestGetEventPR(t *testing.T) {
 				"GITHUB_EVENT_PATH": validGithubEventPath,
 			},
 			want: want{
-				htmlURL:   "https://github.com/someorg/somerepo/pull/8",
-				number:    8,
+				htmlURL:   "https://github.com/someorg/somerepo/pull/1494",
+				number:    1494,
 				title:     "envvar",
 				body:      "test",
 				headSHA:   "ea61b5bd72dec0878ae388b04d76a988439d1e28",

--- a/cmd/terramate/cli/github/testdata/event_pull_request.json
+++ b/cmd/terramate/cli/github/testdata/event_pull_request.json
@@ -2,29 +2,29 @@
   "action": "synchronize",
   "after": "ea61b5bd72dec0878ae388b04d76a988439d1e28",
   "before": "5344bd35836d6cd71f4d0773d5a540acfb57aafa",
-  "number": 8,
+  "number": 1494,
   "pull_request": {
     "_links": {
       "comments": {
-        "href": "https://api.github.com/repos/someorg/somerepo/issues/8/comments"
+        "href": "https://api.github.com/repos/someorg/somerepo/issues/1494/comments"
       },
       "commits": {
-        "href": "https://api.github.com/repos/someorg/somerepo/pulls/8/commits"
+        "href": "https://api.github.com/repos/someorg/somerepo/pulls/1494/commits"
       },
       "html": {
-        "href": "https://github.com/someorg/somerepo/pull/8"
+        "href": "https://github.com/someorg/somerepo/pull/1494"
       },
       "issue": {
-        "href": "https://api.github.com/repos/someorg/somerepo/issues/8"
+        "href": "https://api.github.com/repos/someorg/somerepo/issues/1494"
       },
       "review_comment": {
         "href": "https://api.github.com/repos/someorg/somerepo/pulls/comments{/number}"
       },
       "review_comments": {
-        "href": "https://api.github.com/repos/someorg/somerepo/pulls/8/comments"
+        "href": "https://api.github.com/repos/someorg/somerepo/pulls/1494/comments"
       },
       "self": {
-        "href": "https://api.github.com/repos/someorg/somerepo/pulls/8"
+        "href": "https://api.github.com/repos/someorg/somerepo/pulls/1494"
       },
       "statuses": {
         "href": "https://api.github.com/repos/someorg/somerepo/statuses/ea61b5bd72dec0878ae388b04d76a988439d1e28"
@@ -216,12 +216,12 @@
     "changed_files": 34,
     "closed_at": null,
     "comments": 1,
-    "comments_url": "https://api.github.com/repos/someorg/somerepo/issues/8/comments",
+    "comments_url": "https://api.github.com/repos/someorg/somerepo/issues/1494/comments",
     "commits": 16,
-    "commits_url": "https://api.github.com/repos/someorg/somerepo/pulls/8/commits",
+    "commits_url": "https://api.github.com/repos/someorg/somerepo/pulls/1494/commits",
     "created_at": "2024-01-22T16:45:23Z",
     "deletions": 98,
-    "diff_url": "https://github.com/someorg/somerepo/pull/8.diff",
+    "diff_url": "https://github.com/someorg/somerepo/pull/1494.diff",
     "draft": false,
     "head": {
       "label": "someuser:eight",
@@ -359,9 +359,9 @@
         "url": "https://api.github.com/users/someuser"
       }
     },
-    "html_url": "https://github.com/someorg/somerepo/pull/8",
+    "html_url": "https://github.com/someorg/somerepo/pull/1494",
     "id": 1690189098,
-    "issue_url": "https://api.github.com/repos/someorg/somerepo/issues/8",
+    "issue_url": "https://api.github.com/repos/someorg/somerepo/issues/1494",
     "labels": [
       {
         "color": "d73a4a",
@@ -383,19 +383,19 @@
     "merged_by": null,
     "milestone": null,
     "node_id": "PR_kwDOK180Ss5kvj0q",
-    "number": 8,
-    "patch_url": "https://github.com/someorg/somerepo/pull/8.patch",
+    "number": 1494,
+    "patch_url": "https://github.com/someorg/somerepo/pull/1494.patch",
     "rebaseable": null,
     "requested_reviewers": [],
     "requested_teams": [],
     "review_comment_url": "https://api.github.com/repos/someorg/somerepo/pulls/comments{/number}",
     "review_comments": 0,
-    "review_comments_url": "https://api.github.com/repos/someorg/somerepo/pulls/8/comments",
+    "review_comments_url": "https://api.github.com/repos/someorg/somerepo/pulls/1494/comments",
     "state": "open",
     "statuses_url": "https://api.github.com/repos/someorg/somerepo/statuses/ea61b5bd72dec0878ae388b04d76a988439d1e28",
     "title": "envvar",
     "updated_at": "2024-02-09T12:38:32Z",
-    "url": "https://api.github.com/repos/someorg/somerepo/pulls/8",
+    "url": "https://api.github.com/repos/someorg/somerepo/pulls/1494",
     "user": {
       "avatar_url": "https://avatars.githubusercontent.com/u/92498?v=4",
       "events_url": "https://api.github.com/users/someuser/events{/privacy}",


### PR DESCRIPTION
## What this PR does / why we need it:

When using `--cloud-sync-preview` this will write the preview URL in a file named `preview_url.txt` at the project root.

## Which issue(s) this PR fixes:
no

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
no
```
