### PR TITLE
chore: improve warn message in case changeset fails.

### DIFF
--- a/cmd/terramate/cli/cloud.go
+++ b/cmd/terramate/cli/cloud.go
@@ -327,12 +327,14 @@ func (c *cli) doPreviewAfter(run stackCloudRun, res runResult) {
 				sprintf("skipping terraform plan sync for %s", run.Stack.Dir.String()),
 				err)
 
-			printer.Stderr.Warn(
-				sprintf("preview status set to \"failed\" (previously %q) due to failure when generating the "+
-					"changeset details", previewStatus),
-			)
+			if previewStatus != preview.StackStatusFailed {
+				printer.Stderr.Warn(
+					sprintf("preview status set to \"failed\" (previously %q) due to failure when generating the "+
+						"changeset details", previewStatus),
+				)
 
-			previewStatus = preview.StackStatusFailed
+				previewStatus = preview.StackStatusFailed
+			}
 		}
 		if changeset != nil {
 			previewChangeset = &cloud.ChangesetDetails{


### PR DESCRIPTION
## What this PR does / why we need it:

Improve the warning message in the case Terramate fails to generate the ASCII or JSON plan details.

## Which issue(s) this PR fixes:
none

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
no
```
