### PR TITLE
docs: refine terramate create command usage , added <path>

### DIFF
--- a/docs/cli/cmdline/create.md
+++ b/docs/cli/cmdline/create.md
@@ -11,7 +11,7 @@ directories as required. Whenever the `create` command is used, the code generat
 
 ## Usage
 
-`terramate create [options] PATH`
+`terramate create [options] <path>`
 
 ## Examples
 


### PR DESCRIPTION

What this PR does / why we need it:

Refines the terramate create command documentation to align with documentation standards
Does this PR introduce a user-facing change?

Yes, it updates the documentation for the terramate create command
