### PR TITLE
fix: broken pagination in Github API calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 - Add support for Gitlab `id_token` OIDC.
   - You can connect to Terramate Cloud using [Gitlab id_token](https://docs.gitlab.com/ee/ci/secrets/id_token_authentication.html) exported as a `TM_GITLAB_ID_TOKEN` environment variable.
 
+### Fixed
+
+- Fix issue with handling paginated responses from Github API when retrieving review and GHA action metadata.
+
 ## v0.8.1
 
 ### Fixed

--- a/cmd/terramate/cli/cloud.go
+++ b/cmd/terramate/cli/cloud.go
@@ -664,7 +664,7 @@ func (c *cli) detectCloudMetadata() {
 
 	checks, err := listGithubChecks(githubClient, r.Owner, r.Name, headCommit)
 	if err != nil {
-		logger.Warn().Err(err).Msg("failed to retrieve PR reviews")
+		logger.Warn().Err(err).Msg("failed to retrieve GHA checks")
 	}
 
 	merged := false
@@ -823,11 +823,12 @@ func listGithubPullReviews(ghClient *github.Client, owner, repo string, pullNumb
 	ctx, cancel := context.WithTimeout(context.Background(), defaultGithubTimeout)
 	defer cancel()
 
-	opt := &github.ListOptions{PerPage: 100}
+	opt := &github.ListOptions{}
+	opt.PerPage = 100
 
 	var allReviews []*github.PullRequestReview
 	for {
-		reviews, resp, err := ghClient.PullRequests.ListReviews(ctx, owner, repo, pullNumber, nil)
+		reviews, resp, err := ghClient.PullRequests.ListReviews(ctx, owner, repo, pullNumber, opt)
 		if err != nil {
 			return nil, err
 		}
@@ -845,11 +846,12 @@ func listGithubChecks(ghClient *github.Client, owner, repo string, commit string
 	ctx, cancel := context.WithTimeout(context.Background(), defaultGithubTimeout)
 	defer cancel()
 
-	opt := &github.ListOptions{PerPage: 100}
+	opt := &github.ListCheckRunsOptions{}
+	opt.PerPage = 100
 
 	var allChecks []*github.CheckRun
 	for {
-		checksResponse, resp, err := ghClient.Checks.ListCheckRunsForRef(ctx, owner, repo, commit, nil)
+		checksResponse, resp, err := ghClient.Checks.ListCheckRunsForRef(ctx, owner, repo, commit, opt)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/terramate-io/terramate/blob/main/CONTRIBUTING.md
2. If the PR is unfinished, mark it as draft: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request
3. Please update the PR title using the Conventional Commits convention: https://www.conventionalcommits.org/en/v1.0.0/
    Example: feat: add support for XYZ.
-->

## What this PR does / why we need it:

This PR fixes a bug in handling paginated responses from the Github API that can be triggered while fetching metadata for PR reviews and GHA checks.

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Keep it empty if not applicable.
-->

## Special notes for your reviewer:

We have no automated tests for this, so I only verified doing a manual test.

Setup:
```
$ export GITHUB_EVENT_PATH=${terramate_repo}/cmd/terramate/e2etests/cloud/interop/testdata/event_pull_request.json
$ cd ${terramate_repo}/cmd/terramate/e2etests/cloud/interop/testdata/interop-stacks/basic-drift
$ CI=true GITHUB_ACTIONS=1 terramate run --sync-drift-status --terraform-plan-file="out.tfplan" -- terraform plan --detailed-exitcode -out=out.tfplan
```
Before, error:
```
WRN failed to retrieve PR reviews error="context deadline exceeded" github_repository=terramate-io/terramate head_commit=daaf4f0505b853071a09b9f72daec559919730ed normalized_repository=github.com/terramate-io/terramate
```
After, success:
```
terramate: Entering stack in /cmd/terramate/e2etests/cloud/interop/testdata/interop-stacks/basic-drift
terramate: Executing command "terraform plan --detailed-exitcode -out=out.tfplan"
```

## Does this PR introduce a user-facing change?
<!--
If no, just write "no" in the block below.
If yes, please explain the change and update documentation and the CHANGELOG.md file accordingly.
-->
```
no
```
