### PR TITLE
feat: add generate_*.inherit attribute.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 
 ### Added
 
+- Add `generate_*.inherit` attribute for controlling if generate blocks must be inherited
+  into child stacks.
 - Add `terramate cloud login --github` for authenticating with the Github account.
 - Add experimental support for `tmgen` file extension for easy code generation/templating
   of existing infrastructure. You can enable it with `terramate.config.experimental = ["tmgen"]`.

--- a/cmd/terramate/e2etests/core/generate_test.go
+++ b/cmd/terramate/e2etests/core/generate_test.go
@@ -449,32 +449,6 @@ func TestGenerateIgnoresWorkingDirectory(t *testing.T) {
 	runFromDir(t, "/stacks/stack-1")
 }
 
-func TestGenerateWarnsForTmGenNonInheritable(t *testing.T) {
-	t.Parallel()
-
-	s := sandbox.NoGit(t, true)
-	s.BuildTree([]string{
-		"s:stacks/stack-1",
-		"s:stacks/stack-2",
-		"f:invalid.tf.tmgen:test = 1",
-	})
-
-	s.RootEntry().CreateFile(
-		config.DefaultFilename,
-		Terramate(
-			Config(
-				Expr("experiments", `["tmgen"]`),
-			),
-		).String(),
-	)
-
-	tmcli := NewCLI(t, s.RootDir())
-	AssertRunResult(t, tmcli.Run("generate"), RunExpected{
-		Stdout:      "Nothing to do, generated code is up to date\n",
-		StderrRegex: "Warning: non-inheritable generate found outside a stack",
-	})
-}
-
 type str string
 
 func (s str) String() string {

--- a/config/config.go
+++ b/config/config.go
@@ -508,10 +508,22 @@ func processTmGenFiles(root *Root, cfg *hcl.Config, cfgdir string, dirEntries []
 			Type: "content",
 			Body: body,
 		}
+
+		// should never fail
+		inheritFalse, diags := hclsyntax.ParseExpression([]byte("false"), "<implicit block>", hhcl.InitialPos)
+		if diags.HasErrors() {
+			panic(errors.E(errors.ErrInternal, diags))
+		}
+
+		inheritAttr := &hclsyntax.Attribute{
+			Name: "inherit",
+			Expr: inheritFalse,
+		}
+
 		implicitGenBlock := hcl.GenHCLBlock{
 			IsImplicitBlock: true,
 			Dir:             project.PrjAbsPath(root.HostDir(), cfgdir),
-			NonInheritable:  true,
+			Inherit:         inheritAttr,
 			Range: info.NewRange(root.HostDir(), hhcl.Range{
 				Filename: absFname,
 				Start:    hhcl.InitialPos,

--- a/generate/generate_hcl_test.go
+++ b/generate/generate_hcl_test.go
@@ -1429,6 +1429,438 @@ EOT
 				},
 			},
 		},
+		{
+			name: "generate_hcl with inherit=true on root stack without child stacks",
+			layout: []string{
+				"s:/",
+			},
+			configs: []hclconfig{
+				{
+					path: "/",
+					add: Doc(
+						GenerateHCL(
+							Labels("root.hcl"),
+							Bool("inherit", true),
+							Content(
+								Str("hello", "world"),
+							),
+						),
+					),
+				},
+			},
+			want: []generatedFile{
+				{
+					dir: "/",
+					files: map[string]fmt.Stringer{
+						"root.hcl": Doc(
+							Str("hello", "world"),
+						),
+					},
+				},
+			},
+			wantReport: generate.Report{
+				Successes: []generate.Result{
+					{
+						Dir:     project.NewPath("/"),
+						Created: []string{"root.hcl"},
+					},
+				},
+			},
+		},
+		{
+			name: "generate_hcl with inherit=true on root stack with child stacks",
+			layout: []string{
+				"s:/",
+				"s:/s1",
+				"s:/s1/s2",
+			},
+			configs: []hclconfig{
+				{
+					path: "/",
+					add: Doc(
+						GenerateHCL(
+							Labels("root.hcl"),
+							Bool("inherit", true),
+							Content(
+								Str("hello", "world"),
+							),
+						),
+					),
+				},
+			},
+			want: []generatedFile{
+				{
+					dir: "/",
+					files: map[string]fmt.Stringer{
+						"root.hcl": Doc(
+							Str("hello", "world"),
+						),
+					},
+				},
+				{
+					dir: "/s1",
+					files: map[string]fmt.Stringer{
+						"root.hcl": Doc(
+							Str("hello", "world"),
+						),
+					},
+				},
+				{
+					dir: "/s1/s2",
+					files: map[string]fmt.Stringer{
+						"root.hcl": Doc(
+							Str("hello", "world"),
+						),
+					},
+				},
+			},
+			wantReport: generate.Report{
+				Successes: []generate.Result{
+					{
+						Dir:     project.NewPath("/"),
+						Created: []string{"root.hcl"},
+					},
+					{
+						Dir:     project.NewPath("/s1"),
+						Created: []string{"root.hcl"},
+					},
+					{
+						Dir:     project.NewPath("/s1/s2"),
+						Created: []string{"root.hcl"},
+					},
+				},
+			},
+		},
+		{
+			name: "generate_hcl with inherit=false on root stack with child stacks",
+			layout: []string{
+				"s:/",
+				"s:/s1",
+				"s:/s1/s2",
+			},
+			configs: []hclconfig{
+				{
+					path: "/",
+					add: Doc(
+						GenerateHCL(
+							Labels("root.hcl"),
+							Bool("inherit", false),
+							Content(
+								Str("hello", "world"),
+							),
+						),
+					),
+				},
+			},
+			want: []generatedFile{
+				{
+					dir: "/",
+					files: map[string]fmt.Stringer{
+						"root.hcl": Doc(
+							Str("hello", "world"),
+						),
+					},
+				},
+			},
+			wantReport: generate.Report{
+				Successes: []generate.Result{
+					{
+						Dir:     project.NewPath("/"),
+						Created: []string{"root.hcl"},
+					},
+				},
+			},
+		},
+		{
+			name: "generate_hcl with inherit=false on intermediate stack with child stack",
+			layout: []string{
+				"s:/",
+				"s:/s1",
+				"s:/s1/s2",
+			},
+			configs: []hclconfig{
+				{
+					path: "/s1",
+					add: Doc(
+						GenerateHCL(
+							Labels("root.hcl"),
+							Bool("inherit", false),
+							Content(
+								Str("hello", "world"),
+							),
+						),
+					),
+				},
+			},
+			want: []generatedFile{
+				{
+					dir: "/s1",
+					files: map[string]fmt.Stringer{
+						"root.hcl": Doc(
+							Str("hello", "world"),
+						),
+					},
+				},
+			},
+			wantReport: generate.Report{
+				Successes: []generate.Result{
+					{
+						Dir:     project.NewPath("/s1"),
+						Created: []string{"root.hcl"},
+					},
+				},
+			},
+		},
+		{
+			name: "generate_hcl with inherit=false on leaf stack with child stack",
+			layout: []string{
+				"s:/",
+				"s:/s1",
+				"s:/s1/s2",
+			},
+			configs: []hclconfig{
+				{
+					path: "/s1/s2",
+					add: Doc(
+						GenerateHCL(
+							Labels("root.hcl"),
+							Bool("inherit", false),
+							Content(
+								Str("hello", "world"),
+							),
+						),
+					),
+				},
+			},
+			want: []generatedFile{
+				{
+					dir: "/s1/s2",
+					files: map[string]fmt.Stringer{
+						"root.hcl": Doc(
+							Str("hello", "world"),
+						),
+					},
+				},
+			},
+			wantReport: generate.Report{
+				Successes: []generate.Result{
+					{
+						Dir:     project.NewPath("/s1/s2"),
+						Created: []string{"root.hcl"},
+					},
+				},
+			},
+		},
+		{
+			name: "generate_hcl at root with inherit=global.inherit generating only in parent",
+			layout: []string{
+				"s:/",
+				"s:/s1",
+				"s:/s1/s2",
+			},
+			configs: []hclconfig{
+				{
+					path: "/",
+					add: Doc(
+						GenerateHCL(
+							Labels("root.hcl"),
+							Expr("inherit", `global.inherit`),
+							Content(
+								Str("hello", "world"),
+							),
+						),
+						Globals(
+							Bool("inherit", false),
+						),
+					),
+				},
+			},
+			want: []generatedFile{
+				{
+					dir: "/",
+					files: map[string]fmt.Stringer{
+						"root.hcl": Doc(
+							Str("hello", "world"),
+						),
+					},
+				},
+			},
+			wantReport: generate.Report{
+				Successes: []generate.Result{
+					{
+						Dir:     project.NewPath("/"),
+						Created: []string{"root.hcl"},
+					},
+				},
+			},
+		},
+		{
+			name: "generate_hcl with inherit=global.inherit=false generates in child if setting overrided",
+			layout: []string{
+				"s:/",
+				"s:/s1",
+				"s:/s1/s2",
+			},
+			configs: []hclconfig{
+				{
+					path: "/",
+					add: Doc(
+						GenerateHCL(
+							Labels("root.hcl"),
+							Expr("inherit", `global.inherit`),
+							Content(
+								Str("hello", "world"),
+							),
+						),
+						Globals(
+							Bool("inherit", false),
+						),
+					),
+				},
+				{
+					path: "/s1",
+					add: Doc(
+						Globals(
+							Bool("inherit", true),
+						),
+					),
+				},
+			},
+			want: []generatedFile{
+				{
+					dir: "/",
+					files: map[string]fmt.Stringer{
+						"root.hcl": Doc(
+							Str("hello", "world"),
+						),
+					},
+				},
+				{
+					dir: "/s1",
+					files: map[string]fmt.Stringer{
+						"root.hcl": Doc(
+							Str("hello", "world"),
+						),
+					},
+				},
+				{
+					dir: "/s1/s2",
+					files: map[string]fmt.Stringer{
+						"root.hcl": Doc(
+							Str("hello", "world"),
+						),
+					},
+				},
+			},
+			wantReport: generate.Report{
+				Successes: []generate.Result{
+					{
+						Dir:     project.NewPath("/"),
+						Created: []string{"root.hcl"},
+					},
+					{
+						Dir:     project.NewPath("/s1"),
+						Created: []string{"root.hcl"},
+					},
+					{
+						Dir:     project.NewPath("/s1/s2"),
+						Created: []string{"root.hcl"},
+					},
+				},
+			},
+		},
+		{
+			name: "generate_hcl with inherit=global.inherit=false at root obey each child sibling stack config",
+			layout: []string{
+				"s:/",
+				"s:/s1",
+				"s:/s2",
+			},
+			configs: []hclconfig{
+				{
+					path: "/",
+					add: Doc(
+						GenerateHCL(
+							Labels("root.hcl"),
+							Expr("inherit", `global.inherit`),
+							Content(
+								Str("hello", "world"),
+							),
+						),
+						Globals(
+							Bool("inherit", false),
+						),
+					),
+				},
+				{
+					path: "/s1",
+					add: Doc(
+						Globals(
+							Bool("inherit", true),
+						),
+					),
+				},
+				{
+					path: "/s2",
+					add: Doc(
+						Globals(
+							Bool("inherit", false),
+						),
+					),
+				},
+			},
+			want: []generatedFile{
+				{
+					dir: "/",
+					files: map[string]fmt.Stringer{
+						"root.hcl": Doc(
+							Str("hello", "world"),
+						),
+					},
+				},
+				{
+					dir: "/s1",
+					files: map[string]fmt.Stringer{
+						"root.hcl": Doc(
+							Str("hello", "world"),
+						),
+					},
+				},
+			},
+			wantReport: generate.Report{
+				Successes: []generate.Result{
+					{
+						Dir:     project.NewPath("/"),
+						Created: []string{"root.hcl"},
+					},
+					{
+						Dir:     project.NewPath("/s1"),
+						Created: []string{"root.hcl"},
+					},
+				},
+			},
+		},
+		{
+			name: "generate_hcl with inherit=false outside of a stack is ignored",
+			layout: []string{
+				"s:/s1",
+				"s:/s2",
+			},
+			configs: []hclconfig{
+				{
+					path: "/",
+					add: Doc(
+						GenerateHCL(
+							Labels("root.hcl"),
+							Expr("inherit", `false`),
+							Content(
+								Str("hello", "world"),
+							),
+						),
+					),
+				},
+			},
+		},
 	})
 }
 

--- a/hcl/hcl_test.go
+++ b/hcl/hcl_test.go
@@ -1181,6 +1181,26 @@ func TestHCLParserMultipleErrors(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "generate_file with inherit and context=root -- fails",
+			input: []cfgfile{
+				{
+					filename: "gen.tm",
+					body: `
+					generate_file "test.tf" {
+						content = "fail"
+						context = root
+						inherit = false
+					}
+					`,
+				},
+			},
+			want: want{
+				errs: []error{
+					errors.E(hcl.ErrTerramateSchema),
+				},
+			},
+		},
 	} {
 		testParser(t, tc)
 	}


### PR DESCRIPTION
## What this PR does / why we need it:

Introduces the `inherit` attribute to both `generate_hcl` and `generate_file` to control when the blocks should be inherited in child stacks.

## Which issue(s) this PR fixes:
none

## Special notes for your reviewer:
- [x] Documentation
- [x] Changelog

## Does this PR introduce a user-facing change?
```
yes
```
