### PR TITLE
fix(generate): generate cleanup deletes dotfiles.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 
 ## Unreleased
 
+### Fixed
+
+- Fixed a bug in the dotfiles handling in the code generation. Now it's possible to generate files such as `.tflint.hcl`.
+
 ### Changed
 
 - (**BREAKING CHANGE**) Removes the option `terramate.config.git.default_branch_base_ref`.

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -446,11 +446,12 @@ processSubdirs:
 		}
 
 		for _, entry := range entries {
-			if config.Skip(entry.Name()) {
-				continue
-			}
-
 			if entry.IsDir() {
+				// only dotdirs are ignored.
+				if entry.Name()[0] == '.' {
+					continue
+				}
+
 				isStack := config.IsStack(root, filepath.Join(absSubdir, entry.Name()))
 				if isStack {
 					continue

--- a/generate/generate_list_test.go
+++ b/generate/generate_list_test.go
@@ -196,13 +196,24 @@ func TestGeneratedFilesListing(t *testing.T) {
 			},
 		},
 		{
-			name: "ignores dot dirs and files",
+			name: "ignores dot dirs",
 			layout: []string{
-				genfile(".name.tf"),
 				genfile(".dir/1.tf"),
 				genfile(".dir/2.tf"),
 			},
 			want: []string{},
+		},
+		{
+			// https://github.com/terramate-io/terramate/issues/1260
+			name: "regression test: dotfiles should not be ignored if not inside a .tmskip",
+			layout: []string{
+				genfile(".name.tf"),
+				genfile("dir/.name.tf"),
+			},
+			want: []string{
+				".name.tf",
+				"dir/.name.tf",
+			},
 		},
 	}
 


### PR DESCRIPTION
## What this PR does / why we need it:

Fix a bug where dot files were not detected when already present in the filesystem and them re-generation occurs.

## Which issue(s) this PR fixes:
Fixes #1260 

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
yes, fixes a bug.
```
