### PR TITLE
fix(ls): panic when workspace is not detected as Terramate project.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
   - Script command options `cloud_*` are shorted to `*`, e.g. `cloud_sync_deployment` => `sync_deployment`.
   - Old flags and command options are still supported as aliases for the new ones.
 
+### Fixed
+
+- Language server panics when editing a file outside a repository.
+
 ## v0.6.0
 
 ### Added

--- a/ls/ls.go
+++ b/ls/ls.go
@@ -364,11 +364,10 @@ func (s *Server) checkFiles(files []string, currentFile string, currentContent s
 	dir := filepath.Dir(currentFile)
 	var experiments []string
 	root, rootdir, found, err := config.TryLoadConfig(dir)
-	if err == nil {
-		experiments = root.Tree().Node.Experiments()
-	}
 	if !found {
 		rootdir = s.workspace
+	} else if err == nil {
+		experiments = root.Tree().Node.Experiments()
 	}
 
 	parser, err := hcl.NewTerramateParser(rootdir, dir, experiments...)

--- a/ls/ls_test.go
+++ b/ls/ls_test.go
@@ -45,6 +45,24 @@ func TestDocumentOpen(t *testing.T) {
 		params.URI.Filename())
 }
 
+func TestDocumentOpenWithoutRootConfig(t *testing.T) {
+	t.Parallel()
+	f := lstest.SetupNoRootConfig(t)
+
+	stack := f.Sandbox.CreateStack("stack")
+	f.Editor.CheckInitialize(f.Sandbox.RootDir())
+	f.Editor.Open(fmt.Sprintf("stack/%s", stackpkg.DefaultFilename))
+	r := <-f.Editor.Requests
+	assert.EqualStrings(t, "textDocument/publishDiagnostics", r.Method(),
+		"unexpected notification request")
+
+	var params lsp.PublishDiagnosticsParams
+	assert.NoError(t, json.Unmarshal(r.Params(), &params), "unmarshaling params")
+	assert.EqualInts(t, 0, len(params.Diagnostics))
+	assert.EqualStrings(t, filepath.Join(stack.Path(), stackpkg.DefaultFilename),
+		params.URI.Filename())
+}
+
 func TestDocumentRegressionErrorLoadingRootConfig(t *testing.T) {
 	t.Parallel()
 	f := lstest.Setup(t)

--- a/test/ls/fixture.go
+++ b/test/ls/fixture.go
@@ -20,11 +20,10 @@ type Fixture struct {
 	Editor  *Editor
 }
 
-// Setup a new fixture.
-func Setup(t *testing.T, layout ...string) Fixture {
+func setup(t *testing.T, createRootConfig bool, layout ...string) Fixture {
 	t.Helper()
 
-	s := sandbox.NoGit(t, true)
+	s := sandbox.NoGit(t, createRootConfig)
 	s.BuildTree(layout)
 
 	// WHY: LSP is bidirectional, the editor calls the server
@@ -68,6 +67,18 @@ func Setup(t *testing.T, layout ...string) Fixture {
 		Editor:  e,
 		Sandbox: s,
 	}
+}
+
+// Setup a new fixture.
+func Setup(t *testing.T, layout ...string) Fixture {
+	t.Helper()
+	return setup(t, true, layout...)
+}
+
+// SetupNoRootConfig a new fixture without root config.
+func SetupNoRootConfig(t *testing.T, layout ...string) Fixture {
+	t.Helper()
+	return setup(t, false, layout...)
 }
 
 func jsonrpc2Conn(rw io.ReadWriteCloser) jsonrpc2.Conn {


### PR DESCRIPTION
## What this PR does / why we need it:

When the user creates a new directory (not inside a repository) and starts writing Terramate files, the language server panics while detecting the project `rootdir` and loading the experiments.

## Which issue(s) this PR fixes:
none

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
yes, fixes a bug
```
