### PR TITLE
Rename scripts to workflows in documentation

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -153,7 +153,7 @@ export default defineConfig({
           items: [
             { text: 'Overview', link: '/cli/orchestration/' },
             { text: 'Run Commands in Stacks', link: '/cli/orchestration/run-commands-in-stacks' },
-            { text: 'Terramate Scripts', link: '/cli/orchestration/scripts' },
+            { text: 'Workflows', link: '/cli/orchestration/scripts' },
             { text: 'Tag Filter', link: '/cli/orchestration/tag-filter' },
             { text: 'Runtime Configuration', link: '/cli/orchestration/runtime-configuration' },
             { text: 'Safe Guards', link: '/cli/orchestration/safeguards' },

--- a/docs/cli/orchestration/scripts.md
+++ b/docs/cli/orchestration/scripts.md
@@ -1,9 +1,12 @@
 ---
-title: Run a sequence of commands in Stacks with Terramate Scripts
-description: Learn how to configure and execute sequences of commands in stacks with Terramate Scripts.
+title: Configure workflows to run sequences of commands in Stacks with Terramate Scripts
+description: Learn how to configure workflows to execute sequences of commands in stacks with Terramate Scripts.
 ---
 
-# Terramate Scripts
+# Configure and run workflows with Terramate Scripts
+
+Workflows are a way of combining multiple commands into one executable unit of work called Terramate Scripts.
+
 
 ## Introduction
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/terramate-io/terramate/blob/main/CONTRIBUTING.md
2. If the PR is unfinished, mark it as draft: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request
3. Please update the PR title using the Conventional Commits convention: https://www.conventionalcommits.org/en/v1.0.0/
    Example: feat: add support for XYZ.
-->

## What this PR does / why we need it:

Renames "Terramate Scripts" to "Workflows" in sidebar.

## Which issue(s) this PR fixes:

Terramate Scripts is the feature but that doesn't ring a bell when a user reads this. Instead, workflows is a commonly known name. Hence we rename this to "Configure Worklows with Terramate Scripts"