### PR TITLE
docs: refine terramate list command usage and examples

### DIFF
--- a/docs/cli/cmdline/list.md
+++ b/docs/cli/cmdline/list.md
@@ -9,7 +9,7 @@ The `list` command lists all Terramate stacks in the current directory recursive
 
 ## Usage
 
-`terramate list`
+`terramate list [options]`
 
 ## Examples
 
@@ -28,8 +28,7 @@ terramate list --run-order
 Explicitly change the working directory:
 
 ```bash
-terramate list --chdir path/to/directory
-```
+terramate list --chdir <path>```
 
 List all stacks below the current directory that have a "drifted" status on Terramate Cloud
 


### PR DESCRIPTION
## What this PR does / why we need it:
This PR refines the `terramate list` command documentation for better clarity and adherence to the Terramate Documentation Guide, specifically updating the usage section and examples.

## Does this PR introduce a user-facing change?
Yes, it updates the documentation to enhance user understanding and application of the `terramate list` command.
