### PR TITLE
fix(cloud): cloud drift show doesn't work with uppercase stack ids.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 ## Unreleased
 
 - Fix `--cloud-status` flag when stacks were synchronized with uppercase in the `stack.id`.
+- Fix `terramate cloud drift show` when used in stacks containing uppercase in the `stack.id`.
 
 ## v0.5.3
 

--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -16,6 +16,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"strings"
 
 	hversion "github.com/apparentlymart/go-versions/versions"
 	"github.com/rs/zerolog"
@@ -188,7 +189,7 @@ func (c *Client) ListReviewRequests(ctx context.Context, orgUUID UUID) (ReviewRe
 func (c *Client) GetStack(ctx context.Context, orgUUID UUID, repo, metaID string) (StackObject, bool, error) {
 	query := url.Values{
 		"repository": []string{repo},
-		"meta_id":    []string{metaID},
+		"meta_id":    []string{strings.ToLower(metaID)},
 	}
 
 	url := c.URL(path.Join(StacksPath, string(orgUUID)), query)

--- a/cloud/testserver/stacks.go
+++ b/cloud/testserver/stacks.go
@@ -443,6 +443,11 @@ func GetStackDrifts(store *cloudstore.Data, w http.ResponseWriter, r *http.Reque
 			Metadata: drift.Metadata,
 		})
 	}
+	res.Pagination = cloud.PaginatedResult{
+		Total:   int64(len(drifts)),
+		Page:    page,
+		PerPage: int64(len(res.Drifts)),
+	}
 	// return most recent drifts first.
 	sort.Slice(res.Drifts, func(i, j int) bool {
 		return res.Drifts[i].ID > res.Drifts[j].ID

--- a/cmd/terramate/e2etests/cloud/interop/interoperability_test.go
+++ b/cmd/terramate/e2etests/cloud/interop/interoperability_test.go
@@ -103,7 +103,7 @@ func TestInteropSyncDeployment(t *testing.T) {
 func TestInteropDrift(t *testing.T) {
 	for _, stackpath := range []string{
 		"testdata/interop-stacks/basic-drift",
-		// "testdata/interop-stacks/basic-drift-uppercase-id", buggy, not yet
+		"testdata/interop-stacks/basic-drift-uppercase-id",
 	} {
 		t.Run("drift: "+filepath.Base(stackpath), func(t *testing.T) {
 			tmcli := NewInteropCLI(t, datapath(t, stackpath))

--- a/cmd/terramate/e2etests/cloud/run_cloud_deployment_test.go
+++ b/cmd/terramate/e2etests/cloud/run_cloud_deployment_test.go
@@ -354,6 +354,7 @@ func TestCLIRunWithCloudSyncDeployment(t *testing.T) {
 		},
 	} {
 		for _, isParallel := range []bool{false, true} {
+			tc := tc
 			isParallel := isParallel
 			name := tc.name
 			if isParallel {


### PR DESCRIPTION
## What this PR does / why we need it:

The `terramate cloud drift show` command does not work with stacks containing uppercase in the `stack.id`.

## Which issue(s) this PR fixes:
none

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
yes, fixes a bug.
```
