### PR TITLE
chore: undo re-enable signal tests for MacOS

### DIFF
--- a/cmd/terramate/e2etests/cloud/run_cloud_signal_test.go
+++ b/cmd/terramate/e2etests/cloud/run_cloud_signal_test.go
@@ -1,6 +1,8 @@
 // Copyright 2023 Terramate GmbH
 // SPDX-License-Identifier: MPL-2.0
 
+//go:build !darwin
+
 package cloud_test
 
 import (

--- a/cmd/terramate/e2etests/internal/runner/runner_signal_fixture.go
+++ b/cmd/terramate/e2etests/internal/runner/runner_signal_fixture.go
@@ -1,6 +1,8 @@
 // Copyright 2023 Terramate GmbH
 // SPDX-License-Identifier: MPL-2.0
 
+//go:build !darwin
+
 package runner
 
 import (

--- a/cmd/terramate/e2etests/internal/runner/runner_unix.go
+++ b/cmd/terramate/e2etests/internal/runner/runner_unix.go
@@ -1,7 +1,7 @@
 // Copyright 2023 Terramate GmbH
 // SPDX-License-Identifier: MPL-2.0
 
-//go:build unix
+//go:build unix && !darwin
 
 package runner
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/terramate-io/terramate/blob/main/CONTRIBUTING.md
2. If the PR is unfinished, mark it as draft: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request
3. Please update the PR title using the Conventional Commits convention: https://www.conventionalcommits.org/en/v1.0.0/
    Example: feat: add support for XYZ.
-->

## What this PR does / why we need it:

Undo #1490 because it results in spurious test failures. Indicates that we have problem with Signal handling on MacOS, must be investigated further and fixed before we can re-enable. 

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Keep it empty if not applicable.
-->

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
<!--
If no, just write "no" in the block below.
If yes, please explain the change and update documentation and the CHANGELOG.md file accordingly.
-->
```
no
```
