### PR TITLE
docs: cloud_sync_previen option in script commands. 

### DIFF
--- a/docs/cli/orchestration/scripts.md
+++ b/docs/cli/orchestration/scripts.md
@@ -121,8 +121,9 @@ script "deploy" {
 ### Command options
 
 - `cloud_sync_deployment` _(optional boolean)_ Send information about the deployment to Terramate Cloud. See [Sending deployment data to Terramate Cloud](../cmdline/run.md#sending-deployment-data-to-terramate-cloud). Only one command per script may have this option set to true.
+- `cloud_sync_preview` _(optional boolean)_ Send information about a _Pull Request_ preview to Terramate Cloud. See [Sending a Pull Request Preview to Terramate Cloud](../cmdline/run.md#sending-a-pull-request-preview-to-terramate-cloud). Only one command per script may have this option set to true.
 - `cloud_sync_drift_status` _(optional boolean)_ Send drift information to Terramate Cloud. See [Detecting Drifts](../cmdline/run.md#detecting-drift).
-- `cloud_sync_terraform_plan_file` _(optional string)_ Sync a Terraform plan file to Terramate Cloud with a deployment or drift. This option is only used when `cloud_sync_deployment` or `cloud_sync_drift_status` are set to true.
+- `cloud_sync_terraform_plan_file` _(optional string)_ Sync a Terraform plan file to Terramate Cloud with a deployment or drift. This option is only used when `cloud_sync_deployment`, `cloud_sync_drift_status` or `cloud_sync_preview` are set to true.
 
 ## Running Scripts
 


### PR DESCRIPTION
## What this PR does / why we need it:

Document the `cloud_sync_preview` option for synchronizing previews to Terramate Cloud.

## Which issue(s) this PR fixes:
none

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
no
```
