### PR TITLE
chore: disable macos-12 in the CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
 
     strategy:
       matrix:
-        os: ["ubuntu-20.04", "macos-12", "macos-13"]
+        os: ["ubuntu-20.04", "macos-13"]
         go: ["1.21"]
 
     steps:


### PR DESCRIPTION
## What this PR does / why we need it:

We never had an issue with incompatible macos version then this PR disables the old one for improving CI feedback/performance.

## Which issue(s) this PR fixes:
none

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
no
```
