### PR TITLE
refactor: remove cloud flag prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 
 - Add experimental support for `tmgen` file extension for easy code generation/templating
   of existing infrastructure. You can enable it with `terramate.config.experimental = ["tmgen"]`.
+- Make cloud-related options more concise by dropping the `cloud` prefix.
+  - Option flags `--cloud-*` are shortened to `--*`, e.g. `--cloud-status=ok` => `--status=ok`.
+  - Script command options `cloud_*` are shorted to `*`, e.g. `cloud_sync_deployment` => `sync_deployment`.
+  - Old flags and command options are still supported as aliases for the new ones.
 
 ## v0.6.0
 

--- a/cloud/preview/preview.go
+++ b/cloud/preview/preview.go
@@ -49,7 +49,7 @@ func (l Layer) String() string {
 func (l Layer) Validate() error {
 	for _, c := range string(l) {
 		if !unicode.IsLetter(c) && !unicode.IsDigit(c) && c != '-' {
-			return errors.E("invalid --cloud-sync-layer, only alphanumeric characters and hyphens are allowed")
+			return errors.E("invalid --layer, only alphanumeric characters and hyphens are allowed")
 		}
 	}
 

--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -142,17 +142,24 @@ type cliSpec struct {
 	List struct {
 		Why                bool   `help:"Shows the reason why the stack has changed."`
 		ExperimentalStatus string `hidden:"" help:"Filter by status (Deprecated)"`
-		CloudStatus        string `help:"Filter by Terramate Cloud status of the stack."`
+		CloudStatus        string `hidden:""`
+		Status             string `help:"Filter by Terramate Cloud status of the stack."`
 		RunOrder           bool   `default:"false" help:"Sort listed stacks by order of execution"`
 	} `cmd:"" help:"List stacks."`
 
 	Run struct {
-		CloudStatus                string        `help:"Filter by Terramate Cloud status of the stack."`
-		CloudSyncDeployment        bool          `default:"false" help:"Synchronize the command as a new deployment to Terramate Cloud."`
-		CloudSyncDriftStatus       bool          `default:"false" help:"Synchronize the command as a new drift run to Terramate Cloud."`
-		CloudSyncPreview           bool          `default:"false" help:"Synchronize the command as a new preview to Terramate Cloud."`
-		CloudSyncLayer             preview.Layer `default:"" help:"Set a customer layer for synchronizing a preview to Terramate Cloud."`
-		CloudSyncTerraformPlanFile string        `default:"" help:"Add details of the Terraform Plan file to the synchronization to Terramate Cloud."`
+		CloudStatus                string        `hidden:""`
+		Status                     string        `help:"Filter by Terramate Cloud status of the stack."`
+		CloudSyncDeployment        bool          `hidden:""`
+		SyncDeployment             bool          `default:"false" help:"Synchronize the command as a new deployment to Terramate Cloud."`
+		CloudSyncDriftStatus       bool          `hidden:""`
+		SyncDriftStatus            bool          `default:"false" help:"Synchronize the command as a new drift run to Terramate Cloud."`
+		CloudSyncPreview           bool          `hidden:""`
+		SyncPreview                bool          `default:"false" help:"Synchronize the command as a new preview to Terramate Cloud."`
+		CloudSyncLayer             preview.Layer `hidden:""`
+		Layer                      preview.Layer `default:"" help:"Set a customer layer for synchronizing a preview to Terramate Cloud."`
+		CloudSyncTerraformPlanFile string        `hidden:""`
+		TerraformPlanFile          string        `default:"" help:"Add details of the Terraform Plan file to the synchronization to Terramate Cloud."`
 		DebugPreviewURL            string        `hidden:"true" default:"" help:"Create a debug preview URL to Terramate Cloud details."`
 		ContinueOnError            bool          `default:"false" help:"Do not stop execution when an error occurs."`
 		NoRecursive                bool          `default:"false" help:"Do not recurse into nested child stacks."`
@@ -182,7 +189,8 @@ type cliSpec struct {
 			Cmds []string `arg:"" optional:"true" passthrough:"" help:"Script to show info for."`
 		} `cmd:"" help:"Show detailed information about a script"`
 		Run struct {
-			CloudStatus     string `help:"Filter by Terramate Cloud status of the stack."`
+			CloudStatus     string `hidden:""`
+			Status          string `help:"Filter by Terramate Cloud status of the stack."`
 			NoRecursive     bool   `default:"false" help:"Do not recurse into nested child stacks."`
 			ContinueOnError bool   `default:"false" help:"Continue executing next stacks when a command returns an error."`
 			DryRun          bool   `default:"false" help:"Plan the execution but do not execute it."`
@@ -227,7 +235,8 @@ type cliSpec struct {
 			Stack              string `arg:"" optional:"true" name:"stack" predictor:"file" help:"The stacks path."`
 			Reason             string `default:"" name:"reason" help:"Set a reason for triggering the stack."`
 			ExperimentalStatus string `hidden:"" help:"Filter by Terramate Cloud status of the stack. (deprecated)"`
-			CloudStatus        string `help:"Filter by Terramate Cloud status of the stack."`
+			CloudStatus        string `hidden:""`
+			Status             string `help:"Filter by Terramate Cloud status of the stack."`
 		} `cmd:"" help:"Mark a stack as changed so it will be triggered in Change Detection."`
 
 		RunGraph struct {
@@ -424,6 +433,8 @@ func newCLI(version string, args []string, stdin io.Reader, stdout, stderr io.Wr
 	if err != nil {
 		fatal("failed to load cli configuration file", err)
 	}
+
+	migrateFlagAliases(&parsedArgs)
 
 	// cmdline flags override configuration file.
 
@@ -877,11 +888,44 @@ func hasVendorDirConfig(cfg hcl.Config) bool {
 	return cfg.Vendor != nil && cfg.Vendor.Dir != ""
 }
 
+func migrateFlagAliases(parsedArgs *cliSpec) {
+	// list
+	migrateStringFlag(&parsedArgs.List.Status, parsedArgs.List.CloudStatus)
+
+	// run
+	migrateStringFlag(&parsedArgs.Run.Status, parsedArgs.Run.CloudStatus)
+	migrateBoolFlag(&parsedArgs.Run.SyncDeployment, parsedArgs.Run.CloudSyncDeployment)
+	migrateBoolFlag(&parsedArgs.Run.SyncDriftStatus, parsedArgs.Run.CloudSyncDriftStatus)
+	migrateBoolFlag(&parsedArgs.Run.SyncPreview, parsedArgs.Run.CloudSyncPreview)
+	migrateStringFlag(&parsedArgs.Run.TerraformPlanFile, parsedArgs.Run.CloudSyncTerraformPlanFile)
+	if parsedArgs.Run.CloudSyncLayer != "" && parsedArgs.Run.Layer == "" {
+		parsedArgs.Run.Layer = parsedArgs.Run.CloudSyncLayer
+	}
+
+	// script run
+	migrateStringFlag(&parsedArgs.Script.Run.Status, parsedArgs.Script.Run.CloudStatus)
+
+	// experimental trigger
+	migrateStringFlag(&parsedArgs.Experimental.Trigger.Status, parsedArgs.Experimental.Trigger.CloudStatus)
+}
+
+func migrateStringFlag(flag *string, alias string) {
+	if alias != "" && *flag == "" {
+		*flag = alias
+	}
+}
+
+func migrateBoolFlag(flag *bool, alias bool) {
+	if alias && !*flag {
+		*flag = alias
+	}
+}
+
 func (c *cli) triggerStackByFilter() {
 	expStatus := c.parsedArgs.Experimental.Trigger.ExperimentalStatus
-	cloudStatus := c.parsedArgs.Experimental.Trigger.CloudStatus
+	cloudStatus := c.parsedArgs.Experimental.Trigger.Status
 	if expStatus != "" && cloudStatus != "" {
-		fatal("--experimental-status and --cloud-status cannot be used together", nil)
+		fatal("--experimental-status and --status cannot be used together", nil)
 	}
 
 	statusStr := expStatus
@@ -890,7 +934,7 @@ func (c *cli) triggerStackByFilter() {
 	}
 
 	if statusStr == "" {
-		fatal("trigger command expects either a stack path or the --cloud-status flag", nil)
+		fatal("trigger command expects either a stack path or the --status flag", nil)
 	}
 
 	status := parseStatusFilter(statusStr)
@@ -1555,9 +1599,9 @@ func (c *cli) printStacks() {
 	}
 
 	expStatus := c.parsedArgs.List.ExperimentalStatus
-	cloudStatus := c.parsedArgs.List.CloudStatus
+	cloudStatus := c.parsedArgs.List.Status
 	if expStatus != "" && cloudStatus != "" {
-		fatal("Invalid args", errors.E("--experimental-status and --cloud-status cannot be used together"))
+		fatal("Invalid args", errors.E("--experimental-status and --status cannot be used together"))
 	}
 
 	statusStr := expStatus

--- a/cmd/terramate/cli/cloud.go
+++ b/cmd/terramate/cli/cloud.go
@@ -161,7 +161,7 @@ func isDriftTask(t stackRunTask) bool      { return t.CloudSyncDriftStatus }
 func isPreviewTask(t stackRunTask) bool    { return t.CloudSyncPreview }
 
 func (c *cli) checkCloudSync() {
-	if !c.parsedArgs.Run.CloudSyncDeployment && !c.parsedArgs.Run.CloudSyncDriftStatus && !c.parsedArgs.Run.CloudSyncPreview {
+	if !c.parsedArgs.Run.SyncDeployment && !c.parsedArgs.Run.SyncDriftStatus && !c.parsedArgs.Run.SyncPreview {
 		return
 	}
 
@@ -172,7 +172,7 @@ func (c *cli) checkCloudSync() {
 		return
 	}
 
-	if c.parsedArgs.Run.CloudSyncDeployment {
+	if c.parsedArgs.Run.SyncDeployment {
 		uuid, err := uuid.GenerateUUID()
 		c.handleCriticalError(err)
 		c.cloud.run.runUUID = cloud.UUID(uuid)

--- a/cmd/terramate/cli/script_run.go
+++ b/cmd/terramate/cli/script_run.go
@@ -39,7 +39,7 @@ func (c *cli) runScript() {
 		stacks = append(stacks, st.Sortable())
 	} else {
 		var err error
-		stacks, err = c.computeSelectedStacks(true, parseStatusFilter(c.parsedArgs.Script.Run.CloudStatus))
+		stacks, err = c.computeSelectedStacks(true, parseStatusFilter(c.parsedArgs.Script.Run.Status))
 		if err != nil {
 			fatal("failed to compute selected stacks", err)
 		}

--- a/cmd/terramate/e2etests/cloud/cloud_status_test.go
+++ b/cmd/terramate/e2etests/cloud/cloud_status_test.go
@@ -39,10 +39,10 @@ func TestCloudStatus(t *testing.T) {
 
 	for _, tc := range []cloudStatusTestcase{
 		{
-			name:       "local repository is not permitted with --cloud-status=",
+			name:       "local repository is not permitted with --status=",
 			layout:     []string{"s:s1:id=s1"},
 			repository: test.TempDir(t),
-			flags:      []string{`--cloud-status=unhealthy`},
+			flags:      []string{`--status=unhealthy`},
 			want: RunExpected{
 				Status:      1,
 				StderrRegex: "unhealthy status filter does not work with filesystem based remotes",
@@ -64,7 +64,7 @@ func TestCloudStatus(t *testing.T) {
 				"s:s1:id=s1",
 				"s:s2:id=s2",
 			},
-			flags: []string{"--cloud-status=unhealthy"},
+			flags: []string{"--status=unhealthy"},
 		},
 		{
 			name: "1 cloud stack healthy, others absent, asking for unhealthy: return nothing",
@@ -85,10 +85,34 @@ func TestCloudStatus(t *testing.T) {
 					},
 				},
 			},
-			flags: []string{`--cloud-status=unhealthy`},
+			flags: []string{`--status=unhealthy`},
 		},
 		{
 			name: "1 cloud stack healthy, others absent, asking for ok: return ok",
+			layout: []string{
+				"s:s1:id=s1",
+				"s:s2:id=s2",
+			},
+			stacks: []cloudstore.Stack{
+				{
+					Stack: cloud.Stack{
+						MetaID:     "s1",
+						Repository: "github.com/terramate-io/terramate",
+					},
+					State: cloudstore.StackState{
+						Status:           stack.OK,
+						DeploymentStatus: deployment.OK,
+						DriftStatus:      drift.OK,
+					},
+				},
+			},
+			flags: []string{`--status=ok`},
+			want: RunExpected{
+				Stdout: nljoin("s1"),
+			},
+		},
+		{
+			name: "deprecated --cloud-status alias",
 			layout: []string{
 				"s:s1:id=s1",
 				"s:s2:id=s2",
@@ -130,7 +154,7 @@ func TestCloudStatus(t *testing.T) {
 					},
 				},
 			},
-			flags: []string{`--cloud-status=healthy`},
+			flags: []string{`--status=healthy`},
 			want: RunExpected{
 				Stdout: nljoin("s1"),
 			},
@@ -154,7 +178,7 @@ func TestCloudStatus(t *testing.T) {
 					},
 				},
 			},
-			flags: []string{`--cloud-status=unhealthy`},
+			flags: []string{`--status=unhealthy`},
 		},
 		{
 			name: "1 cloud stack drifted, other absent, asking for unhealthy: return drifted",
@@ -175,7 +199,7 @@ func TestCloudStatus(t *testing.T) {
 					},
 				},
 			},
-			flags: []string{`--cloud-status=unhealthy`},
+			flags: []string{`--status=unhealthy`},
 			want: RunExpected{
 				Stdout: nljoin("s1"),
 			},
@@ -199,7 +223,7 @@ func TestCloudStatus(t *testing.T) {
 					},
 				},
 			},
-			flags: []string{`--cloud-status=unhealthy`},
+			flags: []string{`--status=unhealthy`},
 			want: RunExpected{
 				Stdout: nljoin("s1"),
 			},
@@ -234,7 +258,7 @@ func TestCloudStatus(t *testing.T) {
 					},
 				},
 			},
-			flags: []string{`--cloud-status=unhealthy`},
+			flags: []string{`--status=unhealthy`},
 			want: RunExpected{
 				Stdout: nljoin("s1"),
 			},
@@ -266,7 +290,7 @@ func TestCloudStatus(t *testing.T) {
 					},
 				},
 			},
-			flags: []string{`--cloud-status=unhealthy`},
+			flags: []string{`--status=unhealthy`},
 		},
 		{
 			name: "2 local stacks, 2 same unhealthy stacks, return both",
@@ -298,7 +322,7 @@ func TestCloudStatus(t *testing.T) {
 					},
 				},
 			},
-			flags: []string{`--cloud-status=unhealthy`},
+			flags: []string{`--status=unhealthy`},
 			want: RunExpected{
 				Stdout: nljoin("s1", "s2"),
 			},
@@ -334,7 +358,7 @@ func TestCloudStatus(t *testing.T) {
 					},
 				},
 			},
