### PR TITLE
feat: add terramate.config.change_detection.terragrunt option.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 
 ## Unreleased
 
+### Added
+
+- Add `terramate.config.change_detection.terragrunt.enabled` attribute. It supports the values below:
+  - `auto` (*default*): Automatically detects if Terragrunt is being used and enables change detection if needed.
+  - `force`: Enables Terragrunt change detection even if no Terragrunt file is detected.
+  - `off`: Disables Terragrunt change detection.
+
 ## v0.6.4
 
 ### Fixed

--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -1727,7 +1727,7 @@ func (c *cli) generateGraph() {
 		fatal(`-label expects the values "stack.name" or "stack.dir"`)
 	}
 
-	entries, err := stack.List(c.cfg().Tree())
+	entries, err := stack.List(c.cfg(), c.cfg().Tree())
 	if err != nil {
 		fatalWithDetails(err, "listing stacks to build graph")
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -49,6 +49,9 @@ const (
 type Root struct {
 	tree Tree
 
+	// hasTerragruntStacks tells if the repository has any Terragrunt stack.
+	hasTerragruntStacks *bool
+
 	runtime project.Runtime
 }
 
@@ -65,6 +68,8 @@ type Tree struct {
 	// Parent is the parent node or nil if none.
 	Parent *Tree
 
+	// project root is only set if Parent == nil.
+	root  *Root
 	stack *Stack
 
 	dir string
@@ -116,9 +121,10 @@ func TryLoadConfig(fromdir string) (tree *Root, configpath string, found bool, e
 
 // NewRoot creates a new [Root] tree for the cfg tree.
 func NewRoot(tree *Tree) *Root {
-	r := &Root{
-		tree: *tree,
-	}
+	r := &Root{}
+	tree.root = r
+	r.tree = *tree
+
 	r.initRuntime()
 	return r
 }
@@ -311,7 +317,15 @@ func (tree *Tree) Root() *Root {
 	if tree.Parent != nil {
 		return tree.Parent.Root()
 	}
-	return NewRoot(tree)
+	return tree.root
+}
+
+// RootTree returns the tree at the project root.
+func (tree *Tree) RootTree() *Tree {
+	if tree.Parent != nil {
+		return tree.Parent.RootTree()
+	}
+	return tree
 }
 
 // IsStack tells if the node is a stack.
@@ -419,7 +433,7 @@ func loadTree(parentTree *Tree, cfgdir string, rootcfg *hcl.Config) (_ *Tree, er
 	}
 
 	if parentTree != nil && rootcfg == nil {
-		rootcfg = &parentTree.Root().Tree().Node
+		rootcfg = &parentTree.RootTree().Node
 	}
 
 	if cfgdir != parentTree.RootDir() {
@@ -437,7 +451,7 @@ func loadTree(parentTree *Tree, cfgdir string, rootcfg *hcl.Config) (_ *Tree, er
 		parentTree = tree
 	}
 
-	err = processTmGenFiles(parentTree.Root(), &parentTree.Node, cfgdir, dirEntries)
+	err = processTmGenFiles(parentTree.RootTree(), &parentTree.Node, cfgdir, dirEntries)
 	if err != nil {
 		return nil, err
 	}
@@ -460,10 +474,10 @@ func loadTree(parentTree *Tree, cfgdir string, rootcfg *hcl.Config) (_ *Tree, er
 	return parentTree, nil
 }
 
-func processTmGenFiles(root *Root, cfg *hcl.Config, cfgdir string, dirEntries []fs.DirEntry) error {
+func processTmGenFiles(rootTree *Tree, cfg *hcl.Config, cfgdir string, dirEntries []fs.DirEntry) error {
 	const tmgenSuffix = ".tmgen"
 
-	tmgenEnabled := root.HasExperiment("tmgen")
+	tmgenEnabled := rootTree.hasExperiment("tmgen")
 
 	// process all .tmgen files.
 	for _, dirEntry := range dirEntries {
@@ -522,9 +536,9 @@ func processTmGenFiles(root *Root, cfg *hcl.Config, cfgdir string, dirEntries []
 
 		implicitGenBlock := hcl.GenHCLBlock{
 			IsImplicitBlock: true,
-			Dir:             project.PrjAbsPath(root.HostDir(), cfgdir),
+			Dir:             project.PrjAbsPath(rootTree.HostDir(), cfgdir),
 			Inherit:         inheritAttr,
-			Range: info.NewRange(root.HostDir(), hhcl.Range{
+			Range: info.NewRange(rootTree.HostDir(), hhcl.Range{
 				Filename: absFname,
 				Start:    hhcl.InitialPos,
 				End: hhcl.Pos{
@@ -572,13 +586,55 @@ func NewTree(cfgdir string) *Tree {
 	}
 }
 
-// HasExperiment returns true if the given experiment name is set.
-func (root *Root) HasExperiment(name string) bool {
-	if root.tree.Node.Terramate == nil || root.tree.Node.Terramate.Config == nil {
+func (tree *Tree) hasExperiment(name string) bool {
+	if tree.Parent != nil {
+		return tree.Parent.hasExperiment(name)
+	}
+	if tree.Node.Terramate == nil || tree.Node.Terramate.Config == nil {
 		return false
 	}
 
-	return slices.Contains(root.tree.Node.Terramate.Config.Experiments, name)
+	return slices.Contains(tree.Node.Terramate.Config.Experiments, name)
+}
+
+// HasExperiment returns true if the given experiment name is set.
+func (root *Root) HasExperiment(name string) bool {
+	return root.tree.hasExperiment(name)
+}
+
+// TerragruntEnabledOption returns the configured `terramate.config.change_detection.terragrunt.enabled` option.
+func (root *Root) TerragruntEnabledOption() hcl.TerragruntChangeDetectionEnabledOption {
+	if root.tree.Node.Terramate != nil &&
+		root.tree.Node.Terramate.Config != nil &&
+		root.tree.Node.Terramate.Config.ChangeDetection != nil &&
+		root.tree.Node.Terramate.Config.ChangeDetection.Terragrunt != nil {
+		return root.tree.Node.Terramate.Config.ChangeDetection.Terragrunt.Enabled
+	}
+	return hcl.TerragruntAutoOption // "auto" is the default.
+}
+
+// HasTerragruntStacks returns true if the stack loading has detected Terragrunt files.
+func (root *Root) HasTerragruntStacks() bool {
+	b := root.hasTerragruntStacks
+	if b == nil {
+		panic(errors.E(errors.ErrInternal, "root.HasTerragruntStacks should be called after stacks list is computed"))
+	}
+	return *b
+}
+
+// IsTerragruntChangeDetectionEnabled returns true if Terragrunt change detection integration
+// must be executed.
+func (root *Root) IsTerragruntChangeDetectionEnabled() bool {
+	switch opt := root.TerragruntEnabledOption(); opt {
+	case hcl.TerragruntOffOption:
+		return false
+	case hcl.TerragruntForceOption:
+		return true
+	case hcl.TerragruntAutoOption:
+		return root.HasTerragruntStacks()
+	default:
+		panic(errors.E(errors.ErrInternal, "unexpected terragrunt option: %v", opt))
+	}
 }
 
 // Skip returns true if the given file/dir name should be ignored by Terramate.

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -90,7 +90,7 @@ type LoadResult struct {
 // a non-nil error. In this case the error is not specific to generating code
 // for a specific dir.
 func Load(root *config.Root, vendorDir project.Path) ([]LoadResult, error) {
-	stacks, err := config.LoadAllStacks(root.Tree())
+	stacks, err := config.LoadAllStacks(root, root.Tree())
 	if err != nil {
 		return nil, err
 	}
@@ -515,7 +515,7 @@ func DetectOutdated(root *config.Root, vendorDir project.Path) ([]string, error)
 		Str("action", "generate.DetectOutdated()").
 		Logger()
 
-	stacks, err := config.LoadAllStacks(root.Tree())
+	stacks, err := config.LoadAllStacks(root, root.Tree())
 	if err != nil {
 		return nil, err
 	}

--- a/globals/globals_test.go
+++ b/globals/globals_test.go
@@ -4066,7 +4066,7 @@ func TestLoadGlobalsErrors(t *testing.T) {
 				test.AppendFile(t, path, config.DefaultFilename, c.body)
 			}
 
-			cfg, err := config.LoadTree(s.RootDir(), s.RootDir())
+			root, err := config.LoadRoot(s.RootDir())
 			// TODO(i4k): this better not be tested here.
 			if errors.IsKind(tcase.want, hcl.ErrHCLSyntax) {
 				errtest.Assert(t, err, tcase.want)
@@ -4076,7 +4076,7 @@ func TestLoadGlobalsErrors(t *testing.T) {
 				return
 			}
 
-			stacks, err := config.LoadAllStacks(cfg)
+			stacks, err := config.LoadAllStacks(root, root.Tree())
 			assert.NoError(t, err)
 			for _, elem := range stacks {
 				report := globals.ForStack(s.Config(), elem.Stack)
@@ -4102,13 +4102,13 @@ func testGlobals(t *testing.T, tcase testcase) {
 
 		wantGlobals := tcase.want
 
-		cfg, err := config.LoadTree(s.RootDir(), s.RootDir())
+		root, err := config.LoadRoot(s.RootDir())
 		if err != nil {
 			errtest.Assert(t, err, tcase.wantErr)
 			return
 		}
 
-		stackEntries, err := stack.List(cfg)
+		stackEntries, err := stack.List(root, root.Tree())
 		assert.NoError(t, err)
 
 		var stacks config.List[*config.SortableStack]

--- a/hcl/hcl.go
+++ b/hcl/hcl.go
@@ -149,6 +149,26 @@ type GitConfig struct {
 	CheckRemote OptionalCheck
 }
 
+// ChangeDetectionConfig is the `terramate.config.change_detection` config.
+type ChangeDetectionConfig struct {
+	Terragrunt *TerragruntConfig
+}
+
+// TerragruntConfig is the `terramate.config.change_detection.terragrunt` config.
+type TerragruntConfig struct {
+	Enabled TerragruntChangeDetectionEnabledOption
+}
+
+// TerragruntChangeDetectionEnabledOption is the change detection options for enabling Terragrunt.
+type TerragruntChangeDetectionEnabledOption int
+
+// Terragrunt Enabling options.
+const (
+	TerragruntAutoOption TerragruntChangeDetectionEnabledOption = iota
+	TerragruntOffOption
+	TerragruntForceOption
+)
+
 // GenerateRootConfig represents the AST node for the `terramate.config.generate` block.
 type GenerateRootConfig struct {
 	HCLMagicHeaderCommentStyle *string
@@ -164,6 +184,7 @@ type CloudConfig struct {
 type RootConfig struct {
 	Git               *GitConfig
 	Generate          *GenerateRootConfig
+	ChangeDetection   *ChangeDetectionConfig
 	Run               *RunConfig
 	Cloud             *CloudConfig
 	Experiments       []string
@@ -1659,7 +1680,7 @@ func (p *TerramateParser) parseRootConfig(cfg *RootConfig, block *ast.MergedBloc
 		}
 	}
 
-	errs.AppendWrap(ErrTerramateSchema, block.ValidateSubBlocks("git", "generate", "run", "cloud"))
+	errs.AppendWrap(ErrTerramateSchema, block.ValidateSubBlocks("git", "generate", "change_detection", "run", "cloud"))
 
 	gitBlock, ok := block.Blocks[ast.NewEmptyLabelBlockType("git")]
 	if ok {
@@ -1683,6 +1704,12 @@ func (p *TerramateParser) parseRootConfig(cfg *RootConfig, block *ast.MergedBloc
 		cfg.Generate = &GenerateRootConfig{}
 
 		errs.Append(parseGenerateRootConfig(cfg.Generate, generateBlock))
+	}
+
+	changeDetectionBlock, ok := block.Blocks[ast.NewEmptyLabelBlockType("change_detection")]
+	if ok {
+		cfg.ChangeDetection = &ChangeDetectionConfig{}
+		errs.Append(parseChangeDetectionConfig(cfg.ChangeDetection, changeDetectionBlock))
 	}
 
 	return errs.AsError()
@@ -1783,6 +1810,70 @@ func parseGenerateRootConfig(cfg *GenerateRootConfig, generateBlock *ast.MergedB
 		}
 	}
 	return errs.AsError()
+}
+
+func parseChangeDetectionConfig(cfg *ChangeDetectionConfig, changeDetectionBlock *ast.MergedBlock) error {
+	err := changeDetectionBlock.ValidateSubBlocks("terragrunt")
+	if err != nil {
+		return err
+	}
+	terragruntBlock, ok := changeDetectionBlock.Blocks[ast.NewEmptyLabelBlockType("terragrunt")]
+	if !ok {
+		return nil
+	}
+
+	cfg.Terragrunt = &TerragruntConfig{}
+	return parseTerragruntConfig(cfg.Terragrunt, terragruntBlock)
+}
+
+func parseTerragruntConfig(cfg *TerragruntConfig, terragruntBlock *ast.MergedBlock) error {
+	errs := errors.L()
+	errs.Append(terragruntBlock.ValidateSubBlocks())
+
+	for _, attr := range terragruntBlock.Attributes {
+		switch attr.Name {
+		case "enabled":
+			value, diags := attr.Expr.Value(nil)
+			if diags.HasErrors() {
+				errs.Append(errors.E(diags,
+					"failed to evaluate terramate.config.change_detection.terragrunt.%s attribute", attr.Name,
+				))
+				continue
+			}
+			if value.Type() != cty.String {
+				errs.Append(attrErr(attr,
+					"terramate.config.change_detection.terragrunt.enabled is not a string but %q",
+					value.Type().FriendlyName(),
+				))
+				continue
+			}
+
+			valStr := value.AsString()
+			var opt TerragruntChangeDetectionEnabledOption
+			switch valStr {
+			case "auto":
+				opt = TerragruntAutoOption
+			case "off":
+				opt = TerragruntOffOption
+			case "force":
+				opt = TerragruntForceOption
+			default:
+				errs.Append(attrErr(attr,
+					`terramate.config.change_detection.terragrunt.enabled must be either "auto", "off" or "force" but %q was given`,
+					valStr,
+				))
+			}
+
+			cfg.Enabled = opt
+		default:
+			errs.Append(errors.E(
+				attr.NameRange,
+				"unrecognized attribute terramate.config.change_detection.terragrunt.%s",
+				attr.Name,
+			))
+		}
+	}
+	return nil
 }
 
 func parseRunEnv(runEnv *RunEnv, envBlock *ast.MergedBlock) error {

--- a/hcl/hcl_test.go
+++ b/hcl/hcl_test.go
@@ -962,6 +962,102 @@ func TestHCLParserRootConfig(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "terramate.config.change_detection.terragrunt.enabled = auto",
+			input: []cfgfile{
+				{
+					filename: "cfg.tm",
+					body: `
+						terramate {
+						  config {
+						    change_detection {
+							  terragrunt {
+							    enabled = "auto"
+							  }
+							}
+						  }
+						}
+					`,
+				},
+			},
+			want: want{
+				config: hcl.Config{
+					Terramate: &hcl.Terramate{
+						Config: &hcl.RootConfig{
+							ChangeDetection: &hcl.ChangeDetectionConfig{
+								Terragrunt: &hcl.TerragruntConfig{
+									Enabled: hcl.TerragruntAutoOption,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "terramate.config.change_detection.terragrunt.enabled = off",
+			input: []cfgfile{
+				{
+					filename: "cfg.tm",
+					body: `
+						terramate {
+						  config {
+						    change_detection {
+							  terragrunt {
+							    enabled = "off"
+							  }
+							}
+						  }
+						}
+					`,
+				},
+			},
+			want: want{
+				config: hcl.Config{
+					Terramate: &hcl.Terramate{
+						Config: &hcl.RootConfig{
+							ChangeDetection: &hcl.ChangeDetectionConfig{
+								Terragrunt: &hcl.TerragruntConfig{
+									Enabled: hcl.TerragruntOffOption,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "terramate.config.change_detection.terragrunt.enabled = force",
+			input: []cfgfile{
+				{
+					filename: "cfg.tm",
+					body: `
+						terramate {
+						  config {
+						    change_detection {
+							  terragrunt {
+							    enabled = "force"
+							  }
+							}
+						  }
+						}
+					`,
+				},
+			},
+			want: want{
+				config: hcl.Config{
+					Terramate: &hcl.Terramate{
+						Config: &hcl.RootConfig{
+							ChangeDetection: &hcl.ChangeDetectionConfig{
+								Terragrunt: &hcl.TerragruntConfig{
+									Enabled: hcl.TerragruntForceOption,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	} {
 		testParser(t, tc)
 	}

--- a/stack/manager_test.go
+++ b/stack/manager_test.go
@@ -161,8 +161,33 @@ func TestListChangedStacks(t *testing.T) {
 			},
 		},
 		{
-			name:        "single Terragrunt stack with single local Terraform module changed",
-			repobuilder: singleTerragruntStackWithSingleTerraformModuleChangedRepo,
+			name: "(terragrunt: auto): single Terragrunt stack with single local Terraform module changed",
+			repobuilder: func(t *testing.T) repository {
+				t.Helper()
+				return singleTerragruntStackWithSingleTerraformModuleChangedRepo(t, "auto")
+			},
+			want: listTestResult{
+				list:    []string{"/tg-stack"},
+				changed: []string{"/tg-stack"},
+			},
+		},
+		{
+			name: "(terragrunt: off): single Terragrunt stack with single local Terraform module changed",
+			repobuilder: func(t *testing.T) repository {
+				t.Helper()
+				return singleTerragruntStackWithSingleTerraformModuleChangedRepo(t, "off")
+			},
+			want: listTestResult{
+				list:    []string{"/tg-stack"},
+				changed: []string{},
+			},
+		},
+		{
+			name: "(terragrunt: force): single Terragrunt stack with single local Terraform module changed",
+			repobuilder: func(t *testing.T) repository {
+				t.Helper()
+				return singleTerragruntStackWithSingleTerraformModuleChangedRepo(t, "force")
+			},
 			want: listTestResult{
 				list:    []string{"/tg-stack"},
 				changed: []string{"/tg-stack"},
@@ -689,12 +714,16 @@ func singleTerragruntStackWithNoChangesRepo(t *testing.T) repository {
 	return repo
 }
 
-func singleTerragruntStackWithSingleTerraformModuleChangedRepo(t *testing.T) repository {
+func singleTerragruntStackWithSingleTerraformModuleChangedRepo(t *testing.T, enabledOption string) repository {
 	repo := singleMergeCommitRepoNoStack(t)
 	test.WriteFile(t, repo.Dir, "terramate.tm.hcl", Doc(
 		Block("terramate",
 			Block("config",
-				Expr("experiments", `["terragrunt"]`),
+				Block("change_detection",
+					Block("terragrunt",
+						Str("enabled", enabledOption),
+					),
+				),
 			),
 		),
 	).String())

--- a/stack/stack.go
+++ b/stack/stack.go
@@ -7,8 +7,8 @@ import "github.com/terramate-io/terramate/config"
 
 // List loads from the config all terramate stacks.
 // It returns a lexicographic sorted list of stack directories.
-func List(cfg *config.Tree) ([]Entry, error) {
-	stacks, err := config.LoadAllStacks(cfg)
+func List(root *config.Root, cfg *config.Tree) ([]Entry, error) {
+	stacks, err := config.LoadAllStacks(root, cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/stack/stack_test.go
+++ b/stack/stack_test.go
@@ -20,9 +20,9 @@ func TestLoadAllFailsIfStacksIDIsNotUnique(t *testing.T) {
 		"s:stacks/stack-1:id=terramate",
 		"s:stacks/stack-2:id=TerraMate",
 	})
-	cfg, err := config.LoadTree(s.RootDir(), s.RootDir())
+	root, err := config.LoadRoot(s.RootDir())
 	assert.NoError(t, err)
-	_, err = config.LoadAllStacks(cfg)
+	_, err = config.LoadAllStacks(root, root.Tree())
 	assert.IsError(t, err, errors.E(config.ErrStackDuplicatedID))
 }
 

--- a/test/sandbox/sandbox.go
+++ b/test/sandbox/sandbox.go
@@ -278,7 +278,7 @@ func (s S) LoadStack(dir project.Path) *config.Stack {
 func (s S) LoadStacks() config.List[*config.SortableStack] {
 	s.t.Helper()
 
-	entries, err := stack.List(s.Config().Tree())
+	entries, err := stack.List(s.Config(), s.Config().Tree())
 	assert.NoError(s.t, err)
 
 	var stacks config.List[*config.SortableStack]
@@ -806,7 +806,7 @@ func assertTree(t testing.TB, root *config.Root, layout []string, opts *assertTr
 
 	if opts.withStrictStacks {
 		gotStrictStacks := []string{}
-		stackEntries, err := stack.List(root.Tree())
+		stackEntries, err := stack.List(root, root.Tree())
 		assert.NoError(t, err)
 
 		for _, st := range stackEntries {


### PR DESCRIPTION
## What this PR does / why we need it:

Introduces the `terramate.config.change_detection.terragrunt.enabled` attribute supporting the options below:
- `auto`: detects if Terragrunt modules are present and enables automatically.
- `off`: turn off the integration.
- `force`: do Terragrunt change detection even if no Terragrunt module is detected.

## Which issue(s) this PR fixes:
Relates to #1656 

## Special notes for your reviewer:

Additional changes were required because the `config.Root` was not a singleton.

## Does this PR introduce a user-facing change?
```
yes, adds a new feature.
```
