### PR TITLE
tests: fix race condition by acquiring wrong lock.

### DIFF
--- a/cloud/testserver/cloudstore/store.go
+++ b/cloud/testserver/cloudstore/store.go
@@ -59,7 +59,7 @@ type (
 		TechnologyLayer string                    `json:"technology_layer"`
 		ReviewRequest   *cloud.ReviewRequest      `json:"review_request,omitempty"`
 		Metadata        *cloud.DeploymentMetadata `json:"metadata,omitempty"`
-		StackPreviews   []StackPreview            `json:"stack_previews"`
+		StackPreviews   []*StackPreview           `json:"stack_previews"`
 	}
 
 	// StackPreview is the stack preview model.
@@ -309,13 +309,12 @@ func (d *Data) UpsertStack(orguuid cloud.UUID, st Stack) (int64, error) {
 
 // AppendPreviewLogs appends logs to the given stack preview.
 func (d *Data) AppendPreviewLogs(org Org, stackPreviewID string, logs cloud.CommandLogs) error {
-	d.mu.RLock()
-	defer d.mu.RUnlock()
+	d.mu.Lock()
+	defer d.mu.Unlock()
 	for _, p := range org.Previews {
-		for spIndex, sp := range p.StackPreviews {
+		for _, sp := range p.StackPreviews {
 			if sp.ID == stackPreviewID {
 				sp.Logs = append(sp.Logs, logs...)
-				p.StackPreviews[spIndex] = sp
 				return nil
 			}
 		}
@@ -377,7 +376,7 @@ func (d *Data) GetPreviewByID(org Org, previewID string) (Preview, bool) {
 }
 
 // UpsertStackPreview inserts or updates the given stack preview.
-func (d *Data) UpsertStackPreview(org Org, previewID string, sp StackPreview) (string, error) {
+func (d *Data) UpsertStackPreview(org Org, previewID string, sp *StackPreview) (string, error) {
 	_, pIndex, found := d.getPreviewByID(org, previewID)
 	d.mu.Lock()
 	defer d.mu.Unlock()
@@ -401,22 +400,21 @@ func (d *Data) UpsertStackPreview(org Org, previewID string, sp StackPreview) (s
 }
 
 // UpdateStackPreview updates the given stack preview.
-func (d *Data) UpdateStackPreview(org Org, stackPreviewID string, status string, changeset *cloud.ChangesetDetails) (StackPreview, bool) {
-	d.mu.RLock()
-	defer d.mu.RUnlock()
-	for i, p := range org.Previews {
-		for spIndex, sp := range p.StackPreviews {
+func (d *Data) UpdateStackPreview(org Org, stackPreviewID string, status string, changeset *cloud.ChangesetDetails) (*StackPreview, bool) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	for _, p := range org.Previews {
+		for _, sp := range p.StackPreviews {
 			if sp.ID == stackPreviewID {
-				org.Previews[i].StackPreviews[spIndex].Status = preview.StackStatus(status)
+				sp.Status = preview.StackStatus(status)
 				if changeset != nil {
-					org.Previews[i].StackPreviews[spIndex].ChangesetDetails = changeset
+					sp.ChangesetDetails = changeset
 				}
 				return sp, true
 			}
 		}
-
 	}
-	return StackPreview{}, false
+	return nil, false
 }
 
 // GetDeployment returns the given deployment.
@@ -607,13 +605,13 @@ func (d *Data) GetGithubPullRequestResponse() json.RawMessage {
 	return d.Github.GetPullRequestResponse
 }
 
-func (d *Data) getStackPreviewByMetaID(spMetaID string, stackPreviews []StackPreview) (StackPreview, int64, bool) {
+func (d *Data) getStackPreviewByMetaID(spMetaID string, stackPreviews []*StackPreview) (*StackPreview, int64, bool) {
 	for i := range stackPreviews {
 		if stackPreviews[i].Stack.MetaID == spMetaID {
 			return stackPreviews[i], int64(i), true
 		}
 	}
-	return StackPreview{}, 0, false
+	return nil, 0, false
 }
 
 func (d *Data) getPreviewByID(org Org, id string) (Preview, int64, bool) {

--- a/cloud/testserver/cloudstore/store_test.go
+++ b/cloud/testserver/cloudstore/store_test.go
@@ -56,7 +56,7 @@ func TestUpsertPreview(t *testing.T) {
 			Description: "Test descritiption",
 			URL:         "https://github.com/terramate-io/terramate/pull/42",
 		},
-		StackPreviews: []cloudstore.StackPreview{
+		StackPreviews: []*cloudstore.StackPreview{
 			{
 				Stack: cloudstore.Stack{
 					Stack: cloud.Stack{

--- a/cloud/testserver/previews.go
+++ b/cloud/testserver/previews.go
@@ -189,7 +189,7 @@ func PostPreviews(store *cloudstore.Data, w http.ResponseWriter, r *http.Request
 			return
 		}
 
-		stackPreviewID, err := store.UpsertStackPreview(org, previewID, cloudstore.StackPreview{
+		stackPreviewID, err := store.UpsertStackPreview(org, previewID, &cloudstore.StackPreview{
 			Stack: cloudstore.Stack{
 				Stack: s.Stack,
 				State: cloudstore.NewState(),

--- a/cmd/terramate/e2etests/cloud/run_cloud_sync_preview_test.go
+++ b/cmd/terramate/e2etests/cloud/run_cloud_sync_preview_test.go
@@ -71,7 +71,7 @@ func TestCLIRunWithCloudSyncPreview(t *testing.T) {
 					Technology:      "terraform",
 					TechnologyLayer: "default",
 					UpdatedAt:       1707482312,
-					StackPreviews: []cloudstore.StackPreview{
+					StackPreviews: []*cloudstore.StackPreview{
 						{
 							ID:     "1",
 							Status: "changed",
@@ -114,7 +114,7 @@ func TestCLIRunWithCloudSyncPreview(t *testing.T) {
 					Technology:      "terraform",
 					TechnologyLayer: "default",
 					UpdatedAt:       1707482312,
-					StackPreviews: []cloudstore.StackPreview{
+					StackPreviews: []*cloudstore.StackPreview{
 						{
 							ID:     "1",
 							Status: "failed",


### PR DESCRIPTION
## What this PR does / why we need it:

Makes use of `mu.Lock()` in the `AppendPreviewLogs()` because `sp.Logs` is being mutated.

As the stack previews need to be updated in the handlers, then it was changed to store a list of pointers so the brittle code below is avoided:
```
for spIndex, sp := range p.StackPreviews {
    for _, sp := range p.StackPreviews { // THIS CREATES A COPY OF SP
        if sp.ID == stackPreviewID {
            sp.Logs = append(sp.Logs, logs...)
            p.StackPreviews[spIndex] = sp // THIS UPDATES WITH THE NEW COPY
	    return nil
        }
    }
}
```
Another example is changes like:
```
org.Previews[i].StackPreviews[spIndex].Status = preview.StackStatus(status)
```
If the value must be mutated by several entities, then better be a pointer protected by mutex than values copied over and also protected by mutex.

Targets #1533 

## Which issue(s) this PR fixes:
none

## Special notes for your reviewer:

@wmalik if you agree, just merge onto your branch (you can rebase later, dont need to maintain this commit)

## Does this PR introduce a user-facing change?
```
no
```
