### PR TITLE
fix: allow map type in tm_dynamic.attributes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 
 ### Fixed
 
+- Fix limitation preventing `tm_dynamic.attributes` use with map types.
 - Fix the loading of `terramate.config.run.env` environment variables not considering equal signs in the value.
 
 ## v0.8.3

--- a/generate/genhcl/genhcl.go
+++ b/generate/genhcl/genhcl.go
@@ -494,9 +494,9 @@ func appendDynamicBlock(
 			if val.IsNull() {
 				return errors.E(ErrParsing, objectExpr.Range(), "attributes is null")
 			}
-			if !val.Type().IsObjectType() {
+			if !val.Type().IsObjectType() && !val.Type().IsMapType() {
 				return attrErr(attrs.attributes,
-					"tm_dynamic attributes must be an object, got %s instead", val.Type().FriendlyName())
+					"tm_dynamic attributes must be an object/map, got %s instead", val.Type().FriendlyName())
 			}
 			iter := val.ElementIterator()
 			for iter.Next() {

--- a/generate/genhcl/genhcl_test.go
+++ b/generate/genhcl/genhcl_test.go
@@ -1392,7 +1392,7 @@ func TestGenerateHCL(t *testing.T) {
 			wantErr: errors.E(hcl.ErrTerramateSchema),
 		},
 		{
-			name:  "attributes on generate_hcl block fails",
+			name:  "unrecognized attributes on generate_hcl block fails",
 			stack: "/stacks/stack",
 			configs: []hclconfig{
 				{


### PR DESCRIPTION
## What this PR does / why we need it:

Allow map type in the `tm_dynamic.attributes`.

## Which issue(s) this PR fixes:
none

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
yes, fixes a usage limitation.
```
