### PR TITLE
Backport to v0.6.x: fix: unchecked nil dereference in metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 - Backward compatibility in versions `0.0.z` is **not guaranteed** when `z` is increased.
 - Backward compatibility in versions `0.y.z` is **not guaranteed** when `y` is increased.
 
+## v0.6.7
+
+### Fixed
+
+- Fix potential crash when trying to obtain the pull request metadata associated with a Github repository.
+
 ## v0.6.6
 
 ### Fixed

--- a/cmd/terramate/cli/cloud.go
+++ b/cmd/terramate/cli/cloud.go
@@ -650,7 +650,7 @@ func (c *cli) detectCloudMetadata() {
 	if err != nil {
 		logger.Debug().Err(err).Msg("unable to get pull_request details from GITHUB_EVENT_PATH")
 	} else {
-		logger.Debug().Err(err).Msg("got pull_request details from GITHUB_EVENT_PATH")
+		logger.Debug().Msg("got pull_request details from GITHUB_EVENT_PATH")
 		c.cloud.run.prFromGHAEvent = prFromEvent
 		prNumber = prFromEvent.GetNumber()
 	}
@@ -733,8 +733,8 @@ func getGithubPRByNumberOrCommit(githubClient *github.Client, ghToken, owner, re
 		return nil, err
 	}
 	if !found {
-		logger.Warn().Msg("no pull request associated with HEAD commit")
-		return nil, err
+		logger.Debug().Msg("no pull request associated with HEAD commit")
+		return nil, stdfmt.Errorf("no pull request associated with HEAD commit")
 	}
 
 	return pull, nil
@@ -934,10 +934,12 @@ func setGithubPRMetadata(md *cloud.DeploymentMetadata, pull *github.PullRequest)
 	md.GithubPullRequestHeadAuthorGravatarID = pull.GetHead().GetUser().GetGravatarID()
 	createdAt := pull.GetCreatedAt()
 	updatedAt := pull.GetUpdatedAt()
+	closedAt := pull.GetClosedAt()
+	mergedAt := pull.GetMergedAt()
 	md.GithubPullRequestCreatedAt = createdAt.GetTime()
 	md.GithubPullRequestUpdatedAt = updatedAt.GetTime()
-	md.GithubPullRequestClosedAt = pull.ClosedAt.GetTime()
-	md.GithubPullRequestMergedAt = pull.MergedAt.GetTime()
+	md.GithubPullRequestClosedAt = closedAt.GetTime()
+	md.GithubPullRequestMergedAt = mergedAt.GetTime()
 
 	md.GithubPullRequestBaseLabel = pull.GetBase().GetLabel()
 	md.GithubPullRequestBaseRef = pull.GetBase().GetRef()


### PR DESCRIPTION
## What this PR does / why we need it:

Backport #1702 to `v0.6.x`.

## Which issue(s) this PR fixes:
none

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
yes, fixes a bug
```
