### PR TITLE
docs: specify main branch for git init in quickstart guide

### DIFF
--- a/docs/cli/getting-started/index.md
+++ b/docs/cli/getting-started/index.md
@@ -60,7 +60,7 @@ inside a repository to work: one commit to compare the changes to and another co
 As a first step, create a new git repository and navigate into it:
 
 ```sh
-git init terramate-quickstart
+git init -b main terramate-quickstart
 cd terramate-quickstart
 ```
 


### PR DESCRIPTION
### What this PR does / why we need it:
this PR is related to the quick-start guide in the CLI docs and was mentioned in #1433 and #1415.
It adds the "-b main" flag to the "git init" command, ensuring that the main branch is created when initializing a new git repository.

### Which issue(s) this PR fixes:
the issues are already closed, it implements the suggested improvement from @serdardalgic

### Does this PR introduce a user-facing change?
Yes, it updates the quick-start guide


### Why another PR ? 
I did not sign my commits in the old PR and could not resolve the issue 