### PR TITLE
feat: add ordering support for --all-terragrunt.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 
 ## Unreleased
 
+### Added
+
+- Automatically add stack ordering to Terragrunt stacks created by `terramate create --all-terragrunt`.
+
 ## v0.5.0
 
 ### BREAKING CHANGES

--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -1259,6 +1259,7 @@ func (c *cli) initTerragrunt() {
 			ID:          stackID.String(),
 			Name:        dirBasename,
 			Description: dirBasename,
+			After:       mod.After.Strings(),
 		}
 
 		err = stack.Create(c.cfg(), stackSpec)

--- a/docs/cli/cmdline/create.md
+++ b/docs/cli/cmdline/create.md
@@ -48,6 +48,9 @@ Terramate detects all Terragrunt Modules that contain a `terraform.source` confi
 terramate create --all-terragrunt
 ```
 
+If the Terragrunt module declare dependencies then the created stack will have its ordering
+attributes automatically set.
+
 ## Usage
 
 ```bash

--- a/tg/tg_library_sanity_test.go
+++ b/tg/tg_library_sanity_test.go
@@ -1,0 +1,291 @@
+// Copyright 2024 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+package tg_test
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/gruntwork-io/go-commons/env"
+	"github.com/gruntwork-io/terragrunt/config"
+	"github.com/gruntwork-io/terragrunt/options"
+	"github.com/gruntwork-io/terragrunt/util"
+	. "github.com/terramate-io/terramate/test/hclwrite/hclutils"
+	"github.com/terramate-io/terramate/test/sandbox"
+)
+
+func TestTerragruntParser(t *testing.T) {
+	type want struct {
+		err    error
+		module *config.TerragruntConfig
+	}
+
+	type testcase struct {
+		name    string
+		baseDir string
+		layout  []string
+		want    want
+	}
+
+	pstr := func(s string) *string { return &s }
+
+	for _, tc := range []testcase{
+		{
+			name: "empty terragrunt.hcl",
+			want: want{
+				err: os.ErrNotExist,
+			},
+		},
+		{
+			name: "simple terragrunt.hcl",
+			layout: []string{
+				`f:terragrunt.hcl:` + Block("terraform",
+					Str("source", "github.com/hashicorp/terraform//example"),
+				).String(),
+			},
+			want: want{
+				module: &config.TerragruntConfig{
+					Terraform: &config.TerraformConfig{
+						Source: pstr("github.com/hashicorp/terraform//example"),
+					},
+					IsPartial: true,
+				},
+			},
+		},
+		{
+			name:    "simple terragrunt.hcl with dependencies block",
+			baseDir: "target",
+			layout: []string{
+				`f:module1/terragrunt.hcl:` + Doc().String(),
+				`f:target/terragrunt.hcl:` + Doc(
+					Block("terraform",
+						Str("source", "github.com/hashicorp/terraform//example"),
+					),
+					Block("dependencies",
+						Expr("paths", `["../module1"]`),
+					)).String(),
+			},
+			want: want{
+				module: &config.TerragruntConfig{
+					IsPartial: true,
+					Terraform: &config.TerraformConfig{
+						Source: pstr("github.com/hashicorp/terraform//example"),
+					},
+					Dependencies: &config.ModuleDependencies{
+						Paths: []string{"../module1"},
+					},
+				},
+			},
+		},
+		{
+			name:    "simple terragrunt.hcl with single dependency block",
+			baseDir: "target",
+			layout: []string{
+				`f:module1/terragrunt.hcl:` + Block("terraform",
+					Str("source", "github.com/hashicorp/terraform//example"),
+				).String(),
+				`f:target/terragrunt.hcl:` + Doc(
+					Block("terraform",
+						Str("source", "github.com/hashicorp/terraform//example"),
+					),
+					Block("dependency",
+						Labels("module1"),
+						Str("config_path", `../module1`),
+					)).String(),
+			},
+			want: want{
+				module: &config.TerragruntConfig{
+					IsPartial: true,
+					Terraform: &config.TerraformConfig{
+						Source: pstr("github.com/hashicorp/terraform//example"),
+					},
+					TerragruntDependencies: []config.Dependency{
+						{
+							Name:       "module1",
+							ConfigPath: "../module1",
+						},
+					},
+					Dependencies: &config.ModuleDependencies{
+						Paths: []string{"../module1"},
+					},
+				},
+			},
+		},
+		{
+			name:    "terragrunt.hcl with both dependency block and dependencies block",
+			baseDir: "target",
+			layout: []string{
+				`f:module1/terragrunt.hcl:` + Block("terraform",
+					Str("source", "github.com/hashicorp/terraform//example1"),
+				).String(),
+				`f:module2/terragrunt.hcl:` + Block("terraform",
+					Str("source", "github.com/hashicorp/terraform//example2"),
+				).String(),
+				`f:target/terragrunt.hcl:` + Doc(
+					Block("terraform",
+						Str("source", "github.com/hashicorp/terraform//example"),
+					),
+					Block("dependency",
+						Labels("module1"),
+						Str("config_path", `../module1`),
+					),
+					Block("dependencies",
+						Expr("paths", `["../module2"]`),
+					),
+				).String(),
+			},
+			want: want{
+				module: &config.TerragruntConfig{
+					IsPartial: true,
+					Terraform: &config.TerraformConfig{
+						Source: pstr("github.com/hashicorp/terraform//example"),
+					},
+					TerragruntDependencies: []config.Dependency{
+						{
+							Name:       "module1",
+							ConfigPath: "../module1",
+						},
+					},
+					Dependencies: &config.ModuleDependencies{
+						Paths: []string{"../module1", "../module2"},
+					},
+				},
+			},
+		},
+		{
+			name:    "terragrunt.hcl with dependency and dependencies sharing entries",
+			baseDir: "target",
+			layout: []string{
+				`f:module1/terragrunt.hcl:` + Block("terraform",
+					Str("source", "github.com/hashicorp/terraform//example1"),
+				).String(),
+				`f:module2/terragrunt.hcl:` + Block("terraform",
+					Str("source", "github.com/hashicorp/terraform//example2"),
+				).String(),
+				`f:target/terragrunt.hcl:` + Doc(
+					Block("terraform",
+						Str("source", "github.com/hashicorp/terraform//example"),
+					),
+					Block("dependency",
+						Labels("module1"),
+						Str("config_path", `../module1`),
+					),
+					Block("dependency",
+						Labels("module2"),
+						Str("config_path", `../module2`),
+					),
+					Block("dependencies",
+						Expr("paths", `["../module2", "../module1"]`),
+					),
+				).String(),
+			},
+			want: want{
+				module: &config.TerragruntConfig{
+					IsPartial: true,
+					Terraform: &config.TerraformConfig{
+						Source: pstr("github.com/hashicorp/terraform//example"),
+					},
+					TerragruntDependencies: []config.Dependency{
+						{
+							Name:       "module1",
+							ConfigPath: "../module1",
+						},
+						{
+							Name:       "module2",
+							ConfigPath: "../module2",
+						},
+					},
+					Dependencies: &config.ModuleDependencies{
+						Paths: []string{"../module1", "../module2"},
+					},
+				},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := sandbox.NoGit(t, false)
+			s.BuildTree(tc.layout)
+
+			baseDir := s.RootDir()
+			if tc.baseDir != "" {
+				baseDir = filepath.Join(baseDir, tc.baseDir)
+			}
+
+			opts := newTerragruntOptions(baseDir)
+			pctx := config.NewParsingContext(context.Background(), opts).WithDecodeList(
+				// needed for tracking:
+				//   - terraform.extra_arguments
+				//   - terraform.required_vars_file
+				//   - terraform.optional_var_files
+				//   - etc
+				config.TerraformBlock,
+
+				// Needed for detecting modules.
+				config.TerraformSource,
+
+				// Need for parsing out the dependencies
+				config.DependencyBlock,
+				config.DependenciesBlock,
+			)
+
+			if tc.want.module != nil {
+				for k, v := range tc.want.module.FieldsMetadata {
+					for kk, vv := range v {
+						if str, ok := vv.(string); kk == "found_in_file" && ok {
+							tc.want.module.FieldsMetadata[k][kk] = filepath.Join(baseDir, str)
+						}
+					}
+				}
+			}
+
+			got, err := config.PartialParseConfigFile(pctx, filepath.Join(baseDir, "terragrunt.hcl"), nil)
+			if err != nil && tc.want.err == nil {
+				t.Error(err)
+			}
+			if diff := cmp.Diff(tc.want.err, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("unexpected error: (-want +got)\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.want.module, got, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("unexpected module: (-want +got)\n%s", diff)
+			}
+		})
+	}
+}
+
+func newTerragruntOptions(dir string) *options.TerragruntOptions {
+	opts := options.NewTerragruntOptions()
+	opts.RunTerragrunt = func(to *options.TerragruntOptions) error {
+
+		return nil
+	}
+	opts.WorkingDir = dir
+	opts.Writer = io.Discard
+	opts.ErrWriter = io.Discard
+	opts.IgnoreExternalDependencies = true
+	opts.RunAllAutoApprove = false
+	opts.AutoInit = false
+
+	// very important, otherwise the functions could block with user prompts.
+	opts.NonInteractive = true
+
+	opts.Env = env.Parse(os.Environ())
+
+	if opts.DisableLogColors {
+		util.DisableLogColors()
+	}
+
+	opts.DownloadDir = util.JoinPath(opts.WorkingDir, util.TerragruntCacheDir)
+	opts.TerragruntConfigPath = config.GetDefaultConfigPath(opts.WorkingDir)
+
+	opts.OriginalTerragruntConfigPath = opts.TerragruntConfigPath
+	opts.OriginalTerraformCommand = opts.TerraformCommand
+	opts.OriginalIAMRoleOptions = opts.IAMRoleOptions
+
+	return opts
+}


### PR DESCRIPTION
## What this PR does / why we need it:

Add detection for Terragrunt dependencies and automatically populates the `stack.after` of created stacks using `terramate create --all-terragrunt`.

## Which issue(s) this PR fixes:
none

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
yes
```
