### PR TITLE
feat: add --terragrunt option for run and scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
     - the script execution will be aborted and no further commands or jobs from that script will be run on the current stack node.
     - the script execution will continue to run on the next stack node.
     - `terramate script run` will return exit code 1 (same behaviour as `terramate run --continue-on-error`).
+- Improved Terragrunt integration by adding `--terragrunt` flag.
+  - Instructs the CLI to use the Terragrunt binary when generating a plan file for cloud syncing.
+  - It's supported as a flag for `terramate run` and as a command option `terragrunt = true` for script commands.
 
 ### Fixed
 

--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -159,6 +159,7 @@ type cliSpec struct {
 		DryRun                     bool          `default:"false" help:"Plan the execution but do not execute it."`
 		Reverse                    bool          `default:"false" help:"Reverse the order of execution."`
 		Eval                       bool          `default:"false" help:"Evaluate command arguments as HCL strings interpolating Globals, Functions and Metadata."`
+		Terragrunt                 bool          `default:"false" help:"Use terragrunt when generating planfile for Terramate Cloud sync."`
 
 		// Note: 0 is not the real default value here, this is just a workaround.
 		// Kong doesn't support having 0 as the default value in case the flag isn't set, but K in case it's set without a value.

--- a/cmd/terramate/cli/script_run.go
+++ b/cmd/terramate/cli/script_run.go
@@ -102,6 +102,7 @@ func (c *cli) runScript() {
 						task.CloudSyncPreview = cmd.Options.CloudSyncPreview
 						task.CloudSyncLayer = cmd.Options.CloudSyncLayer
 						task.CloudSyncTerraformPlanFile = cmd.Options.CloudSyncTerraformPlan
+						task.UseTerragrunt = cmd.Options.UseTerragrunt
 					}
 					run.Tasks = append(run.Tasks, task)
 				}

--- a/cmd/terramate/e2etests/core/run_test.go
+++ b/cmd/terramate/e2etests/core/run_test.go
@@ -2696,6 +2696,25 @@ func TestRunDryRun(t *testing.T) {
 
 }
 
