### PR TITLE
fix: use lower case stack.id for lookup

### DIFF
--- a/cloud/types.go
+++ b/cloud/types.go
@@ -410,6 +410,11 @@ func (s Stack) Validate() error {
 	if s.MetaID == "" {
 		return errors.E(`missing "meta_id" field`)
 	}
+
+	if strings.ToLower(s.MetaID) != s.MetaID {
+		return errors.E(`"meta_id" requires a lowercase string but %s provided`, s.MetaID)
+	}
+
 	return nil
 }
 

--- a/cmd/terramate/cli/cloud_sync_deployment.go
+++ b/cmd/terramate/cli/cloud_sync_deployment.go
@@ -149,7 +149,7 @@ func (c *cli) doCloudSyncDeployment(run runContext, status deployment.Status) {
 		Stringer("status", status).
 		Logger()
 
-	stackID, ok := c.cloud.run.meta2id[st.ID]
+	stackID, ok := c.cloud.run.meta2id[strings.ToLower(st.ID)]
 	if !ok {
 		logger.Error().Msg("unable to update deployment status due to invalid API response")
 		return

--- a/cmd/terramate/cli/cloud_sync_drift.go
+++ b/cmd/terramate/cli/cloud_sync_drift.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"time"
 
 	tfjson "github.com/hashicorp/terraform-json"
@@ -68,7 +69,7 @@ func (c *cli) cloudSyncDriftStatus(run runContext, res runResult, err error) {
 			Repository:      c.prj.prettyRepo(),
 			DefaultBranch:   c.prj.gitcfg().DefaultBranch,
 			Path:            st.Dir.String(),
-			MetaID:          st.ID,
+			MetaID:          strings.ToLower(st.ID),
 			MetaName:        st.Name,
 			MetaDescription: st.Description,
 			MetaTags:        st.Tags,

--- a/cmd/terramate/cli/run.go
+++ b/cmd/terramate/cli/run.go
@@ -373,7 +373,7 @@ func (c *cli) syncLogs(logger *zerolog.Logger, run runContext, logs cloud.Deploy
 	logger.Debug().RawJSON("logs", data).Msg("synchronizing logs")
 	ctx, cancel := context.WithTimeout(context.Background(), defaultCloudTimeout)
 	defer cancel()
-	stackID := c.cloud.run.meta2id[run.Stack.ID]
+	stackID := c.cloud.run.meta2id[strings.ToLower(run.Stack.ID)]
 	err := c.cloud.client.SyncDeploymentLogs(
 		ctx, c.cloud.run.orgUUID, stackID, c.cloud.run.runUUID, logs,
 	)

--- a/cmd/terramate/e2etests/cloud/run_cloud_drift_test.go
+++ b/cmd/terramate/e2etests/cloud/run_cloud_drift_test.go
@@ -230,6 +230,29 @@ func TestCLIRunWithCloudSyncDriftStatus(t *testing.T) {
 			},
 		},
 		{
+			name:   "basic drift sync with uppercase stack id",
+			layout: []string{"s:stack:id=STACK"},
+			cmd: []string{
+				HelperPath, "exit", "2",
+			},
+			want: want{
+				drifts: expectedDriftStackPayloadRequests{
+					{
+						DriftStackPayloadRequest: cloud.DriftStackPayloadRequest{
+							Stack: cloud.Stack{
+								Repository:    "local",
+								DefaultBranch: "main",
+								Path:          "/stack",
+								MetaName:      "stack",
+								MetaID:        "stack",
+							},
+							Status: drift.Drifted,
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "only stacks inside working dir are synced",
 			layout: []string{
 				"s:parent:id=parent",


### PR DESCRIPTION
## What this PR does / why we need it:

This would allow users to sync stack logs for stacks having uppercase (or mixed case) stack ids.

## Which issue(s) this PR fixes:
## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
Yes, this would allow users to sync stacks with uppercase (or mixed case) stack
ids to Terramate Cloud.
```
