### PR TITLE
fix: fmt --detailed-exit-code not saving the files.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 
 ## Unreleased
 
+### Fixed
+
+- Fix `fmt --detailed-exit-code` not saving the modified files.
+
 ## v0.6.3
 
 ### Fixed

--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -1597,10 +1597,6 @@ func (c *cli) format() {
 		if c.parsedArgs.Fmt.Check {
 			os.Exit(1)
 		}
-
-		if c.parsedArgs.Fmt.DetailedExitCode {
-			os.Exit(2)
-		}
 	}
 
 	errs := errors.L()
@@ -1609,7 +1605,11 @@ func (c *cli) format() {
 	}
 
 	if err := errs.AsError(); err != nil {
-		fatalWithDetails(err, "saving files formatted files")
+		fatalWithDetails(err, "saving formatted files")
+	}
+
+	if len(results) > 0 && c.parsedArgs.Fmt.DetailedExitCode {
+		os.Exit(2)
 	}
 }
 

--- a/cmd/terramate/e2etests/core/fmt_test.go
+++ b/cmd/terramate/e2etests/core/fmt_test.go
@@ -94,15 +94,18 @@ name = "name"
 		assertWantedFilesContents(t, unformattedHCL)
 	})
 
-	t.Run("--detailed-exit-code returns status=2 when used on unformatted files", func(t *testing.T) {
+	t.Run("--detailed-exit-code returns status=2 when used on unformatted files - do modify the files", func(t *testing.T) {
+		// see: https://github.com/terramate-io/terramate/issues/1649
+		writeUnformattedFiles()
 		AssertRunResult(t, cli.Run("fmt", "--detailed-exit-code"), RunExpected{
 			Status: 2,
 			Stdout: wantedFilesStr,
 		})
-		assertWantedFilesContents(t, unformattedHCL)
+		assertWantedFilesContents(t, formattedHCL)
 	})
 
 	t.Run("checking fails with unformatted files on subdirs", func(t *testing.T) {
+		writeUnformattedFiles()
 		subdir := filepath.Join(s.RootDir(), "another-stacks")
 		cli := NewCLI(t, subdir)
 		AssertRunResult(t, cli.Run("fmt", "--check"), RunExpected{
@@ -117,6 +120,7 @@ name = "name"
 	})
 
 	t.Run("update unformatted files in place", func(t *testing.T) {
+		writeUnformattedFiles()
 		AssertRunResult(t, cli.Run("fmt"), RunExpected{
 			Stdout: wantedFilesStr,
 		})
@@ -124,6 +128,8 @@ name = "name"
 	})
 
 	t.Run("checking succeeds when all files are formatted", func(t *testing.T) {
+		writeUnformattedFiles()
+		AssertRunResult(t, cli.Run("fmt"), RunExpected{IgnoreStdout: true})
 		AssertRunResult(t, cli.Run("fmt", "--check"), RunExpected{})
 		assertWantedFilesContents(t, formattedHCL)
 	})


### PR DESCRIPTION
## What this PR does / why we need it:

Fix a bug that `fmt --detailed-exit-code` exits before actual saving the files.

## Which issue(s) this PR fixes:
Fixes #1649 

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
yes, fixes a bug.
```