-			flags: []string{`--cloud-status=unhealthy`},
+			flags: []string{`--status=unhealthy`},
 			want: RunExpected{
 				Stdout: nljoin("s1", "s2"),
 			},
@@ -451,7 +475,7 @@ func paginationTestcase(perPage int) cloudStatusTestcase {
 		layout:  layout,
 		stacks:  stacks,
 		perPage: perPage,
-		flags:   []string{`--cloud-status=unhealthy`},
+		flags:   []string{`--status=unhealthy`},
 		want: RunExpected{
 			Stdout: nljoin(names...),
 		},

--- a/cmd/terramate/e2etests/cloud/exp_trigger_cloud_test.go
+++ b/cmd/terramate/e2etests/cloud/exp_trigger_cloud_test.go
@@ -63,7 +63,7 @@ func TestTriggerUnhealthyStacks(t *testing.T) {
 	env := RemoveEnv(os.Environ(), "CI")
 	env = append(env, "TMC_API_URL=http://"+addr, "CI=")
 	cli := NewCLI(t, s.RootDir(), env...)
-	AssertRunResult(t, cli.Run("experimental", "trigger", "--cloud-status=unhealthy"), RunExpected{
+	AssertRunResult(t, cli.Run("experimental", "trigger", "--status=unhealthy"), RunExpected{
 		IgnoreStdout: true,
 	})
 
@@ -94,10 +94,10 @@ func TestCloudTriggerUnhealthy(t *testing.T) {
 
 	for _, tc := range []testcase{
 		{
-			name:       "local repository is not permitted with --cloud-status=",
+			name:       "local repository is not permitted with --status=",
 			layout:     []string{"s:s1:id=s1"},
 			repository: test.TempDir(t),
-			flags:      []string{`--cloud-status=unhealthy`},
+			flags:      []string{`--status=unhealthy`},
 			want: want{
 				trigger: RunExpected{
 					Status:      1,
@@ -114,7 +114,7 @@ func TestCloudTriggerUnhealthy(t *testing.T) {
 			want: want{
 				trigger: RunExpected{
 					Status:      1,
-					StderrRegex: "trigger command expects either a stack path or the --cloud-status flag",
+					StderrRegex: "trigger command expects either a stack path or the --status flag",
 				},
 			},
 		},
@@ -124,7 +124,7 @@ func TestCloudTriggerUnhealthy(t *testing.T) {
 				"s:s1:id=s1",
 				"s:s2:id=s2",
 			},
-			flags: []string{"--cloud-status=unhealthy"},
+			flags: []string{"--status=unhealthy"},
 		},
 		{
 			name: "1 cloud stack healthy, other absent, asking for unhealthy: trigger nothing",
@@ -145,7 +145,7 @@ func TestCloudTriggerUnhealthy(t *testing.T) {
 					},
 				},
 			},
-			flags: []string{`--cloud-status=unhealthy`},
+			flags: []string{`--status=unhealthy`},
 		},
 		{
 			name: "1 cloud stack unhealthy but different repository, trigger nothing",
@@ -166,10 +166,39 @@ func TestCloudTriggerUnhealthy(t *testing.T) {
 					},
 				},
 			},
-			flags: []string{`--cloud-status=unhealthy`},
+			flags: []string{`--status=unhealthy`},
 		},
 		{
 			name: "1 cloud stack failed, other absent, asking for unhealthy, trigger the failed",
+			layout: []string{
+				"s:s1:id=s1",
+				"s:s2:id=s2",
+			},
+			stacks: []cloudstore.Stack{
+				{
+					Stack: cloud.Stack{
+						MetaID:     "s1",
+						Repository: "github.com/terramate-io/terramate",
+					},
+					State: cloudstore.StackState{
+						Status:           stack.Failed,
+						DeploymentStatus: deployment.Failed,
+						DriftStatus:      drift.Unknown,
+					},
+				},
+			},
+			flags: []string{`--status=unhealthy`},
+			want: want{
+				trigger: RunExpected{
+					StdoutRegex: "Created trigger for stack",
+				},
+				list: RunExpected{
+					Stdout: nljoin("s1"),
+				},
+			},
+		},
+		{
+			name: "deprecated --cloud-status alias",
 			layout: []string{
 				"s:s1:id=s1",
 				"s:s2:id=s2",
@@ -227,7 +256,7 @@ func TestCloudTriggerUnhealthy(t *testing.T) {
 					},
 				},
 			},
-			flags: []string{`--cloud-status=unhealthy`},
+			flags: []string{`--status=unhealthy`},
 			want: want{
 				trigger: RunExpected{
 					StdoutRegex: "Created trigger for stack",
@@ -267,7 +296,7 @@ func TestCloudTriggerUnhealthy(t *testing.T) {
 					},
 				},
 			},
-			flags: []string{`--cloud-status=ok`},
+			flags: []string{`--status=ok`},
 			want: want{
 				trigger: RunExpected{
 					StdoutRegex: "Created trigger for stack",
@@ -307,7 +336,7 @@ func TestCloudTriggerUnhealthy(t *testing.T) {
 					},
 				},
 			},
-			flags: []string{`--cloud-status=ok`},
+			flags: []string{`--status=ok`},
 			want: want{
 				trigger: RunExpected{
 					StdoutRegex: "Created trigger for stack",
@@ -347,7 +376,7 @@ func TestCloudTriggerUnhealthy(t *testing.T) {
 					},
 				},
 			},
-			flags: []string{`--cloud-status=failed`},
+			flags: []string{`--status=failed`},
 			want: want{
 				trigger: RunExpected{
 					StdoutRegex: "Created trigger for stack",
@@ -387,7 +416,7 @@ func TestCloudTriggerUnhealthy(t *testing.T) {
 					},
 				},
 			},
-			flags: []string{`--cloud-status=drifted`},
+			flags: []string{`--status=drifted`},
 			want: want{
 				trigger: RunExpected{
 					StdoutRegex: "Created trigger for stack",
@@ -424,7 +453,7 @@ func TestCloudTriggerUnhealthy(t *testing.T) {
 					},
 				},
 			},
-			flags: []string{`--cloud-status=unhealthy`},
+			flags: []string{`--status=unhealthy`},
 		},
 		{
 			name: "2 local stacks, 2 same unhealthy stacks, trigger both",
@@ -456,7 +485,7 @@ func TestCloudTriggerUnhealthy(t *testing.T) {
 					},
 				},
 			},
-			flags: []string{`--cloud-status=unhealthy`},
+			flags: []string{`--status=unhealthy`},
 			want: want{
 				trigger: RunExpected{
 					StdoutRegex: "Created trigger for stack",
@@ -497,7 +526,7 @@ func TestCloudTriggerUnhealthy(t *testing.T) {
 					},
 				},
 			},
-			flags: []string{`--cloud-status=unhealthy`},
+			flags: []string{`--status=unhealthy`},
 			want: want{
 				trigger: RunExpected{
 					StdoutRegex: "Created trigger for stack",

--- a/cmd/terramate/e2etests/cloud/interop/interoperability_test.go
+++ b/cmd/terramate/e2etests/cloud/interop/interoperability_test.go
@@ -40,8 +40,8 @@ func TestInteropCloudSyncPreview(t *testing.T) {
 			)
 			AssertRunResult(t,
 				tmcli.Run("run", "--quiet",
-					"--cloud-sync-preview",
-					"--cloud-sync-terraform-plan-file=out.plan",
+					"--sync-preview",
+					"--terraform-plan-file=out.plan",
 					"--",
 					TerraformTestPath,
 					"plan",
@@ -70,33 +70,33 @@ func TestInteropSyncDeployment(t *testing.T) {
 				Stdout: nljoin("."),
 			})
 			AssertRunResult(t,
-				tmcli.Run("run", "--quiet", "--cloud-sync-deployment", "--", HelperPath, "false"),
+				tmcli.Run("run", "--quiet", "--sync-deployment", "--", HelperPath, "false"),
 				RunExpected{
 					IgnoreStderr: true,
 					Status:       1,
 				},
 			)
 			AssertRunResult(t,
-				tmcli.Run("list", "--cloud-status=unhealthy"), RunExpected{
+				tmcli.Run("list", "--status=unhealthy"), RunExpected{
 					Stdout: nljoin("."),
 				},
 			)
 			AssertRunResult(t,
-				tmcli.Run("list", "--cloud-status=failed"), RunExpected{
+				tmcli.Run("list", "--status=failed"), RunExpected{
 					Stdout: nljoin("."),
 				},
 			)
 			// fix the failed stacks
-			AssertRun(t, tmcli.Run("run", "--quiet", "--cloud-status=failed", "--cloud-sync-deployment", "--", HelperPath, "true"))
+			AssertRun(t, tmcli.Run("run", "--quiet", "--status=failed", "--sync-deployment", "--", HelperPath, "true"))
 
 			AssertRunResult(t,
-				tmcli.Run("list", "--cloud-status=ok"), RunExpected{
+				tmcli.Run("list", "--status=ok"), RunExpected{
 					Stdout: nljoin("."),
 				},
 			)
-			AssertRun(t, tmcli.Run("list", "--cloud-status=unhealthy"))
-			AssertRun(t, tmcli.Run("list", "--cloud-status=failed"))
-			AssertRun(t, tmcli.Run("list", "--cloud-status=drifted"))
+			AssertRun(t, tmcli.Run("list", "--status=unhealthy"))
+			AssertRun(t, tmcli.Run("list", "--status=failed"))
+			AssertRun(t, tmcli.Run("list", "--status=drifted"))
 		})
 	}
 }
@@ -123,7 +123,7 @@ func TestInteropDrift(t *testing.T) {
 
 			// basic drift, without details
 			AssertRunResult(t,
-				tmcli.Run("run", "--quiet", "--cloud-sync-drift-status", "--", TerraformTestPath, "plan", "-detailed-exitcode"),
+				tmcli.Run("run", "--quiet", "--sync-drift-status", "--", TerraformTestPath, "plan", "-detailed-exitcode"),
 				RunExpected{
 					Status:       0,
 					IgnoreStdout: true,
@@ -131,12 +131,12 @@ func TestInteropDrift(t *testing.T) {
 				},
 			)
 			AssertRunResult(t,
-				tmcli.Run("list", "--cloud-status=unhealthy"), RunExpected{
+				tmcli.Run("list", "--status=unhealthy"), RunExpected{
 					Stdout: nljoin("."),
 				},
 			)
 			AssertRunResult(t,
-				tmcli.Run("list", "--cloud-status=drifted"), RunExpected{
+				tmcli.Run("list", "--status=drifted"), RunExpected{
 					Stdout: nljoin("."),
 				},
 			)
@@ -151,7 +151,7 @@ func TestInteropDrift(t *testing.T) {
 			// complete drift
 			AssertRunResult(t,
 				tmcli.Run(
-					"run", "--cloud-sync-drift-status", "--cloud-sync-terraform-plan-file=out.plan", "--",
+					"run", "--sync-drift-status", "--terraform-plan-file=out.plan", "--",
 					TerraformTestPath, "plan", "-out=out.plan", "-detailed-exitcode",
 				),
 				RunExpected{
@@ -161,12 +161,12 @@ func TestInteropDrift(t *testing.T) {
 				},
 			)
 			AssertRunResult(t,
-				tmcli.Run("list", "--cloud-status=unhealthy"), RunExpected{
+				tmcli.Run("list", "--status=unhealthy"), RunExpected{
 					Stdout: nljoin("."),
 				},
 			)
 			AssertRunResult(t,
-				tmcli.Run("list", "--cloud-status=drifted"), RunExpected{
+				tmcli.Run("list", "--status=drifted"), RunExpected{
 					Stdout: nljoin("."),
 				},
 			)
@@ -182,11 +182,11 @@ func TestInteropDrift(t *testing.T) {
 			)
 
 			// check reseting the drift status to OK
-			AssertRun(t, tmcli.Run("run", "--quiet", "--cloud-status=drifted", "--cloud-sync-drift-status", "--", HelperPath, "exit", "0"))
-			AssertRun(t, tmcli.Run("list", "--cloud-status=unhealthy"))
-			AssertRun(t, tmcli.Run("list", "--cloud-status=drifted"))
+			AssertRun(t, tmcli.Run("run", "--quiet", "--status=drifted", "--sync-drift-status", "--", HelperPath, "exit", "0"))
+			AssertRun(t, tmcli.Run("list", "--status=unhealthy"))
+			AssertRun(t, tmcli.Run("list", "--status=drifted"))
 			AssertRunResult(t,
-				tmcli.Run("list", "--cloud-status=ok"), RunExpected{
+				tmcli.Run("list", "--status=ok"), RunExpected{
 					Stdout: nljoin("."),
 				},
 			)

--- a/cmd/terramate/e2etests/cloud/run_cloud_config_test.go
+++ b/cmd/terramate/e2etests/cloud/run_cloud_config_test.go
@@ -183,7 +183,7 @@ func TestCloudConfig(t *testing.T) {
 				"run",
 				"--disable-safeguards=git-out-of-sync",
 				"--quiet",
-				"--cloud-sync-deployment",
+				"--sync-deployment",
 				"--", HelperPath, "true",
 			}
 			AssertRunResult(t, tm.Run(cmd...), tc.want)

--- a/cmd/terramate/e2etests/cloud/run_cloud_deployment_test.go
+++ b/cmd/terramate/e2etests/cloud/run_cloud_deployment_test.go
@@ -311,7 +311,7 @@ func TestCLIRunWithCloudSyncDeployment(t *testing.T) {
 		{
 			name:     "skip missing plan",
 			layout:   []string{"s:stack:id=stack"},
-			runflags: []string{`--eval`, `--cloud-sync-terraform-plan-file=out.tfplan`},
+			runflags: []string{`--eval`, `--terraform-plan-file=out.tfplan`},
 			cmd:      []string{HelperPathAsHCL, "echo", "${terramate.stack.path.absolute}"},
 			want: want{
 				run: RunExpected{
@@ -337,7 +337,7 @@ func TestCLIRunWithCloudSyncDeployment(t *testing.T) {
 				"run:s2:terraform init",
 				"run:s2:terraform plan -no-color -out=out.tfplan",
 			},
-			runflags: []string{`--eval`, `--cloud-sync-terraform-plan-file=out.tfplan`},
+			runflags: []string{`--eval`, `--terraform-plan-file=out.tfplan`},
 			cmd:      []string{HelperPathAsHCL, "echo", "${terramate.stack.path.absolute}"},
 			env: []string{
 				`TF_VAR_content=my secret`,
@@ -392,7 +392,7 @@ func TestCLIRunWithCloudSyncDeployment(t *testing.T) {
 					"run",
 					"--disable-safeguards=git-out-of-sync",
 					"--quiet",
-					"--cloud-sync-deployment",
+					"--sync-deployment",
 				}
 				if isParallel {
 					runflags = append(runflags, "--parallel", "5")
@@ -501,7 +501,7 @@ func TestRunGithubTokenDetection(t *testing.T) {
 
 		result := tm.Run("run",
 			"--disable-check-git-remote",
-			"--cloud-sync-deployment", "--", HelperPath, "true")
+			"--sync-deployment", "--", HelperPath, "true")
 		AssertRunResult(t, result, RunExpected{
 			Status:      0,
 			StderrRegex: "GitHub token obtained from GH_TOKEN",
@@ -517,7 +517,7 @@ func TestRunGithubTokenDetection(t *testing.T) {
 
 		result := tm.Run("run",
 			"--disable-check-git-remote",
-			"--cloud-sync-deployment", "--", HelperPath, "true")
+			"--sync-deployment", "--", HelperPath, "true")
 		AssertRunResult(t, result, RunExpected{
 			Status:      0,
 			StderrRegex: "GitHub token obtained from GITHUB_TOKEN",
@@ -544,7 +544,7 @@ func TestRunGithubTokenDetection(t *testing.T) {
 
 		result := tm.Run("run",
 			"--disable-check-git-remote",
-			"--cloud-sync-deployment", "--", HelperPath, "true")
+			"--sync-deployment", "--", HelperPath, "true")
 		AssertRunResult(t, result, RunExpected{
 			Status:      0,
 			StderrRegex: "GitHub token obtained from oauth_token",

--- a/cmd/terramate/e2etests/cloud/run_cloud_drift_test.go
+++ b/cmd/terramate/e2etests/cloud/run_cloud_drift_test.go
@@ -341,12 +341,12 @@ func TestCLIRunWithCloudSyncDriftStatus(t *testing.T) {
 			},
 		},
 		{
-			name: "using --cloud-sync-terraform-plan-file with non-existent plan file",
+			name: "using --terraform-plan-file with non-existent plan file",
 			layout: []string{
 				"s:s1:id=s1",
 			},
 			runflags: []string{
-				`--cloud-sync-terraform-plan-file=out.tfplan`,
+				`--terraform-plan-file=out.tfplan`,
 			},
 			cmd: []string{HelperPath, "exit", "2"},
 			want: want{
@@ -373,12 +373,12 @@ func TestCLIRunWithCloudSyncDriftStatus(t *testing.T) {
 			},
 		},
 		{
-			name: "using --cloud-sync-terraform-plan-file with absolute path",
+			name: "using --terraform-plan-file with absolute path",
 			layout: []string{
 				"s:s1:id=s1",
 			},
 			runflags: []string{
-				fmt.Sprintf(`--cloud-sync-terraform-plan-file=%s`, absPlanFilePath),
+				fmt.Sprintf(`--terraform-plan-file=%s`, absPlanFilePath),
 			},
 			cmd: []string{HelperPath, "exit", "2"},
 			want: want{
@@ -406,7 +406,7 @@ func TestCLIRunWithCloudSyncDriftStatus(t *testing.T) {
 			},
 		},
 		{
-			name: "using --cloud-sync-terraform-plan-file=out.tfplan",
+			name: "using --terraform-plan-file=out.tfplan",
 			layout: []string{
 				"s:s1:id=s1",
 				"s:s1/s2:id=s2",
@@ -416,7 +416,7 @@ func TestCLIRunWithCloudSyncDriftStatus(t *testing.T) {
 				"run:s1/s2:terraform init",
 			},
 			runflags: []string{
-				`--cloud-sync-terraform-plan-file=out.tfplan`,
+				`--terraform-plan-file=out.tfplan`,
 			},
 			env: []string{
 				`TF_VAR_content=my secret`,
@@ -552,7 +552,7 @@ func TestCLIRunWithCloudSyncDriftStatus(t *testing.T) {
 					"run",
 					"--disable-safeguards=git-out-of-sync",
 					"--quiet",
-					"--cloud-sync-drift-status",
+					"--sync-drift-status",
 				}
 				if isParallel {
 					runflags = append(runflags, "-j", "5")

--- a/cmd/terramate/e2etests/cloud/run_cloud_signal_test.go
+++ b/cmd/terramate/e2etests/cloud/run_cloud_signal_test.go
@@ -97,7 +97,7 @@ func TestCLIRunWithCloudSyncDeploymentWithSignals(t *testing.T) {
 
 				runflags := []string{
 					"--disable-safeguards=git-out-of-sync",
-					"--cloud-sync-deployment",
+					"--sync-deployment",
 				}
 				if isParallel {
 					runflags = append(runflags, "--parallel", "5")
@@ -197,7 +197,7 @@ func TestCLIRunWithCloudSyncDriftStatusWithSignals(t *testing.T) {
 				s.Git().SetRemoteURL("origin", testRemoteRepoURL)
 				runflags := []string{
 					"--disable-safeguards=git-out-of-sync",
-					"--cloud-sync-drift-status",
+					"--sync-drift-status",
 				}
 				if isParallel {
 					runflags = append(runflags, "--parallel=5")

--- a/cmd/terramate/e2etests/cloud/run_cloud_sync_preview_test.go
+++ b/cmd/terramate/e2etests/cloud/run_cloud_sync_preview_test.go
@@ -60,7 +60,7 @@ func TestCLIRunWithCloudSyncPreview(t *testing.T) {
 				  }`,
 				"run:stack:terraform init",
 			},
-			runflags:        []string{`--cloud-sync-terraform-plan-file=out.tfplan`},
+			runflags:        []string{`--terraform-plan-file=out.tfplan`},
 			cmd:             []string{TerraformTestPath, "plan", "-out=out.tfplan", "-no-color", "-detailed-exitcode"},
 			githubEventPath: datapath(t, "interop/testdata/event_pull_request.json"),
 			want: want{
@@ -70,7 +70,7 @@ func TestCLIRunWithCloudSyncPreview(t *testing.T) {
 						"Plan: 1 to add, 0 to change, 0 to destroy.",
 					},
 					StderrRegexes: []string{
-						"--cloud-sync-preview is only supported in GitHub Actions workflows",
+						"--sync-preview is only supported in GitHub Actions workflows",
 					},
 				},
 				ignoreTypes: cmpopts.IgnoreTypes(
@@ -92,7 +92,7 @@ func TestCLIRunWithCloudSyncPreview(t *testing.T) {
 				  }`,
 				"run:stack:terraform init",
 			},
-			runflags: []string{`--cloud-sync-terraform-plan-file=out.tfplan`},
+			runflags: []string{`--terraform-plan-file=out.tfplan`},
 			cmd:      []string{TerraformTestPath, "plan", "-out=out.tfplan", "-no-color", "-detailed-exitcode"},
 			env: []string{
 				"GITHUB_ACTIONS=1",
@@ -161,7 +161,7 @@ func TestCLIRunWithCloudSyncPreview(t *testing.T) {
 				  }`,
 				"run:stack:terraform init",
 			},
-			runflags: []string{`--cloud-sync-terraform-plan-file=out.tfplan`},
+			runflags: []string{`--terraform-plan-file=out.tfplan`},
 			cmd:      []string{TerraformTestPath, "plan-invalid-subcommand", "-out=out.tfplan", "-no-color", "-detailed-exitcode"},
 			env: []string{
 				"GITHUB_ACTIONS=1",
@@ -235,7 +235,7 @@ func TestCLIRunWithCloudSyncPreview(t *testing.T) {
 			runflags := []string{
 				"run",
 				"--disable-safeguards=all",
-				"--cloud-sync-preview",
+				"--sync-preview",
 			}
 			runflags = append(runflags, tc.runflags...)
 			runflags = append(runflags, "--")

--- a/cmd/terramate/e2etests/cloud/run_cloud_uimode_test.go
+++ b/cmd/terramate/e2etests/cloud/run_cloud_uimode_test.go
@@ -75,7 +75,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 					cmd: []string{
 						"run",
 						"--quiet",
-						"--cloud-sync-deployment",
+						"--sync-deployment",
 						"--", HelperPath, "true",
 					},
 				},
@@ -85,7 +85,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 					cmd: []string{
 						"run",
 						"--quiet",
-						"--cloud-sync-deployment",
+						"--sync-deployment",
 						"--", HelperPath, "true",
 					},
 				},
@@ -95,7 +95,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 					cmd: []string{
 						"run",
 						"--quiet",
-						"--cloud-sync-drift-status",
+						"--sync-drift-status",
 						"--", HelperPath, "true",
 					},
 				},
@@ -105,7 +105,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 					cmd: []string{
 						"run",
 						"--quiet",
-						"--cloud-sync-drift-status",
+						"--sync-drift-status",
 						"--", HelperPath, "true",
 					},
 				},
@@ -143,7 +143,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 					uimode: cli.HumanMode,
 					cmd: []string{
 						"run",
-						"--cloud-sync-deployment",
+						"--sync-deployment",
 						"--", HelperPath, "true",
 					},
 					want: RunExpected{
@@ -159,7 +159,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 					uimode: cli.AutomationMode,
 					cmd: []string{
 						"run",
-						"--cloud-sync-deployment",
+						"--sync-deployment",
 						"--", HelperPath, "true",
 					},
 					want: RunExpected{
@@ -175,7 +175,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 					uimode: cli.HumanMode,
 					cmd: []string{
 						"run",
-						"--cloud-sync-drift-status",
+						"--sync-drift-status",
 						"--", HelperPath, "true",
 					},
 					want: RunExpected{
@@ -191,7 +191,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 					uimode: cli.AutomationMode,
 					cmd: []string{
 						"run",
-						"--cloud-sync-drift-status",
+						"--sync-drift-status",
 						"--", HelperPath, "true",
 					},
 					want: RunExpected{
@@ -241,7 +241,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 					cmd: []string{
 						"run",
 						"--quiet",
-						"--cloud-sync-deployment",
+						"--sync-deployment",
 						"--", HelperPath, "true",
 					},
 				},
@@ -251,7 +251,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 					cmd: []string{
 						"run",
 						"--quiet",
-						"--cloud-sync-deployment",
+						"--sync-deployment",
 						"--", HelperPath, "true",
 					},
 				},
@@ -261,7 +261,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 					cmd: []string{
 						"run",
 						"--quiet",
-						"--cloud-sync-drift-status",
+						"--sync-drift-status",
 						"--", HelperPath, "true",
 					},
 				},
@@ -271,7 +271,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 					cmd: []string{
 						"run",
 						"--quiet",
-						"--cloud-sync-drift-status",
+						"--sync-drift-status",
 						"--", HelperPath, "true",
 					},
 				},
@@ -311,7 +311,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 					uimode: cli.HumanMode,
 					cmd: []string{
 						"run",
-						"--cloud-sync-deployment",
+						"--sync-deployment",
 						"--", HelperPath, "true",
 					},
 					want: RunExpected{
@@ -327,7 +327,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 					uimode: cli.AutomationMode,
 					cmd: []string{
 						"run",
-						"--cloud-sync-deployment",
+						"--sync-deployment",
 						"--", HelperPath, "true",
 					},
 					want: RunExpected{
@@ -342,7 +342,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 					uimode: cli.HumanMode,
 					cmd: []string{
 						"run",
-						"--cloud-sync-drift-status",
+						"--sync-drift-status",
 						"--", HelperPath, "true",
 					},
 					want: RunExpected{
@@ -358,7 +358,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 					uimode: cli.AutomationMode,
 					cmd: []string{
 						"run",
-						"--cloud-sync-drift-status",
+						"--sync-drift-status",
 						"--", HelperPath, "true",
 					},
 					want: RunExpected{
@@ -417,7 +417,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 					uimode: cli.HumanMode,
 					cmd: []string{
 						"run",
-						"--cloud-sync-deployment",
+						"--sync-deployment",
 						"--", HelperPath, "true",
 					},
 					want: RunExpected{
@@ -433,7 +433,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 					uimode: cli.AutomationMode,
 					cmd: []string{
 						"run",
-						"--cloud-sync-deployment",
+						"--sync-deployment",
 						"--", HelperPath, "true",
 					},
 					want: RunExpected{
@@ -448,7 +448,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 					uimode: cli.HumanMode,
 					cmd: []string{
 						"run",
-						"--cloud-sync-drift-status",
+						"--sync-drift-status",
 						"--", HelperPath, "true",
 					},
 					want: RunExpected{
@@ -464,7 +464,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 					uimode: cli.AutomationMode,
 					cmd: []string{
 						"run",
-						"--cloud-sync-drift-status",
+						"--sync-drift-status",
 						"--", HelperPath, "true",
 					},
 					want: RunExpected{
@@ -511,7 +511,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 					uimode: cli.HumanMode,
 					cmd: []string{
 						"run",
-						"--cloud-sync-deployment",
+						"--sync-deployment",
 						"--", HelperPath, "true",
 					},
 					want: RunExpected{
@@ -524,7 +524,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 					uimode: cli.AutomationMode,
 					cmd: []string{
 						"run",
-						"--cloud-sync-deployment",
+						"--sync-deployment",
 						"--", HelperPath, "true",
 					},
 					want: RunExpected{
@@ -536,7 +536,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 					uimode: cli.HumanMode,
 					cmd: []string{
 						"run",
-						"--cloud-sync-drift-status",
+						"--sync-drift-status",
 						"--", HelperPath, "true",
 					},
 					want: RunExpected{
@@ -549,7 +549,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 					uimode: cli.AutomationMode,
 					cmd: []string{
 						"run",
-						"--cloud-sync-drift-status",
+						"--sync-drift-status",
 						"--", HelperPath, "true",
 					},
 					want: RunExpected{
@@ -608,7 +608,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 					uimode: cli.HumanMode,
 					cmd: []string{
 						"run",
-						"--cloud-sync-deployment",
+						"--sync-deployment",
 						"--", HelperPath, "true",
 					},
 					want: RunExpected{
@@ -624,7 +624,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 					uimode: cli.AutomationMode,
 					cmd: []string{
 						"run",
-						"--cloud-sync-deployment",
+						"--sync-deployment",
 						"--", HelperPath, "true",
 					},
 					want: RunExpected{
@@ -640,7 +640,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 					uimode: cli.HumanMode,
 					cmd: []string{
 						"run",
-						"--cloud-sync-drift-status",
+						"--sync-drift-status",
 						"--", HelperPath, "true",
 					},
 					want: RunExpected{
@@ -656,7 +656,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 					uimode: cli.AutomationMode,
 					cmd: []string{
 						"run",
-						"--cloud-sync-drift-status",
+						"--sync-drift-status",
 						"--", HelperPath, "true",
 					},
 					want: RunExpected{
@@ -742,7 +742,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 					uimode: cli.HumanMode,
 					cmd: []string{
 						"run",
-						"--cloud-sync-deployment",
+						"--sync-deployment",
 						"--", HelperPath, "true",
 					},
 					want: RunExpected{
@@ -758,7 +758,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 					uimode: cli.AutomationMode,
 					cmd: []string{
 						"run",
-						"--cloud-sync-deployment",
+						"--sync-deployment",
 						"--", HelperPath, "true",
 					},
 					want: RunExpected{
@@ -773,7 +773,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 					uimode: cli.HumanMode,
 					cmd: []string{
 						"run",
-						"--cloud-sync-drift-status",
+						"--sync-drift-status",
 						"--", HelperPath, "true",
 					},
 					want: RunExpected{
@@ -789,7 +789,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 					uimode: cli.AutomationMode,
 					cmd: []string{
 						"run",
-						"--cloud-sync-drift-status",
+						"--sync-drift-status",
 						"--", HelperPath, "true",
 					},
 					want: RunExpected{
@@ -861,7 +861,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 					uimode: cli.HumanMode,
 					cmd: []string{
 						"run",
-						"--cloud-sync-deployment",
+						"--sync-deployment",
 						"--", HelperPath, "true",
 					},
 					want: RunExpected{
@@ -878,7 +878,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 					uimode: cli.AutomationMode,
 					cmd: []string{
 						"run",
-						"--cloud-sync-deployment",
+						"--sync-deployment",
 						"--", HelperPath, "true",
 					},
 					want: RunExpected{
@@ -894,7 +894,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 					uimode: cli.HumanMode,
 					cmd: []string{
 						"run",
-						"--cloud-sync-drift-status",
+						"--sync-drift-status",
 						"--", HelperPath, "true",
 					},
 					want: RunExpected{
@@ -911,7 +911,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 					uimode: cli.AutomationMode,
 					cmd: []string{
 						"run",
-						"--cloud-sync-drift-status",
+						"--sync-drift-status",
 						"--", HelperPath, "true",
 					},
 					want: RunExpected{
@@ -998,7 +998,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 					cmd: []string{
 						"run",
 						"--quiet",
-						"--cloud-sync-deployment",
+						"--sync-deployment",
 						"--", HelperPath, "true",
 					},
 				},
@@ -1008,7 +1008,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 					cmd: []string{
 						"run",
 						"--quiet",
-						"--cloud-sync-deployment",
+						"--sync-deployment",
 						"--", HelperPath, "true",
 					},
 				},
@@ -1018,7 +1018,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 					cmd: []string{
 						"run",
 						"--quiet",
-						"--cloud-sync-drift-status",
+						"--sync-drift-status",
 						"--", HelperPath, "true",
 					},
 				},
@@ -1028,7 +1028,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 					cmd: []string{
 						"run",
 						"--quiet",
-						"--cloud-sync-drift-status",
+						"--sync-drift-status",
 						"--", HelperPath, "true",
 					},
 				},
@@ -1069,7 +1069,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 					uimode: cli.HumanMode,
 					cmd: []string{
 						"run",
-						"--cloud-sync-deployment",
+						"--sync-deployment",
 						"--", HelperPath, "true",
 					},
 					want: RunExpected{
@@ -1081,7 +1081,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 					uimode: cli.AutomationMode,
 					cmd: []string{
 						"run",
-						"--cloud-sync-deployment",
+						"--sync-deployment",
 						"--", HelperPath, "true",
 					},
 					want: RunExpected{
@@ -1116,7 +1116,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 					uimode: cli.HumanMode,
 					cmd: []string{
 						"run",
-						"--cloud-sync-deployment",
+						"--sync-deployment",
 						"--", HelperPath, "true",
 					},
 					want: RunExpected{
@@ -1128,7 +1128,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 					uimode: cli.AutomationMode,
 					cmd: []string{
 						"run",
-						"--cloud-sync-deployment",
+						"--sync-deployment",
 						"--", HelperPath, "true",
 					},
 					want: RunExpected{
@@ -1150,7 +1150,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 					uimode: cli.HumanMode,
 					cmd: []string{
 						"run",
-						"--cloud-sync-deployment",
+						"--sync-deployment",
 						"--", HelperPath, "true",
 					},
 					want: RunExpected{
@@ -1165,7 +1165,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 					uimode: cli.AutomationMode,
 					cmd: []string{
 						"run",
-						"--cloud-sync-deployment",
+						"--sync-deployment",
 						"--", HelperPath, "true",
 					},
 					want: RunExpected{
@@ -1180,7 +1180,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 					uimode: cli.HumanMode,
 					cmd: []string{
 						"run",
-						"--cloud-sync-drift-status",
+						"--sync-drift-status",
 						"--", HelperPath, "true",
 					},
 					want: RunExpected{
@@ -1195,7 +1195,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 					uimode: cli.AutomationMode,
 					cmd: []string{
 						"run",
-						"--cloud-sync-drift-status",
+						"--sync-drift-status",
 						"--", HelperPath, "true",
 					},
 					want: RunExpected{
@@ -1221,7 +1221,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 					uimode: cli.HumanMode,
 					cmd: []string{
 						"run",
-						"--cloud-sync-drift-status",
+						"--sync-drift-status",
 						"--", HelperPath, "true",
 					},
 					want: RunExpected{
@@ -1234,7 +1234,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 					uimode: cli.AutomationMode,
 					cmd: []string{
 						"run",
-						"--cloud-sync-drift-status",
+						"--sync-drift-status",
 						"--", HelperPath, "true",
 					},
 					want: RunExpected{

--- a/cmd/terramate/e2etests/cloud/run_script_cloud_deployment_test.go
+++ b/cmd/terramate/e2etests/cloud/run_script_cloud_deployment_test.go
@@ -26,8 +26,8 @@ func TestCLIScriptRunWithCloudSyncDeployment(t *testing.T) {
 			Str("description", "no"),
 			Block("job",
 				Expr("command", fmt.Sprintf(`["echo", "${terramate.stack.name}", {
-			cloud_sync_deployment = %v,
-			cloud_sync_terraform_plan_file = "%s"
+			sync_deployment = %v,
+			sync_terraform_plan_file = "%s"
 		}]`, syncDeployment, plan)),
 			),
 		).String()
@@ -72,7 +72,7 @@ func TestCLIScriptRunWithCloudSyncDeployment(t *testing.T) {
 					description = "no"
 					job {
 						command = ["echooooo", "${terramate.stack.name}", {
-							cloud_sync_deployment = true
+							sync_deployment = true
 						}]
 					}
 				}`,
@@ -97,7 +97,7 @@ func TestCLIScriptRunWithCloudSyncDeployment(t *testing.T) {
 					description = "no"
 					job {
 						command = ["echooooo", "${terramate.stack.name}", {
-							cloud_sync_deployment = true
+							sync_deployment = true
 						}]
 					}
 				}`,

--- a/cmd/terramate/e2etests/cloud/run_script_cloud_drift_test.go
+++ b/cmd/terramate/e2etests/cloud/run_script_cloud_drift_test.go
@@ -53,7 +53,7 @@ func TestScriptRunDriftStatus(t *testing.T) {
 					Str("description", "test"),
 					Block("job",
 						Expr("command", `["echo", "ok", {
-							cloud_sync_drift_status = true
+							sync_drift_status = true
 						}]`),
 					),
 				).String(),
@@ -75,7 +75,7 @@ func TestScriptRunDriftStatus(t *testing.T) {
 					Str("description", "test"),
 					Block("job",
 						Expr("command", `["non-existent-command", {
-							cloud_sync_drift_status = true
+							sync_drift_status = true
 						}]`),
 					),
 				).String(),
@@ -113,7 +113,7 @@ func TestScriptRunDriftStatus(t *testing.T) {
 					Str("description", "test"),
 					Block("job",
 						Expr("command", `["non-existent-command", {
-							cloud_sync_drift_status = true
+							sync_drift_status = true
 						}]`),
 					),
 				).String(),
@@ -151,7 +151,7 @@ func TestScriptRunDriftStatus(t *testing.T) {
 					Block("job",
 						Expr("command", fmt.Sprintf(
 							`["%s", "exit", "2", {
-							cloud_sync_drift_status = true
+							sync_drift_status = true
 						}]`, HelperPathAsHCL)),
 					),
 				).String(),
@@ -186,7 +186,7 @@ func TestScriptRunDriftStatus(t *testing.T) {
 					Block("job",
 						Expr("command", fmt.Sprintf(
 							`["%s", "echo", "${terramate.stack.path.absolute}", {
-							cloud_sync_drift_status = true
+							sync_drift_status = true
 						}]`, HelperPathAsHCL)),
 					),
 				).String(),
@@ -225,7 +225,7 @@ func TestScriptRunDriftStatus(t *testing.T) {
 					Block("job",
 						Expr("command", fmt.Sprintf(
 							`["%s", "exit", "2", {
-							cloud_sync_drift_status = true
+							sync_drift_status = true
 						}]`, HelperPathAsHCL)),
 					),
 				).String(),
@@ -263,7 +263,7 @@ func TestScriptRunDriftStatus(t *testing.T) {
 			},
 		},
 		{
-			name: "using --cloud-sync-terraform-plan-file with non-existent plan file",
+			name: "using --terraform-plan-file with non-existent plan file",
 			layout: []string{
 				"s:s1:id=s1",
 				"f:script.tm:" + Block("script",
@@ -272,8 +272,8 @@ func TestScriptRunDriftStatus(t *testing.T) {
 					Block("job",
 						Expr("command", fmt.Sprintf(
 							`["%s", "exit", "2", {
-							cloud_sync_drift_status = true
-							cloud_sync_terraform_plan_file = "out.tfplan"
+							sync_drift_status = true
+							sync_terraform_plan_file = "out.tfplan"
 						}]`, HelperPathAsHCL)),
 					),
 				).String(),
@@ -303,7 +303,7 @@ func TestScriptRunDriftStatus(t *testing.T) {
 			},
 		},
 		{
-			name: "using --cloud-sync-terraform-plan-file with absolute path",
+			name: "using --terraform-plan-file with absolute path",
 			layout: []string{
 				"s:s1:id=s1",
 				"f:script.tm:" + Block("script",
@@ -312,8 +312,8 @@ func TestScriptRunDriftStatus(t *testing.T) {
 					Block("job",
 						Expr("command", fmt.Sprintf(
 							`["%s", "exit", "2", {
-							cloud_sync_drift_status = true
-							cloud_sync_terraform_plan_file = "%s"
+							sync_drift_status = true
+							sync_terraform_plan_file = "%s"
 						}]`, HelperPathAsHCL, absPlanFilePathAsHCL)),
 					),
 				).String(),
@@ -344,7 +344,7 @@ func TestScriptRunDriftStatus(t *testing.T) {
 			},
 		},
 		{
-			name: "using --cloud-sync-terraform-plan-file=out.tfplan",
+			name: "using --terraform-plan-file=out.tfplan",
 			layout: []string{
 				"s:s1:id=s1",
 				"s:s1/s2:id=s2",
@@ -358,8 +358,8 @@ func TestScriptRunDriftStatus(t *testing.T) {
 					Block("job",
 						Expr("command",
 							`["terraform", "plan", "-no-color", "-detailed-exitcode", "-out=out.tfplan", {
-							cloud_sync_drift_status = true
-							cloud_sync_terraform_plan_file = "out.tfplan"
+							sync_drift_status = true
+							sync_terraform_plan_file = "out.tfplan"
 						}]`),
 					),
 				).String(),
@@ -438,7 +438,7 @@ func TestScriptRunDriftStatus(t *testing.T) {
 					Block("job",
 						Expr("command", fmt.Sprintf(
 							`["%s", "exit", "2", {
-							cloud_sync_drift_status = true
+							sync_drift_status = true
 						}]`, HelperPathAsHCL)),
 					),
 				).String(),

--- a/cmd/terramate/e2etests/cloud/run_script_cloud_sync_preview_test.go
+++ b/cmd/terramate/e2etests/cloud/run_script_cloud_sync_preview_test.go
@@ -75,8 +75,8 @@ func TestScriptRunWithCloudSyncPreview(t *testing.T) {
 					job {
 					  commands = [
 						["%s", "plan", "-out=out.tfplan", "-no-color", "-detailed-exitcode", {
-						  cloud_sync_preview             = true,
-						  cloud_sync_terraform_plan_file = "out.tfplan",
+						  sync_preview             = true,
+						  sync_terraform_plan_file = "out.tfplan",
 						}],
 					  ]
 					}
@@ -100,7 +100,7 @@ func TestScriptRunWithCloudSyncPreview(t *testing.T) {
 						"Plan: 1 to add, 0 to change, 0 to destroy.",
 					},
 					StderrRegexes: []string{
-						"--cloud-sync-preview is only supported in GitHub Actions workflows",
+						"--sync-preview is only supported in GitHub Actions workflows",
 					},
 				},
 				ignoreTypes: cmpopts.IgnoreTypes(
@@ -129,8 +129,8 @@ func TestScriptRunWithCloudSyncPreview(t *testing.T) {
 					job {
 					  commands = [
 						["%s", "plan", "-out=out.tfplan", "-no-color", "-detailed-exitcode", {
-						  cloud_sync_preview             = true,
-						  cloud_sync_terraform_plan_file = "out.tfplan",
+						  sync_preview             = true,
+						  sync_terraform_plan_file = "out.tfplan",
 						}],
 					  ]
 					}

--- a/cmd/terramate/e2etests/cmd/helper/main.go
+++ b/cmd/terramate/e2etests/cmd/helper/main.go
@@ -27,7 +27,7 @@ func main() {
 	}
 
 	// note: unrecovered panic() aborts the program with exit code 2 and this
-	// could be confused with a *detected drift* (see: run --cloud-sync-drift-status)
+	// could be confused with a *detected drift* (see: run --sync-drift-status)
 	// then avoid panics here and do proper os.Exit(1) in case of errors.
 
 	switch os.Args[1] {

--- a/cmd/terramate/e2etests/internal/runner/runner_signal_fixture.go
+++ b/cmd/terramate/e2etests/internal/runner/runner_signal_fixture.go
@@ -65,7 +65,7 @@ func (tm CLI) helperPath() string {
 // Usage:
 //
 //	cli := NewCli(t, chdir)
-//	fixture := NewRunFixture(hangRun, s.RootDir(), "--cloud-sync-deployment")
+//	fixture := NewRunFixture(hangRun, s.RootDir(), "--sync-deployment")
 //	result = fixture.Run()
 //	AssertRunResult(t, result, expected)
 func (tm *CLI) NewRunFixture(mode RunMode, rootdir string, flags ...string) RunFixture {

--- a/config/script.go
+++ b/config/script.go
@@ -187,7 +187,7 @@ func EvalScript(evalctx *eval.Context, script hcl.Script) (Script, error) {
 	}
 	if len(cmdsWithCloudSyncDeployment) > 1 {
 		errs.Append(errors.E(ErrScriptInvalidCmdOptions,
-			"only a single command per script may have 'cloud_sync_deployment' enabled, but was enabled by: %v",
+			"only a single command per script may have 'sync_deployment' enabled, but was enabled by: %v",
 			strings.Join(cmdsWithCloudSyncDeployment, " "),
 		))
 	}
@@ -202,7 +202,7 @@ func EvalScript(evalctx *eval.Context, script hcl.Script) (Script, error) {
 	}
 	if len(cmdsWithCloudSyncPreview) > 1 {
 		errs.Append(errors.E(ErrScriptInvalidCmdOptions,
-			"only a single command per script may have 'cloud_sync_preview' enabled, but was enabled by: %v",
+			"only a single command per script may have 'sync_preview' enabled, but was enabled by: %v",
 			strings.Join(cmdsWithCloudSyncDeployment, " "),
 		))
 	}
@@ -297,7 +297,7 @@ func unmarshalScriptJobCommand(cmdValues cty.Value, expr hhcl.Expression) (*Scri
 					r.Options.CloudSyncPreview &&
 					(r.Options.CloudSyncDriftStatus || r.Options.CloudSyncDeployment) {
 					errs.Append(errors.E(ErrScriptInvalidCmdOptions, expr.Range(),
-						"cloud_sync_preview cannot be used with cloud_sync_deployment or cloud_sync_drift_status"))
+						"sync_preview cannot be used with sync_deployment or sync_drift_status"))
 				}
 				errs.Append(err)
 			} else {
@@ -338,6 +338,8 @@ func unmarshalScriptCommandOptions(obj cty.Value, expr hhcl.Expression) (*Script
 		}
 
 		switch ks := k.AsString(); ks {
+		case "sync_deployment":
+			fallthrough
 		case "cloud_sync_deployment":
 			if v.Type() != cty.Bool {
 				errs.Append(errors.E(ErrScriptInvalidCmdOptions, expr.Range(),
@@ -347,6 +349,8 @@ func unmarshalScriptCommandOptions(obj cty.Value, expr hhcl.Expression) (*Script
 			}
 			r.CloudSyncDeployment = v.True()
 
+		case "sync_drift_status":
+			fallthrough
 		case "cloud_sync_drift_status":
 			if v.Type() != cty.Bool {
 				errs.Append(errors.E(ErrScriptInvalidCmdOptions, expr.Range(),
@@ -355,6 +359,8 @@ func unmarshalScriptCommandOptions(obj cty.Value, expr hhcl.Expression) (*Script
 				break
 			}
 			r.CloudSyncDriftStatus = v.True()
+		case "sync_preview":
+			fallthrough
 		case "cloud_sync_preview":
 			if v.Type() != cty.Bool {
 				errs.Append(errors.E(ErrScriptInvalidCmdOptions, expr.Range(),
@@ -364,6 +370,8 @@ func unmarshalScriptCommandOptions(obj cty.Value, expr hhcl.Expression) (*Script
 			}
 			r.CloudSyncPreview = v.True()
 
+		case "sync_layer":
+			fallthrough
 		case "cloud_sync_layer":
 			if v.Type() != cty.String {
 				errs.Append(errors.E(ErrScriptInvalidCmdOptions, expr.Range(),
@@ -378,6 +386,8 @@ func unmarshalScriptCommandOptions(obj cty.Value, expr hhcl.Expression) (*Script
 					"command option '%s' must contain only alphanumeric characters and hyphens", ks))
 			}
 
+		case "sync_terraform_plan_file":
+			fallthrough
 		case "cloud_sync_terraform_plan_file":
 			if v.Type() != cty.String {
 				errs.Append(errors.E(ErrScriptInvalidCmdOptions, expr.Range(),
@@ -402,7 +412,7 @@ func unmarshalScriptCommandOptions(obj cty.Value, expr hhcl.Expression) (*Script
 
 		if r.CloudSyncDeployment && r.CloudSyncDriftStatus {
 			errs.Append(errors.E(ErrScriptInvalidCmdOptions, expr.Range(),
-				"command option 'cloud_sync_deployment' and 'cloud_sync_drift_status' are conflicting options in the same command"))
+				"command option 'sync_deployment' and 'sync_drift_status' are conflicting options in the same command"))
 		}
 	}
 

--- a/config/script_test.go
+++ b/config/script_test.go
@@ -525,7 +525,7 @@ func TestScriptEval(t *testing.T) {
 			},
 		},
 		{
-			name: "command options with cloud_sync_deployment and cloud_sync_preview",
+			name: "command options with sync_deployment and sync_preview",
 			script: hcl.Script{
 				Labels:      labels,
 				Description: makeAttribute(t, "description", `"some description"`),
@@ -534,9 +534,9 @@ func TestScriptEval(t *testing.T) {
 						Commands: makeCommands(t, `
 						  [
 							["echo", "hello", {
-								cloud_sync_deployment = true
-								cloud_sync_preview = true
-								cloud_sync_terraform_plan_file = "plan_a"
+								sync_deployment = true
+								sync_preview = true
+								sync_terraform_plan_file = "plan_a"
 							}],
 						  ]
 						`),
@@ -546,7 +546,7 @@ func TestScriptEval(t *testing.T) {
 			wantErr: errors.E(config.ErrScriptInvalidCmdOptions),
 		},
 		{
-			name: "command options with invalid cloud_sync_layer",
+			name: "command options with invalid sync_layer",
 			script: hcl.Script{
 				Labels:      labels,
 				Description: makeAttribute(t, "description", `"some description"`),
@@ -555,9 +555,9 @@ func TestScriptEval(t *testing.T) {
 						Commands: makeCommands(t, `
 						  [
 							["echo", "hello", {
-								cloud_sync_preview = true
-								cloud_sync_terraform_plan_file = "plan_a"
-								cloud_sync_layer = "a+b"
+								sync_preview = true
+								sync_terraform_plan_file = "plan_a"
+								sync_layer = "a+b"
 							}],
 						  ]
 						`),
@@ -567,7 +567,7 @@ func TestScriptEval(t *testing.T) {
 			wantErr: errors.E(config.ErrScriptInvalidCmdOptions),
 		},
 		{
-			name: "command options with cloud_sync_preview + planfile + layer",
+			name: "command options with sync_preview + planfile + layer",
 			script: hcl.Script{
 				Labels:      labels,
 				Description: makeAttribute(t, "description", `"some description"`),
@@ -576,9 +576,9 @@ func TestScriptEval(t *testing.T) {
 						Commands: makeCommands(t, `
 						  [
 							["echo", "hello", {
-								cloud_sync_preview = true
-								cloud_sync_terraform_plan_file = "plan_a"
-								cloud_sync_layer = "staging"
+								sync_preview = true
+								sync_terraform_plan_file = "plan_a"
+								sync_layer = "staging"
 							}],
 						  ]
 						`),
@@ -615,8 +615,8 @@ func TestScriptEval(t *testing.T) {
 						Commands: makeCommands(t, `
 						  [
 							["echo", "hello", {
-								cloud_sync_deployment = false
-								cloud_sync_terraform_plan_file = "plan_a"
+								sync_deployment = false
+								sync_terraform_plan_file = "plan_a"
 							}],
 						  ]
 						`),
@@ -624,8 +624,8 @@ func TestScriptEval(t *testing.T) {
 					{
 						Command: makeCommand(t, `
 							["echo", "hello", {
-								cloud_sync_deployment = true
-								cloud_sync_terraform_plan_file = "plan_b"
+								sync_deployment = true
+								sync_terraform_plan_file = "plan_b"
 							}]
 						`),
 					},
@@ -668,8 +668,8 @@ func TestScriptEval(t *testing.T) {
 						Commands: makeCommands(t, `
 						  [
 							["echo", "hello", {
-								cloud_sync_deployment = true
-								cloud_sync_terraform_plan_file = "plan_a"
+								sync_deployment = true
+								sync_terraform_plan_file = "plan_a"
 								terragrunt = true
 							}],
 						  ]
@@ -706,7 +706,7 @@ func TestScriptEval(t *testing.T) {
 						Commands: makeCommands(t, `
 						  [
 							["echo", "hello", {
-								cloud_sync_deploymenttttttt = false
+								sync_deploymenttttttt = false
 							}],
 						  ]
 						`),
@@ -742,7 +742,7 @@ func TestScriptEval(t *testing.T) {
 						Commands: makeCommands(t, `
 						  [
 							["echo", "hello", {
-								cloud_sync_deployment = "false"
+								sync_deployment = "false"
 							}],
 						  ]
 						`),
@@ -752,7 +752,7 @@ func TestScriptEval(t *testing.T) {
 			wantErr: errors.E(config.ErrScriptInvalidCmdOptions),
 		},
 		{
-			name: "multiple cloud_sync_deployments",
+			name: "multiple sync_deployments",
 			script: hcl.Script{
 				Labels:      labels,
 				Description: makeAttribute(t, "description", `"some description"`),
@@ -761,8 +761,8 @@ func TestScriptEval(t *testing.T) {
 						Commands: makeCommands(t, `
 							  [
 								["echo", "hello", {
-									cloud_sync_deployment = true
-									cloud_sync_terraform_plan_file = "plan_a"
+									sync_deployment = true
+									sync_terraform_plan_file = "plan_a"
 								}],
 							  ]
 							`),
@@ -770,8 +770,8 @@ func TestScriptEval(t *testing.T) {
 					{
 						Command: makeCommand(t, `
 								["echo", "hello", {
-									cloud_sync_deployment = true
-									cloud_sync_terraform_plan_file = "plan_a"
+									sync_deployment = true
+									sync_terraform_plan_file = "plan_a"
 								}]
 							`),
 					},

--- a/makefiles/common.mk
+++ b/makefiles/common.mk
@@ -156,7 +156,7 @@ cloud/sync/ok: build test/helper
 			--disable-check-git-untracked   \
 			--disable-check-git-uncommitted \
 			--tags test \
-			run --cloud-sync-deployment --  \
+			run --sync-deployment --  \
 			$(PWD)/bin/helper true
 
 ## sync the Terramate example stack with a failed status.
@@ -166,7 +166,7 @@ cloud/sync/failed: build test/helper
 			--disable-check-git-untracked   \
 			--disable-check-git-uncommitted \
 			--tags test \
-			run --cloud-sync-deployment --  \
+			run --sync-deployment --  \
 			$(PWD)/bin/helper false
 
 ## Display help for all targets


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/terramate-io/terramate/blob/main/CONTRIBUTING.md
2. If the PR is unfinished, mark it as draft: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request
3. Please update the PR title using the Conventional Commits convention: https://www.conventionalcommits.org/en/v1.0.0/
    Example: feat: add support for XYZ.
-->

## What this PR does / why we need it:

This PR renames all `--cloud-*` flags to `--*` to make the options more accessible. The old flags are still supported as aliases, but not shown in help or error messages.

Same goes for script command options, where `cloud_*` command option prefix is dropped.

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Keep it empty if not applicable.
-->

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
<!--
If no, just write "no" in the block below.
If yes, please explain the change and update documentation and the CHANGELOG.md file accordingly.
-->
```
Yes. Flags are renamed and promoted, but the old ones are still supported.
```
