### PR TITLE
feat: add --cloud-sync-layer to terramate run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
   - Ordering constraints between stacks are still respected, i.e. `before`/`after`, parent before sub-folders.
 - Add `cloud_sync_drift_status` option to `script` block commands. It allows for synchronizing the
   stack drift details from script jobs.
+- Add --cloud-sync-layer to allow users to specify a preview layer, e.g.: `stg`, `prod` etc.
+  - This is useful when users want to preview changes in a specific terraform workspace.
 
 ### Fixed
 

--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -15,6 +15,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/google/uuid"
 	hhcl "github.com/hashicorp/hcl/v2"
@@ -156,17 +157,18 @@ type cliSpec struct {
 	} `cmd:"" help:"List stacks"`
 
 	Run struct {
-		CloudStatus                string `help:"Filter by status. Example: --cloud-status=unhealthy"`
-		CloudSyncDeployment        bool   `default:"false" help:"Enable synchronization of stack execution with the Terramate Cloud"`
-		CloudSyncDriftStatus       bool   `default:"false" help:"Enable drift detection and synchronization with the Terramate Cloud"`
-		CloudSyncPreview           bool   `default:"false" help:"Enable synchronization of review request previews to Terramate Cloud"`
-		DebugPreviewURL            string `default:"" help:"Debug preview URL"`
-		CloudSyncTerraformPlanFile string `default:"" help:"Enable sync of Terraform plan file"`
-		ContinueOnError            bool   `default:"false" help:"Continue executing in other stacks in case of error"`
-		NoRecursive                bool   `default:"false" help:"Do not recurse into child stacks"`
-		DryRun                     bool   `default:"false" help:"Plan the execution but do not execute it"`
-		Reverse                    bool   `default:"false" help:"Reverse the order of execution"`
-		Eval                       bool   `default:"false" help:"Evaluate command line arguments as HCL strings"`
+		CloudStatus                string         `help:"Filter by status. Example: --cloud-status=unhealthy"`
+		CloudSyncDeployment        bool           `default:"false" help:"Enable synchronization of stack execution with the Terramate Cloud"`
+		CloudSyncDriftStatus       bool           `default:"false" help:"Enable drift detection and synchronization with the Terramate Cloud"`
+		CloudSyncPreview           bool           `default:"false" help:"Enable synchronization of review request previews to Terramate Cloud"`
+		CloudSyncLayer             cloudSyncLayer `default:"" help:"Layer to use for synchronizing previews to Terramate Cloud e.g. stg, prod etc."`
+		CloudSyncTerraformPlanFile string         `default:"" help:"Enable sync of Terraform plan file"`
+		DebugPreviewURL            string         `default:"" help:"Debug preview URL"`
+		ContinueOnError            bool           `default:"false" help:"Continue executing in other stacks in case of error"`
+		NoRecursive                bool           `default:"false" help:"Do not recurse into child stacks"`
+		DryRun                     bool           `default:"false" help:"Plan the execution but do not execute it"`
+		Reverse                    bool           `default:"false" help:"Reverse the order of execution"`
+		Eval                       bool           `default:"false" help:"Evaluate command line arguments as HCL strings"`
 
 		// Note: 0 is not the real default value here, this is just a workaround.
 		// Kong doesn't support having 0 as the default value in case the flag isn't set, but K in case it's set without a value.
@@ -734,6 +736,22 @@ func (s *kongParallelFlag) Decode(ctx *kong.DecodeContext) error {
 	}
 
 	s.Value = defaultParallelRunCount
+
+	return nil
+}
+
+type cloudSyncLayer string
+
+func (csl cloudSyncLayer) String() string {
+	return string(csl)
+}
+
+func (csl cloudSyncLayer) Validate() error {
+	for _, c := range csl {
+		if !unicode.IsLetter(c) && !unicode.IsDigit(c) && c != '-' {
+			return errors.E("invalid --cloud-sync-layer, only alphanumeric characters and hyphens are allowed")
+		}
+	}
 
 	return nil
 }

--- a/cmd/terramate/cli/run.go
+++ b/cmd/terramate/cli/run.go
@@ -65,6 +65,7 @@ type stackRunTask struct {
 	CloudSyncDeployment        bool
 	CloudSyncDriftStatus       bool
 	CloudSyncPreview           bool
+	CloudSyncLayer             string
 	CloudSyncTerraformPlanFile string
 }
 
@@ -153,6 +154,7 @@ func (c *cli) runOnStacks() {
 					CloudSyncDriftStatus:       c.parsedArgs.Run.CloudSyncDriftStatus,
 					CloudSyncPreview:           c.parsedArgs.Run.CloudSyncPreview,
 					CloudSyncTerraformPlanFile: c.parsedArgs.Run.CloudSyncTerraformPlanFile,
+					CloudSyncLayer:             c.parsedArgs.Run.CloudSyncLayer.String(),
 				},
 			},
 		}
@@ -546,9 +548,13 @@ func (c *cli) createCloudPreview(runs []stackCloudRun) map[string]string {
 
 	technology := "other"
 	technologyLayer := "default"
-	if c.parsedArgs.Run.CloudSyncTerraformPlanFile != "" {
-		technology = "terraform"
-		technologyLayer = "default"
+	for _, run := range runs {
+		if run.Task.CloudSyncTerraformPlanFile != "" {
+			technology = "terraform"
+		}
+		if layer := run.Task.CloudSyncLayer; layer != "" {
+			technologyLayer = sprintf("custom:%s", layer)
+		}
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), defaultCloudTimeout)


### PR DESCRIPTION
## What this PR does / why we need it:

Add `-cloud-sync-layer` to `terramate run`. This would allow users to create
previews for a specific terraform workspace e.g. `staging`, `prod` etc.

## Which issue(s) this PR fixes:

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
Yes, a new flag --cloud-sync-layer has been added to terramate run.
```
