### PR TITLE
docs: fix typo on parallel examples

### DIFF
--- a/docs/cli/cmdline/run.md
+++ b/docs/cli/cmdline/run.md
@@ -75,15 +75,15 @@ The following example runs 5 stacks in parallel, selects only recently changed s
 
 ```bash
 # initialize changed stacks
-terramate run --changed --prallel 5 -- \
+terramate run --changed --parallel 5 -- \
   terraform init
 
 # create a preview plan
-terramate run --changed --prallel 5 -- \
+terramate run --changed --parallel 5 -- \
   terraform plan -lock-timeout=5m -out out.tfplan
 
 # run the deployment
-terramate run --changed --prallel 5 \
+terramate run --changed --parallel 5 \
   --cloud-sync-deployment \
   --cloud-sync-terraform-plan-file=out.tfplan \
   -- \
@@ -110,7 +110,7 @@ terramate run --parallel 5 -- \\
   terraform init
 
 # run the actual drift detection
-terramate run --prallel 5 \
+terramate run --parallel 5 \
   --cloud-sync-drift-status \
   --cloud-sync-terraform-plan-file=drift.tfplan \
   -- \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/terramate-io/terramate/blob/main/CONTRIBUTING.md
2. If the PR is unfinished, mark it as draft: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request
3. Please update the PR title using the Conventional Commits convention: https://www.conventionalcommits.org/en/v1.0.0/
    Example: feat: add support for XYZ.
-->

## What this PR does / why we need it:

Fixing typos on documentation, `parallel` instead of `prallel`.

## Does this PR introduce a user-facing change?
<!--
If no, just write "no" in the block below.
If yes, please explain the change and update documentation and the CHANGELOG.md file accordingly.
-->
```
no
```
