### PR TITLE
docs: refine terramate clone command usage

### DIFF
--- a/docs/cli/cmdline/clone.md
+++ b/docs/cli/cmdline/clone.md
@@ -19,7 +19,7 @@ in this case, the source directory itself must be a stack.
 
 ## Usage
 
-`terramate experimental clone SOURCE TARGET`
+`terramate experimental clone [options] <source> <target>`
 
 ## Examples
 


### PR DESCRIPTION
## What this PR does / why we need it:
This PR refines the documentation for the `terramate clone` command, ensuring the usage section reflect required and optional command components, enhancing usability and adherence to Terramate documentation standards.

## Does this PR introduce a user-facing change?
Yes, it updates the documentation to provide clearer guidance on using the `terramate clone` command, including adjustments to the usage syntax .
