### PR TITLE
fix: goreleaser should be extracted outside repo dir.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,10 +27,9 @@ jobs:
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
       - name: install goreleaser
         run: |
-          curl -sL https://github.com/goreleaser/goreleaser-pro/releases/download/v1.14.0-pro/goreleaser-pro_Linux_x86_64.tar.gz -o goreleaser.tar.gz
-          tar -xzf goreleaser.tar.gz
-          chmod +x goreleaser
-          sudo mv goreleaser /usr/local/bin/
+          curl -sL https://github.com/goreleaser/goreleaser-pro/releases/download/v1.14.0-pro/goreleaser-pro_Linux_x86_64.tar.gz -o /tmp/goreleaser.tar.gz
+          cd /tmp && tar -xzf goreleaser.tar.gz && chmod +x goreleaser
+          sudo mv /tmp/goreleaser /usr/local/bin/
       
       - name: Run GoReleaser
         run: make release


### PR DESCRIPTION
## What this PR does / why we need it:

Released failed with:

```
⨯ release failed after 0s                  error=git is in a dirty state
Please check in your pipeline what can be changing the following files:
 M README.md
?? LICENSE.md
?? completions/
?? goreleaser.tar.gz
?? manpages/

````

## Which issue(s) this PR fixes:
none

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
no
```
