### PR TITLE
docs: refine terramate list command usage and examples

### DIFF
--- a/docs/cli/cmdline/list.md
+++ b/docs/cli/cmdline/list.md
@@ -9,7 +9,7 @@ The `terramate list` command lists all Terramate stacks in the current directory
 
 ## Usage
 
-`terramate list`
+`terramate list [options]`
 
 ## Examples
 
@@ -36,3 +36,21 @@ List all stacks below the current directory that have a "drifted" status on Terr
 ```bash
 terramate list --cloud-status=drifted
 ```
+
+## Options
+
+- `-C, --chdir=<path>`: Set the working directory.
+- `-B, --git-change-base=<ref>`: Specify the Git base ref for computing changes.
+- `-c, --changed`: Filter stacks by changed infrastructure.
+- `--tags=<tags>`: Filter stacks by tags. Use ":" for logical AND and "," for logical OR. Examples:
+  - `--tags=app:prod` filters stacks containing tag "app" AND "prod".
+  - If multiple `--tags` options are provided, an OR expression is created. Example: `--tags=a --tags=b` is the same as `--tags=a,b`.
+- `--no-tags=<no-tags>`: Filter stacks that do not have the given tags.
+- `--log-level=<level>`: Set the log level. Possible values include 'disabled', 'trace', 'debug', 'info', 'warn', 'error', or 'fatal'.
+- `--log-fmt=<format>`: Choose the log format. Options are 'console', 'text', or 'json'.
+- `--log-destination=<destination>`: Set the destination of log messages. Default is `stderr`.
+- `--quiet`: Disable output.
+- `-v, --verbose=<level>`: Increase the verbosity of the output. The level is optional and defaults to 0 if not specified.
+- `--why`: Show the reason why a stack has changed.
+- `--cloud-status=<status>`: Filter by status on Terramate Cloud.
+- `--run-order`: Sort stacks by order of execution.****


### PR DESCRIPTION
## What this PR does / why we need it:
This PR refines the `terramate list` command documentation for better clarity and adherence to the Terramate Documentation Guide, specifically updating the usage section and examples.

## Does this PR introduce a user-facing change?
Yes, it updates the documentation to enhance user understanding and application of the `terramate list` command.
