### PR TITLE
fix: generate inherit=false not working when imported.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 
 ## Unreleased
 
+### Fixed
+
+- Fixed the `generate_*.inherit=false` case when the blocks are imported and inherited in child stacks.
+
 ## v0.6.2
 
 ### Fixed


### PR DESCRIPTION
## What this PR does / why we need it:

Fixes a problem that generate blocks with `inherit=false` are not generated if the blocks are imported and inherited in child stacks.

Thanks @ckd

## Which issue(s) this PR fixes:
Reported on discord: https://discord.com/channels/1088753599951151154/1229901710319685692/1230006750325768192

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
yes, fixes a bug.
```
