### PR TITLE
fix: use --quiet flag in interop tests

### DIFF
--- a/cmd/terramate/e2etests/cloud/interop/interoperability_test.go
+++ b/cmd/terramate/e2etests/cloud/interop/interoperability_test.go
@@ -21,7 +21,7 @@ func TestInteropSyncDeployment(t *testing.T) {
 		Stdout: nljoin("."),
 	})
 	AssertRunResult(t,
-		tmcli.Run("run", "--cloud-sync-deployment", "--", HelperPath, "false"),
+		tmcli.Run("run", "--quiet", "--cloud-sync-deployment", "--", HelperPath, "false"),
 		RunExpected{
 			IgnoreStderr: true,
 			Status:       1,
@@ -32,7 +32,7 @@ func TestInteropSyncDeployment(t *testing.T) {
 			Stdout: nljoin("."),
 		},
 	)
-	AssertRun(t, tmcli.Run("run", "--cloud-sync-deployment", "--", HelperPath, "true"))
+	AssertRun(t, tmcli.Run("run", "--quiet", "--cloud-sync-deployment", "--", HelperPath, "true"))
 	AssertRun(t, tmcli.Run("list", "--cloud-status=unhealthy"))
 }
 
@@ -43,7 +43,7 @@ func TestInteropDrift(t *testing.T) {
 	})
 	// initialize the providers
 	AssertRunResult(t,
-		tmcli.Run("run", "--", TerraformTestPath, "init"),
+		tmcli.Run("run", "--quiet", "--", TerraformTestPath, "init"),
 		RunExpected{
 			Status:       0,
 			IgnoreStdout: true,
@@ -53,7 +53,7 @@ func TestInteropDrift(t *testing.T) {
 
 	// basic drift, without details
 	AssertRunResult(t,
-		tmcli.Run("run", "--cloud-sync-drift-status", "--", TerraformTestPath, "plan", "-detailed-exitcode"),
+		tmcli.Run("run", "--quiet", "--cloud-sync-drift-status", "--", TerraformTestPath, "plan", "-detailed-exitcode"),
 		RunExpected{
 			Status:       0,
 			IgnoreStdout: true,
@@ -102,7 +102,7 @@ func TestInteropDrift(t *testing.T) {
 	)
 
 	// check reseting the drift status to OK
-	AssertRun(t, tmcli.Run("run", "--cloud-sync-drift-status", "--", HelperPath, "exit", "0"))
+	AssertRun(t, tmcli.Run("run", "--quiet", "--cloud-sync-drift-status", "--", HelperPath, "exit", "0"))
 	AssertRun(t, tmcli.Run("list", "--cloud-status=unhealthy"))
 	AssertRunResult(t,
 		tmcli.Run("cloud", "drift", "show"),


### PR DESCRIPTION
## What this PR does / why we need it:

This PR backports the fix for interop tests in 0.4.x.

## Which issue(s) this PR fixes:

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
No.
```
