### PR TITLE
chore: support -j N syntax for parallel flag and remove default value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,8 +41,7 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 - Improve user experience when using Terramate with existing Terragrunt projects.
   - Add  `terramate create --all-terragrunt` option, which will automatically create Terramate stacks for each Terraform module.
 - Allow to run independent stacks in parallel for faster deployments and better utilization of system resources in general.
-  - Add `--parallel` (short `-j`) option to `terramate run` and `terramate script run`.
-  - `--parallel=N` limits the number of concurrent runs to `N`, otherwise a sensible default limit is chosen.
+  - Add `--parallel=N` (short `-j N`) option to `terramate run` and `terramate script run` to allow running up to `N` stacks in parallel.
   - Ordering constraints between stacks are still respected, i.e. `before`/`after`, parent before sub-folders.
 - Add `cloud_sync_drift_status` option to `script` block commands. It allows for synchronizing the
   stack drift details from script jobs.

--- a/cmd/terramate/cli/run.go
+++ b/cmd/terramate/cli/run.go
@@ -187,7 +187,7 @@ func (c *cli) runOnStacks() {
 		Reverse:         c.parsedArgs.Run.Reverse,
 		ScriptRun:       false,
 		ContinueOnError: c.parsedArgs.Run.ContinueOnError,
-		Parallel:        c.parsedArgs.Run.Parallel.Value,
+		Parallel:        c.parsedArgs.Run.Parallel,
 	})
 	if err != nil {
 		fatal("one or more commands failed", err)

--- a/cmd/terramate/cli/script_run.go
+++ b/cmd/terramate/cli/script_run.go
@@ -118,7 +118,7 @@ func (c *cli) runScript() {
 		DryRun:          c.parsedArgs.Script.Run.DryRun,
 		ScriptRun:       true,
 		ContinueOnError: false,
-		Parallel:        c.parsedArgs.Script.Run.Parallel.Value,
+		Parallel:        c.parsedArgs.Script.Run.Parallel,
 	})
 	if err != nil {
 		fatal("one or more commands failed", err)

--- a/cmd/terramate/e2etests/cloud/run_cloud_deployment_test.go
+++ b/cmd/terramate/e2etests/cloud/run_cloud_deployment_test.go
@@ -407,7 +407,7 @@ func TestCLIRunWithCloudSyncDeployment(t *testing.T) {
 					"--cloud-sync-deployment",
 				}
 				if isParallel {
-					runflags = append(runflags, "--parallel")
+					runflags = append(runflags, "--parallel", "5")
 					tc.want.run.IgnoreStdout = true
 					tc.want.run.IgnoreStderr = true
 				}

--- a/cmd/terramate/e2etests/cloud/run_cloud_drift_test.go
+++ b/cmd/terramate/e2etests/cloud/run_cloud_drift_test.go
@@ -531,7 +531,7 @@ func TestCLIRunWithCloudSyncDriftStatus(t *testing.T) {
 					"--cloud-sync-drift-status",
 				}
 				if isParallel {
-					runflags = append(runflags, "--parallel")
+					runflags = append(runflags, "-j", "5")
 					tc.want.run.IgnoreStdout = true
 					tc.want.run.IgnoreStderr = true
 				}

--- a/cmd/terramate/e2etests/cloud/run_cloud_signal_test.go
+++ b/cmd/terramate/e2etests/cloud/run_cloud_signal_test.go
@@ -120,7 +120,7 @@ func TestCLIRunWithCloudSyncDeploymentWithSignals(t *testing.T) {
 					"--cloud-sync-deployment",
 				}
 				if isParallel {
-					runflags = append(runflags, "--parallel")
+					runflags = append(runflags, "--parallel", "5")
 					tc.want.run.IgnoreStdout = true
 					tc.want.run.IgnoreStderr = true
 				}
@@ -220,7 +220,7 @@ func TestCLIRunWithCloudSyncDriftStatusWithSignals(t *testing.T) {
 					"--cloud-sync-drift-status",
 				}
 				if isParallel {
-					runflags = append(runflags, "--parallel")
+					runflags = append(runflags, "--parallel=5")
 					tc.want.run.IgnoreStdout = true
 					tc.want.run.IgnoreStderr = true
 				}

--- a/cmd/terramate/e2etests/cloud/run_script_cloud_deployment_test.go
+++ b/cmd/terramate/e2etests/cloud/run_script_cloud_deployment_test.go
@@ -236,7 +236,7 @@ func TestCLIScriptRunWithCloudSyncDeployment(t *testing.T) {
 
 				scriptArgs := []string{"--quiet", "--disable-safeguards=git-out-of-sync"}
 				if isParallel {
-					scriptArgs = append(scriptArgs, "--parallel")
+					scriptArgs = append(scriptArgs, "--parallel=5")
 					// For the parallel test, we ignore output validation, since the print order is non-deterministic.
 					tc.want.run.IgnoreStderr = true
 					tc.want.run.IgnoreStdout = true

--- a/cmd/terramate/e2etests/cloud/run_script_cloud_drift_test.go
+++ b/cmd/terramate/e2etests/cloud/run_script_cloud_drift_test.go
@@ -512,7 +512,7 @@ func TestScriptRunDriftStatus(t *testing.T) {
 					"--quiet",
 				}
 				if isParallel {
-					runflags = append(runflags, "--parallel")
+					runflags = append(runflags, "--parallel", "5")
 					tc.want.run.IgnoreStdout = true
 					tc.want.run.IgnoreStderr = true
 				}

--- a/cmd/terramate/e2etests/core/run_parallel_test.go
+++ b/cmd/terramate/e2etests/core/run_parallel_test.go
@@ -39,7 +39,7 @@ func TestParallelFibonacci(t *testing.T) {
 
 			tmcli := NewCLI(t, s.RootDir())
 
-			res := tmcli.Run("run", "--quiet", "--parallel", "--", HelperPath, "fibonacci")
+			res := tmcli.Run("run", "--quiet", "--parallel=5", "--", HelperPath, "fibonacci")
 			AssertRunResult(t, res, RunExpected{})
 
 			b, err := os.ReadFile(s.RootDir() + fmt.Sprintf("/fib.%v/fib.txt", tc.FibN))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/terramate-io/terramate/blob/main/CONTRIBUTING.md
2. If the PR is unfinished, mark it as draft: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request
3. Please update the PR title using the Conventional Commits convention: https://www.conventionalcommits.org/en/v1.0.0/
    Example: feat: add support for XYZ.
-->

## What this PR does / why we need it:

This PR adds support for supplying a parameter to the short form of the `--parallel`flag, i.e. `-j N`.
It also removes the default value, so the long version always needs a value.

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Keep it empty if not applicable.
-->

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
<!--
If no, just write "no" in the block below.
If yes, please explain the change and update documentation and the CHANGELOG.md file accordingly.
-->
```
no
```
