### PR TITLE
fix: incorrect warnings emitted by the parser.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 
 ## Unreleased
 
+### Fixed
+
+- Fix incorrect warning emitted by the parser in the case `terramate.config.run.env` is defined outside project root.
+
 ## v0.8.0
 
 ### Added

--- a/hcl/hcl_import_test.go
+++ b/hcl/hcl_import_test.go
@@ -225,7 +225,7 @@ func TestHCLImport(t *testing.T) {
 			},
 			want: want{
 				errs: []error{
-					errors.E(hcl.ErrUnexpectedTerramate),
+					errors.E(hcl.ErrTerramateSchema),
 				},
 			},
 		},

--- a/hcl/hcl_test.go
+++ b/hcl/hcl_test.go
@@ -1595,7 +1595,7 @@ func TestHCLParserTerramateBlocksMerging(t *testing.T) {
 			},
 		},
 		{
-			name:     "terramate in non-root directory fails",
+			name:     "terramate.config.git in non-root directory fails",
 			parsedir: "stack",
 			input: []cfgfile{
 				{
@@ -1610,14 +1610,18 @@ func TestHCLParserTerramateBlocksMerging(t *testing.T) {
 					filename: "stack/terramate.tm",
 					body: `
 						terramate {
+							config {
+								git {
 
+								}
+							}
 						}
 					`,
 				},
 			},
 			want: want{
 				errs: []error{
-					errors.E(hcl.ErrUnexpectedTerramate),
+					errors.E(hcl.ErrTerramateSchema),
 				},
 			},
 		},


### PR DESCRIPTION
## What this PR does / why we need it:

Fix incorrect warnings emitted by the parser when `terramate.config.run.env` is declared in child directories.

## Which issue(s) this PR fixes:
none

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
<!--
If no, just write "no" in the block below.
If yes, please explain the change and update documentation and the CHANGELOG.md file accordingly.
-->
```

```
