### PR TITLE
fix: clone stacks with imports.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 ### Fixed
 
 - Fixed a bug in the dotfiles handling in the code generation. Now it's possible to generate files such as `.tflint.hcl`.
+- Fixed the cloning of stacks containing `import` blocks.
 
 ### Changed
 

--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -1949,7 +1949,7 @@ func (c *cli) ensureStackID() {
 			continue
 		}
 
-		id, err := stack.UpdateStackID(entry.Stack.HostDir(c.cfg()))
+		id, err := stack.UpdateStackID(c.cfg(), entry.Stack.HostDir(c.cfg()))
 		if err != nil {
 			fatal(sprintf("failed to update stack.id of stack %s", entry.Stack.Dir), err)
 		}

--- a/stack/clone.go
+++ b/stack/clone.go
@@ -136,7 +136,7 @@ func Clone(root *config.Root, destdir, srcdir string, skipChildStacks bool) (int
 			continue
 		}
 
-		if _, err := UpdateStackID(st.Destdir); err != nil {
+		if _, err := UpdateStackID(root, st.Destdir); err != nil {
 			return 0, err
 		}
 	}
@@ -148,8 +148,8 @@ func Clone(root *config.Root, destdir, srcdir string, skipChildStacks bool) (int
 // UpdateStackID updates the stack.id of the given stack directory.
 // The functions updates just the file which defines the stack block.
 // The updated file will lose all comments.
-func UpdateStackID(stackdir string) (string, error) {
-	parser, err := hcl.NewTerramateParser(stackdir, stackdir)
+func UpdateStackID(root *config.Root, stackdir string) (string, error) {
+	parser, err := hcl.NewTerramateParser(root.HostDir(), stackdir)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
## What this PR does / why we need it:

Fix the cloning of stacks that contains imports.

## Which issue(s) this PR fixes:
Fixes #1390 

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
yes, bug is fixed.
```
