### PR TITLE
feat: add script.job.name and script.job.description.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 
 ## Unreleased
 
+- Add `script.job.name` and `script.job.description` attributes.
+
 ## v0.5.4
 
 - Fix `--cloud-status` flag when stacks were synchronized with uppercase in the `stack.id`.

--- a/cmd/terramate/cli/script_info.go
+++ b/cmd/terramate/cli/script_info.go
@@ -41,10 +41,11 @@ func (c *cli) printScriptInfo() {
 	for _, x := range m.Results {
 		c.output.MsgStdOut("Definition: %v", x.ScriptCfg.Range)
 		if x.ScriptCfg.Name != nil {
-			c.output.MsgStdOut("Name: %s", nameTruncation(exprString(x.ScriptCfg.Name.Expr)))
+			c.output.MsgStdOut("Name: %s", nameTruncation(exprString(x.ScriptCfg.Name.Expr), "script.name"))
 		}
-		c.output.MsgStdOut("Description: %s", exprString(x.ScriptCfg.Description.Expr))
-
+		if x.ScriptCfg.Description != nil {
+			c.output.MsgStdOut("Description: %s", descTruncation(exprString(x.ScriptCfg.Description.Expr), "script.description"))
+		}
 		if len(x.Stacks) > 0 {
 			c.output.MsgStdOut("Stacks:")
 			for _, st := range x.Stacks {
@@ -58,6 +59,12 @@ func (c *cli) printScriptInfo() {
 		for _, job := range x.ScriptCfg.Jobs {
 			for cmdIdx, cmd := range formatScriptJob(job) {
 				if cmdIdx == 0 {
+					if job.Name != nil {
+						c.output.MsgStdOut("  Name: %s", nameTruncation(exprString(job.Name.Expr), "script.job.name"))
+					}
+					if job.Description != nil {
+						c.output.MsgStdOut("  Description: %s", descTruncation(exprString(job.Description.Expr), "script.job.description"))
+					}
 					c.output.MsgStdOut("  * %v", cmd)
 				} else {
 					c.output.MsgStdOut("    %v", cmd)
@@ -175,12 +182,22 @@ func formatScriptJob(job *hcl.ScriptJob) []string {
 	return []string{}
 }
 
-func nameTruncation(name string) string {
+func nameTruncation(name string, attrName string) string {
 	if len(name) > config.MaxScriptNameRunes {
 		printer.Stderr.Warn(
-			fmt.Sprintf("`script.name` exceeds the maximum allowed characters (%d): field truncated", config.MaxScriptNameRunes),
+			fmt.Sprintf("`%s` exceeds the maximum allowed characters (%d): field truncated", attrName, config.MaxScriptNameRunes),
 		)
 		return name[:config.MaxScriptNameRunes] + "..."
+	}
+	return name
+}
+
+func descTruncation(name string, attrName string) string {
+	if len(name) > config.MaxScriptDescRunes {
+		printer.Stderr.Warn(
+			fmt.Sprintf("`%s` exceeds the maximum allowed characters (%d): field truncated", attrName, config.MaxScriptNameRunes),
+		)
+		return name[:config.MaxScriptDescRunes] + "..."
 	}
 	return name
 }

--- a/cmd/terramate/cli/script_list.go
+++ b/cmd/terramate/cli/script_list.go
@@ -35,10 +35,11 @@ func (c *cli) printScriptList() {
 
 		c.output.MsgStdOut("%v", name)
 		if entry.ScriptCfg.Name != nil {
-			c.output.MsgStdOut("  Name: %v", nameTruncation(exprString(entry.ScriptCfg.Name.Expr)))
+			c.output.MsgStdOut("  Name: %v", nameTruncation(exprString(entry.ScriptCfg.Name.Expr), "script.name"))
 		}
-		c.output.MsgStdOut("  Description: %v", exprString(entry.ScriptCfg.Description.Expr))
-
+		if entry.ScriptCfg.Description != nil {
+			c.output.MsgStdOut("  Description: %v", exprString(entry.ScriptCfg.Description.Expr))
+		}
 		c.output.MsgStdOut("  Defined at %v", entry.Dir)
 
 		if entry.DefCount > 1 {

--- a/cmd/terramate/cli/script_tree.go
+++ b/cmd/terramate/cli/script_tree.go
@@ -75,12 +75,14 @@ func (node *scriptsTreeNode) format(w io.Writer, prefix string, parentScripts []
 	}
 
 	for _, sc := range node.Scripts {
-		desc := exprString(sc.Description.Expr)
 		fmt.Fprintln(w, blockPrefix+"* "+scriptColor(sc.AccessorName()+": "))
 		if sc.Name != nil {
-			fmt.Fprintln(w, blockPrefix+"  "+scriptColor("  name: "+nameTruncation(exprString(sc.Name.Expr))))
+			fmt.Fprintln(w, blockPrefix+"  "+scriptColor("  Name: "+nameTruncation(exprString(sc.Name.Expr), "script.name")))
 		}
-		fmt.Fprintln(w, blockPrefix+"  "+scriptColor("  description: "+desc))
+		if sc.Description != nil {
+			desc := exprString(sc.Description.Expr)
+			fmt.Fprintln(w, blockPrefix+"  "+scriptColor("  Description: "+desc))
+		}
 	}
 
 	if node.IsStack {

--- a/hcl/hcl_script_test.go
+++ b/hcl/hcl_script_test.go
@@ -15,9 +15,9 @@ import (
 )
 
 func TestHCLScript(t *testing.T) {
-	makeAttribute := func(t *testing.T, name string, expr string) ast.Attribute {
+	makeAttribute := func(t *testing.T, name string, expr string) *ast.Attribute {
 		t.Helper()
-		return ast.Attribute{
+		return &ast.Attribute{
 			Attribute: &hhcl.Attribute{
 				Name: name,
 				Expr: test.NewExpr(t, expr),
@@ -26,12 +26,14 @@ func TestHCLScript(t *testing.T) {
 	}
 
 	makeCommand := func(t *testing.T, expr string) *hcl.Command {
-		parsed := hcl.Command(makeAttribute(t, "command", expr))
+		attr := makeAttribute(t, "command", expr)
+		parsed := hcl.Command(*attr)
 		return &parsed
 	}
 
 	makeCommands := func(t *testing.T, expr string) *hcl.Commands {
-		parsed := hcl.Commands(makeAttribute(t, "commands", expr))
+		attr := makeAttribute(t, "commands", expr)
+		parsed := hcl.Commands(*attr)
 		return &parsed
 	}
 
@@ -119,16 +121,30 @@ func TestHCLScript(t *testing.T) {
 					filename: "script.tm",
 					body: `
 					  script "group1" "script1" {
+						job {
+							command = ["echo", "hello"]
+						}
 					  }
 					`,
 				},
 			},
 			want: want{
-				errs: []error{
-					errors.E(hcl.ErrScriptNoDesc,
-						Mkrange("script.tm", Start(2, 8, 8), End(3, 9, 44))),
-					errors.E(hcl.ErrScriptMissingOrInvalidJob,
-						Mkrange("script.tm", Start(2, 8, 8), End(3, 9, 44))),
+				config: hcl.Config{
+					Terramate: &hcl.Terramate{
+						Config: &hcl.RootConfig{
+							Experiments: []string{"scripts"},
+						},
+					},
+					Scripts: []*hcl.Script{
+						{
+							Labels: []string{"group1", "script1"},
+							Jobs: []*hcl.ScriptJob{
+								{
+									Command: makeCommand(t, `["echo", "hello"]`),
+								},
+							},
+						},
+					},
 				},
 			},
 		},
@@ -299,7 +315,7 @@ func TestHCLScript(t *testing.T) {
 					Scripts: []*hcl.Script{
 						{
 							Labels:      []string{"group1", "script1"},
-							Description: hcl.NewScriptDescription(makeAttribute(t, "description", `"some description"`)),
+							Description: makeAttribute(t, "description", `"some description"`),
 							Jobs: []*hcl.ScriptJob{
 								{
 									Command: makeCommand(t, `["echo", "hello"]`),
@@ -379,7 +395,7 @@ func TestHCLScript(t *testing.T) {
 					Scripts: []*hcl.Script{
 						{
 							Labels:      []string{"group1", "script1"},
-							Description: hcl.NewScriptDescription(makeAttribute(t, "description", `"some description"`)),
+							Description: makeAttribute(t, "description", `"some description"`),
 							Jobs: []*hcl.ScriptJob{
 								{
 									Commands: makeCommands(t, `[["echo", "hello"], ["echo", "bye"]]`),
@@ -491,7 +507,7 @@ func TestHCLScript(t *testing.T) {
 			},
 			want: want{
 				errs: []error{
-					errors.E(hcl.ErrScriptUnrecognizedAttr,
+					errors.E(hcl.ErrScriptJobUnrecognizedAttr,
 						Mkrange("script.tm", Start(6, 9, 126), End(6, 20, 137))),
 					errors.E(hcl.ErrScriptMissingOrInvalidJob,
 						Mkrange("script.tm", Start(2, 8, 8), End(8, 9, 162))),
@@ -541,7 +557,7 @@ func TestHCLScript(t *testing.T) {
 					Scripts: []*hcl.Script{
 						{
 							Labels:      []string{"group1", "script1"},
-							Description: hcl.NewScriptDescription(makeAttribute(t, "description", `"some description"`)),
+							Description: makeAttribute(t, "description", `"some description"`),
 							Jobs: []*hcl.ScriptJob{
 								{
 									Commands: makeCommands(t, `[["echo", "hello"], ["echo", "bye"]]`),
@@ -605,7 +621,7 @@ func TestHCLScript(t *testing.T) {
 					Scripts: []*hcl.Script{
 						{
 							Labels:      []string{"group1", "script1"},
-							Description: hcl.NewScriptDescription(makeAttribute(t, "description", `"script1 desc"`)),
+							Description: makeAttribute(t, "description", `"script1 desc"`),
 							Jobs: []*hcl.ScriptJob{
 								{
 									Commands: makeCommands(t, `[["echo", "hello"], ["echo", "bye"]]`),
@@ -614,7 +630,7 @@ func TestHCLScript(t *testing.T) {
 						},
 						{
 							Labels:      []string{"group1", "script2"},
-							Description: hcl.NewScriptDescription(makeAttribute(t, "description", `"script2 desc"`)),
+							Description: makeAttribute(t, "description", `"script2 desc"`),
 							Jobs: []*hcl.ScriptJob{
 								{
 									Commands: makeCommands(t, `[["cat", "main.tf"]]`),
@@ -660,6 +676,8 @@ func TestHCLScript(t *testing.T) {
 					  script "group1" "script1" {
 						description = "some description"
 						job {
+						  name = "hello job"
+						  description = "hello job description"
 						  command = ["echo", "hello"]
 						}
 					  }
@@ -680,10 +698,12 @@ func TestHCLScript(t *testing.T) {
 					Scripts: []*hcl.Script{
 						{
 							Labels:      []string{"group1", "script1"},
-							Description: hcl.NewScriptDescription(makeAttribute(t, "description", `"some description"`)),
+							Description: makeAttribute(t, "description", `"some description"`),
 							Jobs: []*hcl.ScriptJob{
 								{
-									Command: makeCommand(t, `["echo", "hello"]`),
+									Name:        makeAttribute(t, "name", `"hello job"`),
+									Description: makeAttribute(t, "description", `"hello job description"`),
+									Command:     makeCommand(t, `["echo", "hello"]`),
 								},
 							},
 						},

--- a/test/hcl.go
+++ b/test/hcl.go
@@ -292,9 +292,14 @@ func assertScriptBlocks(t *testing.T, got, want []*hcl.Script) {
 	for i, g := range got {
 		w := want[i]
 
-		assert.EqualStrings(t,
-			exprAsStr(t, w.Description.Expr), exprAsStr(t, g.Description.Expr),
-			"description expr mismatch")
+		if w.Description != nil {
+			assert.EqualStrings(t,
+				exprAsStr(t, w.Description.Expr), exprAsStr(t, g.Description.Expr),
+				"description expr mismatch")
+		} else if g.Description != nil {
+			t.Fatalf("got script.description[%s] but expected nil", exprAsStr(t, g.Description.Expr))
+
+		}
 
 		assert.IsTrue(t, slices.Equal(w.Labels, g.Labels),
 			fmt.Sprintf("script label value mismatch: want[%#v], got [%#v]", w.Labels, g.Labels))
@@ -302,6 +307,24 @@ func assertScriptBlocks(t *testing.T, got, want []*hcl.Script) {
 		assert.EqualInts(t, len(w.Jobs), len(g.Jobs), "script len(jobs) mismatch")
 		for k, gotJob := range g.Jobs {
 			wantJob := w.Jobs[k]
+
+			if wantJob.Name != nil {
+				assert.EqualStrings(t,
+					exprAsStr(t, wantJob.Name.Expr),
+					exprAsStr(t, gotJob.Name.Expr),
+				)
+			} else if gotJob.Name != nil {
+				t.Fatalf("got job.name[%s] but expected nil", exprAsStr(t, gotJob.Name.Expr))
+			}
+
+			if wantJob.Description != nil {
+				assert.EqualStrings(t,
+					exprAsStr(t, wantJob.Description.Expr),
+					exprAsStr(t, gotJob.Description.Expr),
+				)
+			} else if gotJob.Description != nil {
+				t.Fatalf("got job.description[%s] but expected nil", exprAsStr(t, gotJob.Description.Expr))
+			}
 
 			if wantJob.Command != nil {
 				assert.EqualStrings(t,


### PR DESCRIPTION
## What this PR does / why we need it:

Now it's possible to give a meaningful name and description to each `script.job` block.

## Which issue(s) this PR fixes:
none

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
yes, a new feature.
```
