### PR TITLE
Fix get-config-value command usage example

### DIFF
--- a/docs/cli/cmdline/get-config-value.md
+++ b/docs/cli/cmdline/get-config-value.md
@@ -13,12 +13,12 @@ The `get-config-value` command prints the value of a specific configuration para
 
 ## Usage
 
-`terramate experimental get-config-value`
+`terramate experimental get-config-value <value>`
 
 ## Examples
 
 Return the stack name for a specific stack:
 
 ```bash
-terramate get-config-value 'terramate.stack.name'
+terramate experimental get-config-value 'terramate.stack.name'
 ```


### PR DESCRIPTION
Fixes wrong reference of the `get-config-value` command in the CLI docs