### PR TITLE
fix: lookup of previewIDs by case-insensitive stack IDs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 
 ## Unreleased
 
+### Fixed
+
+- Fixed internal mapping of `metaID -> previewID` that prevented stack previews from being created if stack ids contained uppercase letters.
+
 ## v0.5.2
 
 ### Fixed

--- a/cmd/terramate/cli/script_run.go
+++ b/cmd/terramate/cli/script_run.go
@@ -173,7 +173,9 @@ func (c *cli) prepareScriptForCloudSync(runs []stackRun) {
 	}
 
 	if len(previewRuns) > 0 {
-		c.cloud.run.stackPreviews = c.createCloudPreview(previewRuns)
+		for metaID, previewID := range c.createCloudPreview(previewRuns) {
+			c.cloud.run.setMeta2PreviewID(metaID, previewID)
+		}
 	}
 }
 


### PR DESCRIPTION
## What this PR does / why we need it:

Fix a similar issue as of #1551 but this time in the map of `metaID -> previewIDs`.

## Which issue(s) this PR fixes:
none

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
no
```
