### PR TITLE
fix: heredoc escape symbols not properly handled.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,8 +49,9 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 
 ### Fixed
 
-- Fix a panic in language server with a project caontaining errors on root directory
+- Fix a panic in language server with a project containing errors on root directory
 - Fix the execution order when using `tag` filter in `after/before` in conjunction with implicit order for nested stacks. (BREAKING CHANGE)
+- Fix escape sequences being interpreted in heredocs (issue #1449)
 
 ## v0.4.6
 

--- a/hcl/ast/expression_test.go
+++ b/hcl/ast/expression_test.go
@@ -71,6 +71,15 @@ EOT
 `,
 		},
 		{
+			name: "heredocs with newlines",
+			expr: `<<-EOT
+Line 1
+Line 2. I want the following \ and n to be in the file: \n
+Line 3
+EOT
+`,
+		},
+		{
 			name: "strings not ending with nl returns as plain string",
 			expr: `"0\n1"`,
 			want: `"0\n1"`,
@@ -181,6 +190,11 @@ EOT
 			want: `"testက"`,
 		},
 		{
+			name: "rendered printable unicodes are also rendered when in quoted string",
+			expr: `"testက"`,
+			want: `"testက"`,
+		},
+		{
 			name: "single nl returns heredocs",
 			expr: `"\n"`,
 			want: `<<-EOT
@@ -236,6 +250,10 @@ EOT
 			expr: `"${a}\ntest\n${global.a}"`,
 		},
 		{
+			name: "escaping carriege returns",
+			expr: `"str \r str"`,
+		},
+		{
 			name: "render string when generating heredoc",
 			expr: `"\t${a}\n\ttest\n\t${global.a}\n"`,
 			want: "<<-EOT\n\t${a}\n\ttest\n\t${global.a}\nEOT\n",
@@ -248,6 +266,24 @@ EOT
 			name: "render escape characters",
 			expr: `"\n${a}${b}\t${b}\n\ntest\n\t${global.a}\n"`,
 			want: "<<-EOT\n\n${a}${b}\t${b}\n\ntest\n\t${global.a}\nEOT\n",
+		},
+		{
+			name: "render quotes",
+			expr: `"this is a \"test\" string"`,
+		},
+		{
+			name: "render quotes in heredocs",
+			expr: `<<-EOT
+this is a "test" string
+EOT
+`,
+		},
+		{
+			name: "render escaped quotes in heredocs",
+			expr: `<<-EOT
+this is a \"test\" string
+EOT
+`,
 		},
 		{
 			name: "utf-8",


### PR DESCRIPTION
## What this PR does / why we need it:

The old escaping logic did multiple passes on the input data, each modifying the input, which led to the issue of re-rendering of escape sequences.

## Which issue(s) this PR fixes:
Fixes #1449 

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
yes
```
