### PR TITLE
fix: deployments with empty stack list are no longer sent to cloud

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 - Backward compatibility in versions `0.0.z` is **not guaranteed** when `z` is increased.
 - Backward compatibility in versions `0.y.z` is **not guaranteed** when `y` is increased.
 
+## Unreleased
+
+### Fixed
+
+- Fix deployments with no stacks still creating empty deployments on Terramate Cloud.
+
 ## v0.8.2
 
 ### Added

--- a/cmd/terramate/cli/cloud_sync_deployment.go
+++ b/cmd/terramate/cli/cloud_sync_deployment.go
@@ -23,7 +23,7 @@ func (c *cli) createCloudDeployment(deployRuns []stackCloudRun) {
 	logger := log.With().
 		Logger()
 
-	if !c.cloudEnabled() {
+	if !c.cloudEnabled() || len(deployRuns) == 0 {
 		return
 	}
 

--- a/cmd/terramate/e2etests/cloud/run_cloud_deployment_test.go
+++ b/cmd/terramate/e2etests/cloud/run_cloud_deployment_test.go
@@ -352,6 +352,21 @@ func TestCLIRunWithCloudSyncDeployment(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "no stacks",
+			layout: []string{
+				"f:empty.txt",
+			},
+			runflags: []string{`--eval`},
+			cmd:      []string{HelperPathAsHCL, "echo", "${terramate.stack.path.absolute}"},
+
+			want: want{
+				run: RunExpected{
+					Status: 0,
+				},
+				events: eventsResponse{},
+			},
+		},
 	} {
 		for _, isParallel := range []bool{false, true} {
 			tc := tc


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/terramate-io/terramate/blob/main/CONTRIBUTING.md
2. If the PR is unfinished, mark it as draft: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request
3. Please update the PR title using the Conventional Commits convention: https://www.conventionalcommits.org/en/v1.0.0/
    Example: feat: add support for XYZ.
-->

## What this PR does / why we need it:

This PR fixes empty deployments being created with `terramate run` or `script run` are invoked without any selected stacks.

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Keep it empty if not applicable.
-->

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
<!--
If no, just write "no" in the block below.
If yes, please explain the change and update documentation and the CHANGELOG.md file accordingly.
-->
```
no
```
