### PR TITLE
feat: add Chocolatey support for Windows package distribution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,21 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version: '1.21'
-
+      - name: Install Snapcraft & Chocolatey
+        # from https://github.com/twpayne/chezmoi/blob/5293b40b48e678c461d68d06b635010173cac970/.github/workflows/main.yml#L154C1-L167C38
+        run: |
+          sudo apt-get --quiet update
+          sudo apt-get --no-install-suggests --no-install-recommends --quiet --yes install musl-tools snapcraft
+          # https://github.com/goreleaser/goreleaser/issues/1715
+          # https://bugs.launchpad.net/snapcraft/+bug/1889741
+          mkdir -p "${HOME}/.cache/snapcraft/download"
+          mkdir -p "${HOME}/.cache/snapcraft/stage-packages"
+          mkdir -p /opt/chocolatey
+          wget -q -O - "https://github.com/chocolatey/choco/releases/download/2.2.2/chocolatey.v2.2.2.tar.gz" | tar -xz -C "/opt/chocolatey"
+          echo '#!/bin/bash' >> /usr/local/bin/choco
+          echo 'mono /opt/chocolatey/choco.exe $@' >> /usr/local/bin/choco
+          chmod +x /usr/local/bin/choco
+      
       - name: Log in to ghcr.io container registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
@@ -30,6 +44,7 @@ jobs:
         run: make release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CHOCOLATEY_API_KEY: ${{ secrets.CHOCOLATEY_API_KEY }}
           DISCORD_WEBHOOK_ID: ${{ secrets.DISCORD_WEBHOOK_ID }}
           DISCORD_WEBHOOK_TOKEN: ${{ secrets.DISCORD_WEBHOOK_TOKEN }}
           TWITTER_CONSUMER_KEY: ${{ secrets.TWITTER_APP_TERRAMATE_RELEASE_CONSUMER_API_KEY }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -37,6 +37,27 @@ archives:
       - goos: windows
         format: zip
 
+chocolateys:
+  - name: 'terramate'
+    ids:
+      - 'terramate'
+      - 'terramate-ls'
+    title: Terramate
+    authors: Terramate GmbH
+    project_url: https://github.com/terramate-io/terramate
+    icon_url: 'https://raw.githubusercontent.com/terramate-io/brand/main/whitemode/stamp.svg'
+    license_url: 'https://github.com/terramate-io/terramate/blob/main/LICENSE'
+    require_license_acceptance: false
+    project_source_url: 'https://github.com/terramate-io/terramate'
+    docs_url: 'https://github.com/terramate-io/terramate/blob/main/README.md'
+    bug_tracker_url: 'https://github.com/terramate-io/terramate/issues'
+    summary: 'Terramate - your infrastructure as code software'
+    description: |
+      Terramate helps you manage and version your infrastructure as code.
+    release_notes: 'https://github.com/terramate-io/terramate/releases/tag/v{{ .Version }}'
+    api_key: '{{ .Env.CHOCOLATEY_API_KEY }}'
+    source_repo: 'https://push.chocolatey.org/'
+
 dockers:
   - dockerfile: hack/release/Dockerfile
     image_templates:


### PR DESCRIPTION
This PR introduces Chocolatey packaging for Windows distributions in our GoReleaser configuration and updates our GitHub Actions to install Chocolatey as part of the CI/CD pipeline. 
