### PR TITLE
refactor!: disallow code generation inside dotdirs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 
 ## Unreleased
 
+### Changed
+
+- The code generation of HCL and plain files was disallowed inside dot directories.
+
 ## v0.5.5
 
 - Add `script.job.name` and `script.job.description` attributes.

--- a/docs/cli/code-generation/index.md
+++ b/docs/cli/code-generation/index.md
@@ -113,6 +113,7 @@ For `stack` context, the labels must follow the constraints below:
 * It is always defined with `/` independent on the OS you are working on
 * It does not contain `../` (code can only be generated inside the stack)
 * It does not start with `./`
+* It does not contain a dot directory (invalid example: `somedir/.invalid/main.tf`)
 * It is not a symbolic link
 * It is not a stack
 * It is unique on the whole hierarchy of a stack for all blocks with condition=true.
@@ -122,6 +123,7 @@ For `root` context, the constraints are:
 * It is an absolute path in the form `/<dir>/<filename>` or just `/<filename>`.
 * It is always defined with `/` independent on the OS you are working on
 * It does not contain `../` (code can only be generated inside the project root)
+* It does not contain a dot directory (invalid example: `somedir/.invalid/file.txt`)
 * It is not a symbolic link
 * It is not a stack
 * It is unique on the whole hierarchy for all blocks with condition=true.

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -992,8 +992,17 @@ func validateStackGeneratedFiles(root *config.Root, stackpath string, generated 
 		abspath := filepath.Join(stackpath, relpath)
 		destdir := filepath.Dir(abspath)
 
-		// We need to check that destdir, or any of its parents, is not a symlink or a stack.
+		// We need to check that destdir, or any of its parents, is not a symlink, a stack or a dotdir.
 		for strings.HasPrefix(destdir, stackpath) && destdir != stackpath {
+			dirname := filepath.Base(destdir)
+			if dirname[0] == '.' {
+				errs.Append(errors.E(
+					ErrInvalidGenBlockLabel,
+					file.Range(),
+					"%s: generation inside dot directories are disallowed",
+					file.Label(),
+				))
+			}
 			info, err := os.Lstat(destdir)
 			if err != nil {
 				if errors.Is(err, fs.ErrNotExist) {

--- a/generate/generate_test.go
+++ b/generate/generate_test.go
@@ -353,6 +353,120 @@ func TestGenerateStackContextSubDirsOnLabels(t *testing.T) {
 			},
 		},
 		{
+			name:   "if path is inside dotdir fails",
+			skipOn: "windows",
+			layout: []string{
+				"s:stacks/stack",
+				"d:.somedir",
+			},
+			configs: []hclconfig{
+				{
+					path: "/stacks/stack",
+					add: Doc(
+						GenerateHCL(
+							Labels(".somedir/name.tf"),
+							Content(
+								Block("something"),
+							),
+						),
+						GenerateFile(
+							Labels(".somedir/name.txt"),
+							Str("content", "something"),
+						),
+					),
+				},
+			},
+			wantReport: generate.Report{
+				Failures: []generate.FailureResult{
+					{
+						Result: generate.Result{
+							Dir: project.NewPath("/stacks/stack"),
+						},
+						Error: errors.L(
+							errors.E(generate.ErrInvalidGenBlockLabel),
+							errors.E(generate.ErrInvalidGenBlockLabel),
+						),
+					},
+				},
+			},
+		},
+		{
+			name:   "if path is inside deep dotdir fails",
+			skipOn: "windows",
+			layout: []string{
+				"s:stacks/stack",
+				"d:somedir/otherdir/.somedir",
+			},
+			configs: []hclconfig{
+				{
+					path: "/stacks/stack",
+					add: Doc(
+						GenerateHCL(
+							Labels("somedir/otherdir/.somedir/name.tf"),
+							Content(
+								Block("something"),
+							),
+						),
+						GenerateFile(
+							Labels("somedir/otherdir/.somedir/name.txt"),
+							Str("content", "something"),
+						),
+					),
+				},
+			},
+			wantReport: generate.Report{
+				Failures: []generate.FailureResult{
+					{
+						Result: generate.Result{
+							Dir: project.NewPath("/stacks/stack"),
+						},
+						Error: errors.L(
+							errors.E(generate.ErrInvalidGenBlockLabel),
+							errors.E(generate.ErrInvalidGenBlockLabel),
+						),
+					},
+				},
+			},
+		},
+		{
+			name:   "if path is inside deep dotdir, even if not the leaf, fails",
+			skipOn: "windows",
+			layout: []string{
+				"s:stacks/stack",
+				"d:somedir/otherdir/.somedir/moredirs/a/b",
+			},
+			configs: []hclconfig{
+				{
+					path: "/stacks/stack",
+					add: Doc(
+						GenerateHCL(
+							Labels("somedir/otherdir/.somedir/moredirs/a/b/name.tf"),
+							Content(
+								Block("something"),
+							),
+						),
+						GenerateFile(
+							Labels("somedir/otherdir/.somedir/moredirs/a/b/name.txt"),
+							Str("content", "something"),
+						),
+					),
+				},
+			},
+			wantReport: generate.Report{
+				Failures: []generate.FailureResult{
+					{
+						Result: generate.Result{
+							Dir: project.NewPath("/stacks/stack"),
+						},
+						Error: errors.L(
+							errors.E(generate.ErrInvalidGenBlockLabel),
+							errors.E(generate.ErrInvalidGenBlockLabel),
+						),
+					},
+				},
+			},
+		},
+		{
 			name: "invalid paths fails",
 			layout: []string{
 				"s:stacks/stack-1",


### PR DESCRIPTION
## What this PR does / why we need it:

Disallow code generation inside dot directories.
Note: this is a breaking change.

Examples below will not work anymore:

```hcl
generate_hcl ".terraform/myfile.tf" {
  content {}
}

generate_hcl "somedir/other/.dotdir/myfile.tf" {
  content {}
}

generate_hcl "somedir/other/.dotdir/test/myfile.tf" {
  content {}
}
```

In the cases above, note that part of the file path contains a "dot directory".

## Which issue(s) this PR fixes:
Relates to #1260 

## Special notes for your reviewer:

I split the PR for fixing the dotfile bug because the disallowing dotdirs is related but not actual part of the bugfix, then by having this separate is easier if a rollback is needed.
Note: this is a breaking change.

- [x] A major version bump is required before this PR can be merged.

## Does this PR introduce a user-facing change?
```
yes, this is a breaking change.
```
