### PR TITLE
feat: add terramate create --watch=<opt1,...>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 - Add `terramate cloud login --github` for authenticating with the Github account.
 - Add experimental support for `tmgen` file extension for easy code generation/templating
   of existing infrastructure. You can enable it with `terramate.config.experimental = ["tmgen"]`.
+- Add `--watch` flag to `terramate create` for populating the `stack.watch` field.
 - Add support for parsing and generating code containing HCL namespaced functions.
   - Check [here](https://github.com/hashicorp/hcl/pull/639) for details.
 - Make cloud-related options more concise by dropping the `cloud` prefix.

--- a/cmd/terramate/e2etests/core/create_test.go
+++ b/cmd/terramate/e2etests/core/create_test.go
@@ -5,6 +5,7 @@ package core_test
 
 import (
 	"fmt"
+	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -105,6 +106,8 @@ func TestCreateStack(t *testing.T) {
 		stackAfter2      = "stack-after-2"
 		stackBefore1     = "stack-before-1"
 		stackBefore2     = "stack-before-2"
+		watch1           = "watched1.txt"
+		watch2           = "watched2.txt"
 		stackTag1        = "a"
 		stackTag2        = "b"
 		genFilename      = "file.txt"
@@ -154,11 +157,18 @@ func TestCreateStack(t *testing.T) {
 			absStackPath := filepath.Join(s.RootDir(), filepath.FromSlash(stackPath))
 			got := s.LoadStack(project.PrjAbsPath(s.RootDir(), absStackPath))
 
+			stackBasePath := project.NewPath(path.Join("/", stackPath))
+			wantWatch := project.Paths{
+				stackBasePath.Join(watch1),
+				stackBasePath.Join(watch2),
+			}
+
 			assert.EqualStrings(t, stackID, got.ID)
 			assert.EqualStrings(t, stackName, got.Name, "checking stack name")
 			assert.EqualStrings(t, stackDescription, got.Description, "checking stack description")
 			test.AssertDiff(t, got.After, []string{stackAfter1, stackAfter2}, "created stack has invalid after")
 			test.AssertDiff(t, got.Before, []string{stackBefore1, stackBefore2}, "created stack has invalid before")
+			test.AssertDiff(t, got.Watch, wantWatch, "created stack has invalid watch")
 			test.AssertDiff(t, got.Tags, []string{stackTag1, stackTag2})
 
 			test.AssertStackImports(t, s.RootDir(), got.HostDir(s.Config()), []string{stackImport1, stackImport2})
@@ -179,6 +189,8 @@ func TestCreateStack(t *testing.T) {
 		"--after", stackAfter2,
 		"--before", stackBefore1,
 		"--before", stackBefore2,
+		"--watch", watch1,
+		"--watch", watch2,
 		"--tags", stackTag1,
 		"--tags", stackTag2,
 	)
@@ -189,6 +201,7 @@ func TestCreateStack(t *testing.T) {
 		"--import", strings.Join([]string{stackImport1, stackImport2}, ","),
 		"--after", strings.Join([]string{stackAfter1, stackAfter2}, ","),
 		"--before", strings.Join([]string{stackBefore1, stackBefore2}, ","),
+		"--watch", strings.Join([]string{watch1, watch2}, ","),
 		"--tags", strings.Join([]string{stackTag1, stackTag2}, ","),
 	)
 }

--- a/config/stack.go
+++ b/config/stack.go
@@ -52,7 +52,7 @@ type (
 		WantedBy []string
 
 		// Watch is the list of files to be watched for changes.
-		Watch []project.Path
+		Watch project.Paths
 
 		// IsChanged tells if this is a changed stack.
 		IsChanged bool
@@ -91,7 +91,7 @@ func NewStackFromHCL(root string, cfg hcl.Config) (*Stack, error) {
 		name = filepath.Base(cfg.AbsDir())
 	}
 
-	watchFiles, err := validateWatchPaths(root, cfg.AbsDir(), cfg.Stack.Watch)
+	watchFiles, err := ValidateWatchPaths(root, cfg.AbsDir(), cfg.Stack.Watch)
 	if err != nil {
 		return nil, errors.E(err, ErrStackInvalidWatch)
 	}
@@ -249,7 +249,9 @@ func (s *Stack) Sortable() *SortableStack {
 	}
 }
 
-func validateWatchPaths(rootdir string, stackpath string, paths []string) (project.Paths, error) {
+// ValidateWatchPaths validates if the provided watch paths points to regular files
+// inside the project repository.
+func ValidateWatchPaths(rootdir string, stackpath string, paths []string) (project.Paths, error) {
 	var projectPaths project.Paths
 	for _, pathstr := range paths {
 		var abspath string

--- a/hcl/printer.go
+++ b/hcl/printer.go
@@ -38,7 +38,6 @@ func PrintConfig(w io.Writer, cfg Config) error {
 	rootBody := f.Body()
 
 	if cfg.Terramate != nil {
-
 		tm := cfg.Terramate
 		tmBlock := rootBody.AppendNewBlock("terramate", nil)
 		tmBody := tmBlock.Body()
@@ -50,7 +49,6 @@ func PrintConfig(w io.Writer, cfg Config) error {
 	}
 
 	if cfg.Stack != nil {
-
 		stack := cfg.Stack
 		stackBlock := rootBody.AppendNewBlock("stack", nil)
 		stackBody := stackBlock.Body()

--- a/stack/create.go
+++ b/stack/create.go
@@ -72,6 +72,7 @@ func Create(root *config.Root, stack config.Stack, imports ...string) (err error
 		Description: stack.Description,
 		After:       stack.After,
 		Before:      stack.Before,
+		Watch:       stack.Watch.Strings(),
 		Tags:        stack.Tags,
 	}
 


### PR DESCRIPTION
## What this PR does / why we need it:

Add support for `--watch` in the `terramate create`.
When provided the user can populate the `stack.watch` attribute of the created stack.

## Which issue(s) this PR fixes:
none

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
yes, add a new feature.
```
