### PR TITLE
fix: run.env not including complete env var.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 
 ## Unreleased
 
+### Fixed
+
+- Fix the loading of `terramate.config.run.env` environment variables not considering equal signs in the value.
+
 ## v0.8.3
 
 ### Fixed

--- a/hcl/eval/eval.go
+++ b/hcl/eval/eval.go
@@ -57,8 +57,8 @@ func (c *Context) SetFunction(name string, fn function.Function) {
 func (c *Context) SetEnv(environ []string) {
 	env := map[string]cty.Value{}
 	for _, v := range environ {
-		parsed := strings.Split(v, "=")
-		env[parsed[0]] = cty.StringVal(parsed[1])
+		equalAt := strings.Index(v, "=") // must always find
+		env[v[:equalAt]] = cty.StringVal(v[equalAt+1:])
 	}
 	c.SetNamespace("env", env)
 }

--- a/run/env_test.go
+++ b/run/env_test.go
@@ -85,6 +85,33 @@ func TestLoadRunEnv(t *testing.T) {
 			},
 		},
 		{
+			// GH issue: https://github.com/terramate-io/terramate/issues/1710
+			name: "regression test: incomplete env due to equal sign split",
+			hostenv: map[string]string{
+				"TESTING_RUN_ENV_VAR": "A=B=C",
+			},
+			layout: []string{
+				"s:stacks/stack-1",
+			},
+			configs: []hclconfig{
+				{
+					path: "/",
+					add: runEnvCfg(
+						Expr("testenv", "env.TESTING_RUN_ENV_VAR"),
+						Str("teststr", "plain=with=equal=string"),
+					),
+				},
+			},
+			want: map[string]result{
+				"stacks/stack-1": {
+					env: run.EnvVars{
+						"testenv=A=B=C",
+						`teststr=plain=with=equal=string`,
+					},
+				},
+			},
+		},
+		{
 			name: "stacks with env loaded from globals and metadata",
 			layout: []string{
 				"s:stacks/stack-1",


### PR DESCRIPTION
## What this PR does / why we need it:

Fixes a bug in the processing of Go's environ, which has the form `NAME=VALUE` but the value can also contain equal signs.

## Which issue(s) this PR fixes:
Fixes #1710 

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
yes, fixes a bug.
```
