### PR TITLE
docs: refine terramate generate command usage

### DIFF
--- a/docs/cli/cmdline/generate.md
+++ b/docs/cli/cmdline/generate.md
@@ -9,7 +9,7 @@ The `generate` command generates files for all code generation strategies. For a
 
 ## Usage
 
-`terramate generate`
+`terramate generate [options]`
 
 
 ## Examples


### PR DESCRIPTION
## What this PR does / why we need it:
Refines the `terramate generate` command documentation to include `[options]` in the usage section.

## Does this PR introduce a user-facing change?
Yes, it updates the documentation of the `terramate generate` command and its options.
