### PR TITLE
fix: naming of cloud script options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 
 ## Unreleased
 
+### Fixed
+
+- Fixed remaining naming inconsistencies of some `cloud` script options.
+  - `--cloud-sync-terraform-plan-file` => `--terraform-plan-file` (flag), `terraform_plan_file` (script option)
+  - `--cloud-sync-layer` => `--layer` (flag), `layer` (script option)
+
 ## v0.6.1
 
 ### Added

--- a/cmd/terramate/e2etests/cloud/run_script_cloud_deployment_test.go
+++ b/cmd/terramate/e2etests/cloud/run_script_cloud_deployment_test.go
@@ -27,7 +27,7 @@ func TestCLIScriptRunWithCloudSyncDeployment(t *testing.T) {
 			Block("job",
 				Expr("command", fmt.Sprintf(`["echo", "${terramate.stack.name}", {
 			sync_deployment = %v,
-			sync_terraform_plan_file = "%s"
+			terraform_plan_file = "%s"
 		}]`, syncDeployment, plan)),
 			),
 		).String()

--- a/cmd/terramate/e2etests/cloud/run_script_cloud_drift_test.go
+++ b/cmd/terramate/e2etests/cloud/run_script_cloud_drift_test.go
@@ -273,7 +273,7 @@ func TestScriptRunDriftStatus(t *testing.T) {
 						Expr("command", fmt.Sprintf(
 							`["%s", "exit", "2", {
 							sync_drift_status = true
-							sync_terraform_plan_file = "out.tfplan"
+							terraform_plan_file = "out.tfplan"
 						}]`, HelperPathAsHCL)),
 					),
 				).String(),
@@ -313,7 +313,7 @@ func TestScriptRunDriftStatus(t *testing.T) {
 						Expr("command", fmt.Sprintf(
 							`["%s", "exit", "2", {
 							sync_drift_status = true
-							sync_terraform_plan_file = "%s"
+							terraform_plan_file = "%s"
 						}]`, HelperPathAsHCL, absPlanFilePathAsHCL)),
 					),
 				).String(),
@@ -359,7 +359,7 @@ func TestScriptRunDriftStatus(t *testing.T) {
 						Expr("command",
 							`["terraform", "plan", "-no-color", "-detailed-exitcode", "-out=out.tfplan", {
 							sync_drift_status = true
-							sync_terraform_plan_file = "out.tfplan"
+							terraform_plan_file = "out.tfplan"
 						}]`),
 					),
 				).String(),

--- a/cmd/terramate/e2etests/cloud/run_script_cloud_sync_preview_test.go
+++ b/cmd/terramate/e2etests/cloud/run_script_cloud_sync_preview_test.go
@@ -76,7 +76,7 @@ func TestScriptRunWithCloudSyncPreview(t *testing.T) {
 					  commands = [
 						["%s", "plan", "-out=out.tfplan", "-no-color", "-detailed-exitcode", {
 						  sync_preview             = true,
-						  sync_terraform_plan_file = "out.tfplan",
+						  terraform_plan_file = "out.tfplan",
 						}],
 					  ]
 					}
@@ -130,7 +130,7 @@ func TestScriptRunWithCloudSyncPreview(t *testing.T) {
 					  commands = [
 						["%s", "plan", "-out=out.tfplan", "-no-color", "-detailed-exitcode", {
 						  sync_preview             = true,
-						  sync_terraform_plan_file = "out.tfplan",
+						  terraform_plan_file = "out.tfplan",
 						}],
 					  ]
 					}

--- a/config/script.go
+++ b/config/script.go
@@ -370,6 +370,8 @@ func unmarshalScriptCommandOptions(obj cty.Value, expr hhcl.Expression) (*Script
 			}
 			r.CloudSyncPreview = v.True()
 
+		case "layer":
+			fallthrough
 		case "sync_layer":
 			fallthrough
 		case "cloud_sync_layer":
@@ -386,6 +388,8 @@ func unmarshalScriptCommandOptions(obj cty.Value, expr hhcl.Expression) (*Script
 					"command option '%s' must contain only alphanumeric characters and hyphens", ks))
 			}
 
