### PR TITLE
docs: refine terramate eval command usage

### DIFF
--- a/docs/cli/cmdline/eval.md
+++ b/docs/cli/cmdline/eval.md
@@ -29,7 +29,7 @@ Below is the list of functions that **cannot be used** in this command:
 
 ## Usage
 
-`terramate experimental eval EXPRS`
+`terramate experimental eval <exprs>`
 
 ## Examples
 


### PR DESCRIPTION
## What this PR does / why we need it:
Refines the `terramate eval` command documentation 

## Does this PR introduce a user-facing change?
Yes, it updates the documentation to clarify the usage of the `terramate eval` command 
