### PR TITLE
tests: uses a fixed version of Terraform in tests.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,8 @@ jobs:
 
       - name: make test
         run: terramate run --tags golang --changed -- make test
+        env:
+          TM_TEST_TERRAFORM_REQUIRED_VERSION: "1.7.5"
 
       - name: make build
         run: terramate run --tags golang --changed -- make build


### PR DESCRIPTION
## What this PR does / why we need it:

Fixes the version of Terraform used in CI tests.
The ubuntu runners were upgrade to use `Terraform v1.8.0` and the Plan JSON output has an additional field that breaks our expected case. We will relax the plan file comparator later in a separate PR.

## Which issue(s) this PR fixes:
none

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
no
```