+func TestRunTerragrunt(t *testing.T) {
+	t.Parallel()
+
+	s := sandbox.New(t)
+
+	_ = s.CreateStack("stack")
+
+	git := s.Git()
+	git.CommitAll("first commit")
+	git.Push("main")
+
+	// This just tests if the option is properly supported.
+	cli := NewCLI(t, s.RootDir())
+	AssertRunResult(t,
+		cli.Run("run", "--terragrunt", "--quiet", HelperPath, "true"),
+		RunExpected{},
+	)
+}
+
 func TestRunFailIfGitSafeguardUncommitted(t *testing.T) {
 	t.Parallel()
 

--- a/config/script.go
+++ b/config/script.go
@@ -40,6 +40,7 @@ type ScriptCmdOptions struct {
 	CloudSyncPreview       bool
 	CloudSyncLayer         preview.Layer
 	CloudSyncTerraformPlan string
+	UseTerragrunt          bool
 }
 
 // ScriptCmd represents an evaluated script command
@@ -385,6 +386,15 @@ func unmarshalScriptCommandOptions(obj cty.Value, expr hhcl.Expression) (*Script
 				break
 			}
 			r.CloudSyncTerraformPlan = v.AsString()
+
+		case "terragrunt":
+			if v.Type() != cty.Bool {
+				errs.Append(errors.E(ErrScriptInvalidCmdOptions, expr.Range(),
+					"command option '%s' must be a bool, but has type %s",
+					ks, v.Type().FriendlyName()))
+				break
+			}
+			r.UseTerragrunt = v.True()
 
 		default:
 			errs.Append(errors.E(ErrScriptInvalidCmdOptions, expr.Range(), "unknown command option: %s", ks))

--- a/config/script_test.go
+++ b/config/script_test.go
@@ -659,6 +659,44 @@ func TestScriptEval(t *testing.T) {
 			},
 		},
 		{
+			name: "command options with planfile + terragrunt",
+			script: hcl.Script{
+				Labels:      labels,
+				Description: makeAttribute(t, "description", `"some description"`),
+				Jobs: []*hcl.ScriptJob{
+					{
+						Commands: makeCommands(t, `
+						  [
+							["echo", "hello", {
+								cloud_sync_deployment = true
+								cloud_sync_terraform_plan_file = "plan_a"
+								terragrunt = true
+							}],
+						  ]
+						`),
+					},
+				},
+			},
+			want: config.Script{
+				Labels:      labels,
+				Description: "some description",
+				Jobs: []config.ScriptJob{
+					{
+						Cmds: []*config.ScriptCmd{
+							{
+								Args: []string{"echo", "hello"},
+								Options: &config.ScriptCmdOptions{
+									CloudSyncDeployment:    true,
+									UseTerragrunt:          true,
+									CloudSyncTerraformPlan: "plan_a",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "invalid command option",
 			script: hcl.Script{
 				Labels:      labels,

--- a/docs/cli/cmdline/run.md
+++ b/docs/cli/cmdline/run.md
@@ -282,6 +282,10 @@ terramate run [options] -- <cmd ...>
 
   This flag is supported in combination with `--cloud-sync-drift-status`, `--cloud-sync-preview`, and `--cloud-sync-preview`.
 
+- `--terragrunt`
+
+  Use Terragrunt to generate the Terraform Plan file.
+
 ## Configuration of the Run Command
 
 The `terramate` block at the project root can be used to customize

--- a/docs/cli/orchestration/scripts.md
+++ b/docs/cli/orchestration/scripts.md
@@ -124,6 +124,7 @@ script "deploy" {
 - `cloud_sync_preview` _(optional boolean)_ Send information about a _Pull Request_ preview to Terramate Cloud. See [Sending a Pull Request Preview to Terramate Cloud](../cmdline/run.md#sending-a-pull-request-preview-to-terramate-cloud). Only one command per script may have this option set to true.
 - `cloud_sync_drift_status` _(optional boolean)_ Send drift information to Terramate Cloud. See [Detecting Drifts](../cmdline/run.md#detecting-drift).
 - `cloud_sync_terraform_plan_file` _(optional string)_ Sync a Terraform plan file to Terramate Cloud with a deployment or drift. This option is only used when `cloud_sync_deployment`, `cloud_sync_drift_status` or `cloud_sync_preview` are set to true.
+- `terragrunt` _(optional boolean)_ Use terragrunt for the plan file generation. This option is only used when `cloud_sync_terraform_plan_file` is set.
 
 ## Running Scripts
 

--- a/docs/cloud/deployments/synchronization-with-scripts.md
+++ b/docs/cloud/deployments/synchronization-with-scripts.md
@@ -22,6 +22,7 @@ The following options are available in Terramate Scripts and mirror the CLI opti
 
 - Set `cloud_sync_deployment = true` to let Terramate CLI know about the command that is doing the actual deployment.
 - Set `cloud_sync_terraform_plan_file` to the name of the terraform plan to synchronize the deployment details.
+- Set `terragrunt = true` to use terragrunt for the plan file generation.
 
 ## Terramate Script Config
 

--- a/docs/cloud/drifts/synchronization-with-scripts.md
+++ b/docs/cloud/drifts/synchronization-with-scripts.md
@@ -22,6 +22,7 @@ The following options are available in Terramate Scripts and mirror the CLI opti
 
 - Set `cloud_sync_drift_status = true` to let Terramate CLI know about the command that is doing the actual drift check and returns a detailed exit status to define a successful run that has changes or has no changes detected.
 - Set `cloud_sync_terraform_plan_file` to the name of the terraform plan to synchronize the deployment details.
+- Set `terragrunt = true` to use terragrunt for the plan file generation.
 
 ## Terramate Script Config
 

--- a/docs/cloud/previews/synchronization-with-scripts.md
+++ b/docs/cloud/previews/synchronization-with-scripts.md
@@ -22,6 +22,7 @@ The following options are available in Terramate Scripts and mirror the CLI opti
 
 - Set `cloud_sync_preview = true` to let Terramate CLI know about the command that is doing the actual preview and returns a detailed exit status to define a successful run that has changes or has no changes detected.
 - Set `cloud_sync_terraform_plan_file` to the name of the terraform plan to synchronize the deployment details.
+- Set `terragrunt = true` to use terragrunt for the plan file generation.
 
 ## Terramate Script Config
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/terramate-io/terramate/blob/main/CONTRIBUTING.md
2. If the PR is unfinished, mark it as draft: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request
3. Please update the PR title using the Conventional Commits convention: https://www.conventionalcommits.org/en/v1.0.0/
    Example: feat: add support for XYZ.
-->

## What this PR does / why we need it:

This PR adds a new option flag `--terragrunt` to `terramate run` and the equivalent `terragrunt = true` script command option. This instructs the CLI to use the `terragrunt show` when generating a plan file instead of `terraform show`. In the future this flag may enable other terragrunt-specific behaviour that should be used when using terramate to invoke terragrunt.

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Keep it empty if not applicable.
-->

## Special notes for your reviewer:

* There are no elaborate tests for this yet, just tests to ensure that the option flag is parsed.

## Does this PR introduce a user-facing change?
<!--
If no, just write "no" in the block below.
If yes, please explain the change and update documentation and the CHANGELOG.md file accordingly.
-->
```
Yes, it adds a new flag and script option.
```
