### PR TITLE
feat!: enable dotfile change detection.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 
 ## Unreleased
 
+### Added
+
+- (**BREAKING CHANGE**) Enable change detection for dotfiles. You can still use `.gitignore` to ignore them (if needed).
+
 ### Fixed
 
 - Fixed a bug in the dotfiles handling in the code generation. Now it's possible to generate files such as `.tflint.hcl`.

--- a/stack/manager.go
+++ b/stack/manager.go
@@ -10,7 +10,6 @@ import (
 	"path"
 	"path/filepath"
 	"sort"
-	"strings"
 
 	"github.com/rs/zerolog/log"
 	"github.com/terramate-io/terramate/config"
@@ -135,11 +134,6 @@ func (m *Manager) ListChanged(gitBaseRef string) (*Report, error) {
 		logger = logger.With().
 			Stringer("path", projpath).
 			Logger()
-
-		if strings.HasPrefix(path, ".") && !isTriggerFile {
-			logger.Debug().Msg("ignoring changed file starting with .")
-			continue
-		}
 
 		if isTriggerFile {
 			logger = logger.With().

--- a/stack/manager_test.go
+++ b/stack/manager_test.go
@@ -55,7 +55,7 @@ func TestListChangedStacks(t *testing.T) {
 			},
 		},
 		{
-			name:        "single stack: different base",
+			name:        "single stack changed using different base",
 			repobuilder: singleNotChangedStack,
 			baseRef:     "HEAD^",
 			want: listTestResult{
@@ -81,6 +81,22 @@ func TestListChangedStacks(t *testing.T) {
 		{
 			name:        "single stack: changed",
 			repobuilder: singleChangedStacksRepo,
+			want: listTestResult{
+				list:    []string{"/"},
+				changed: []string{"/"},
+			},
+		},
+		{
+			name:        "single stack: dotfile changed",
+			repobuilder: singleChangedDotFileStackRepo,
+			want: listTestResult{
+				list:    []string{"/"},
+				changed: []string{"/"},
+			},
+		},
+		{
+			name:        "single stack: file inside dotdir changed",
+			repobuilder: singleChangedDotDirStackRepo,
 			want: listTestResult{
 				list:    []string{"/"},
 				changed: []string{"/"},
@@ -294,6 +310,34 @@ func singleChangedStacksRepo(t *testing.T) repository {
 	assert.NoError(t, g.Add("bar"), "add bar failed")
 	assert.NoError(t, g.Commit("bar message"), "bar commit failed")
 
+	return repo
+}
+
+func singleChangedDotFileStackRepo(t *testing.T) repository {
+	repo := singleMergeCommitRepo(t)
+
+	g := test.NewGitWrapper(t, repo.Dir, []string{})
+
+	assert.NoError(t, g.Checkout("testbranch2", true), "git checkout failed")
+
+	_ = test.WriteFile(t, repo.Dir, ".bar", "bar")
+
+	assert.NoError(t, g.Add(".bar"), "add .bar failed")
+	assert.NoError(t, g.Commit("bar message"), "bar commit failed")
+	return repo
+}
+
+func singleChangedDotDirStackRepo(t *testing.T) repository {
+	repo := singleMergeCommitRepo(t)
+
+	g := test.NewGitWrapper(t, repo.Dir, []string{})
+
+	assert.NoError(t, g.Checkout("testbranch2", true), "git checkout failed")
+
+	_ = test.WriteFile(t, filepath.Join(repo.Dir, ".bar"), "bar", "bar")
+
+	assert.NoError(t, g.Add(".bar"), "add .bar dir failed")
+	assert.NoError(t, g.Commit("bar dir message"), "bar commit failed")
 	return repo
 }
 


### PR DESCRIPTION
## What this PR does / why we need it:

Enable the detection of changes in dotfiles.
*Note: this is a breaking change*

@soerenmartius @mariux It looks like we never documented that dotfiles were ignored in the change detection. Should we explicit document this now or is it clear that they are treated the same as any other file? See [here](https://terramate.io/docs/cli/change-detection/integrations/git)

## Which issue(s) this PR fixes:
none

## Special notes for your reviewer:

- [x] A major version bump is needed before this PR can be merged.

## Does this PR introduce a user-facing change?
```
yes
```
