### PR TITLE
fix(preview): draft field not sent when false.

### DIFF
--- a/cloud/types.go
+++ b/cloud/types.go
@@ -235,7 +235,7 @@ type (
 		Labels                []Label    `json:"labels,omitempty"`
 		Reviewers             Reviewers  `json:"reviewers,omitempty"`
 		Status                string     `json:"status"`
-		Draft                 bool       `json:"draft,omitempty"`
+		Draft                 bool       `json:"draft"`
 		ReviewRequired        bool       `json:"review_required,omitempty"`
 		ChangesRequestedCount int        `json:"changes_requested_count"`
 		ApprovedCount         int        `json:"approved_count"`


### PR DESCRIPTION
## What this PR does / why we need it:

The `draft` field must not have an `omitempty` JSON tag because we need to explicitly tell the backend when the draft status changed.

## Which issue(s) this PR fixes:
no

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
no
```
