### PR TITLE
fix: remove lowercase validation from stack.meta_id

### DIFF
--- a/cloud/types.go
+++ b/cloud/types.go
@@ -410,9 +410,6 @@ func (s Stack) Validate() error {
 	if s.MetaID == "" {
 		return errors.E(`missing "meta_id" field`)
 	}
-	if strings.ToLower(s.MetaID) != s.MetaID {
-		return errors.E(`"meta_id" requires a lowercase string but %s provided`, s.MetaID)
-	}
 	return nil
 }
 


### PR DESCRIPTION
## What this PR does / why we need it:

The lowercase validation prevents users from syncing the stack details to TMC.
This PR removes that validation.

## Which issue(s) this PR fixes:

## Special notes for your reviewer:

This fix is targetted for `v0.4.7`

## Does this PR introduce a user-facing change?
```
Yes, this will allow users to use uppercase stack ids in the stack block.

```