+		case "terraform_plan_file":
+			fallthrough
 		case "sync_terraform_plan_file":
 			fallthrough
 		case "cloud_sync_terraform_plan_file":

--- a/config/script_test.go
+++ b/config/script_test.go
@@ -536,7 +536,7 @@ func TestScriptEval(t *testing.T) {
 							["echo", "hello", {
 								sync_deployment = true
 								sync_preview = true
-								sync_terraform_plan_file = "plan_a"
+								terraform_plan_file = "plan_a"
 							}],
 						  ]
 						`),
@@ -546,7 +546,7 @@ func TestScriptEval(t *testing.T) {
 			wantErr: errors.E(config.ErrScriptInvalidCmdOptions),
 		},
 		{
-			name: "command options with invalid sync_layer",
+			name: "command options with invalid layer",
 			script: hcl.Script{
 				Labels:      labels,
 				Description: makeAttribute(t, "description", `"some description"`),
@@ -556,8 +556,8 @@ func TestScriptEval(t *testing.T) {
 						  [
 							["echo", "hello", {
 								sync_preview = true
-								sync_terraform_plan_file = "plan_a"
-								sync_layer = "a+b"
+								terraform_plan_file = "plan_a"
+								layer = "a+b"
 							}],
 						  ]
 						`),
@@ -577,8 +577,8 @@ func TestScriptEval(t *testing.T) {
 						  [
 							["echo", "hello", {
 								sync_preview = true
-								sync_terraform_plan_file = "plan_a"
-								sync_layer = "staging"
+								terraform_plan_file = "plan_a"
+								layer = "staging"
 							}],
 						  ]
 						`),
@@ -616,7 +616,7 @@ func TestScriptEval(t *testing.T) {
 						  [
 							["echo", "hello", {
 								sync_deployment = false
-								sync_terraform_plan_file = "plan_a"
+								terraform_plan_file = "plan_a"
 							}],
 						  ]
 						`),
@@ -625,7 +625,7 @@ func TestScriptEval(t *testing.T) {
 						Command: makeCommand(t, `
 							["echo", "hello", {
 								sync_deployment = true
-								sync_terraform_plan_file = "plan_b"
+								terraform_plan_file = "plan_b"
 							}]
 						`),
 					},
@@ -669,7 +669,7 @@ func TestScriptEval(t *testing.T) {
 						  [
 							["echo", "hello", {
 								sync_deployment = true
-								sync_terraform_plan_file = "plan_a"
+								terraform_plan_file = "plan_a"
 								terragrunt = true
 							}],
 						  ]
@@ -762,7 +762,7 @@ func TestScriptEval(t *testing.T) {
 							  [
 								["echo", "hello", {
 									sync_deployment = true
-									sync_terraform_plan_file = "plan_a"
+									terraform_plan_file = "plan_a"
 								}],
 							  ]
 							`),
@@ -771,7 +771,7 @@ func TestScriptEval(t *testing.T) {
 						Command: makeCommand(t, `
 								["echo", "hello", {
 									sync_deployment = true
-									sync_terraform_plan_file = "plan_a"
+									terraform_plan_file = "plan_a"
 								}]
 							`),
 					},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/terramate-io/terramate/blob/main/CONTRIBUTING.md
2. If the PR is unfinished, mark it as draft: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request
3. Please update the PR title using the Conventional Commits convention: https://www.conventionalcommits.org/en/v1.0.0/
    Example: feat: add support for XYZ.
-->

## What this PR does / why we need it:

In the previous release, the flags `--cloud-sync-terraform-plan-file` and `--cloud-sync-layer` were shorted to `--terraform-plan-file` and `--layer`, but the script option for both still had the `sync_` prefix. This PR shortens them further to `terraform_plan_file` and `layer`, so everything is aligned. As before, the old names are still supported.

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Keep it empty if not applicable.
-->

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
<!--
If no, just write "no" in the block below.
If yes, please explain the change and update documentation and the CHANGELOG.md file accordingly.
-->
```
Two script options are renamed, old names (including the `sync_*` ones) are still supported.
```
