### PR TITLE
doc: correcting typo

### DIFF
--- a/docs/cli/code-generation/index.md
+++ b/docs/cli/code-generation/index.md
@@ -257,7 +257,7 @@ We recommend the following best practices when working with code generation.
 
 ### Add generated files to your Git repository
 
-Commit the generated files to the repository. This can be archived either by manually running `terramate generate`
+Commit the generated files to the repository. This can be achieved either by manually running `terramate generate`
 locally or by automating `terramate generate` in your CI/CD pipelines.
 In any case, the generated files should be available to the Pull Request reviewer so they can spot misconfigurations.
 

--- a/docs/cli/stacks/nesting.md
+++ b/docs/cli/stacks/nesting.md
@@ -42,7 +42,7 @@ This tree structure following the directory hierarchy has three significant feat
   [breadth-first search algorithm](https://en.wikipedia.org/wiki/Breadth-first_search), which will be created before the
   EC2 instance. This means a great reduction in explicit dependencies:
   you do not need to specify that the subnet depends upon the existing VPC - it's a natural outcome of the hierarchy
-  (though we also support explicit dependencies with wants, before and after attributes in
+  (though we also support explicit dependencies with `wants`, `before` and `after` attributes in
   [stack configuration](./configuration.md)).
 - **Cloning of stacks:** nested stacks can represent whole environments, services or single resources. A neat feature in
   Terramate is that stacks and nested stacks can easily be cloned using the


### PR DESCRIPTION

## What this PR does / why we need it:
Correcting a spelling mistake in the docs.

