### PR TITLE
chore: increase terraform show timeout.

### DIFF
--- a/cmd/terramate/cli/cloud_sync_drift.go
+++ b/cmd/terramate/cli/cloud_sync_drift.go
@@ -22,6 +22,8 @@ import (
 	"github.com/terramate-io/terramate/errors"
 )
 
+const terraformShowTimeout = 60 * time.Second
+
 func (c *cli) cloudSyncDriftStatus(run runContext, res runResult, err error) {
 	st := run.Stack
 
@@ -165,8 +167,7 @@ func (c *cli) runTerraformShow(run runContext, planfile string, flags ...string)
 	args = append(args, flags...)
 	args = append(args, planfile)
 
-	const tfShowTimeout = 5 * time.Second
-	ctx, cancel := context.WithTimeout(context.Background(), tfShowTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), terraformShowTimeout)
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, "terraform", args...)


### PR DESCRIPTION
## What this PR does / why we need it:

Increases the `terraform show` timeout to `60s`.

## Which issue(s) this PR fixes:
none

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
no
```
