### PR TITLE
feat: for-expr with variables in generate_hcl.content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,14 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 
 ## Unreleased
 
+### Added
+
+- Add support for `[for ...]` and `{for ...}` expressions containing Terramate variables and functions inside the `generate_hcl.content` block.
+
+### Changed
+
+- (**BREAKING CHANGE**) The format of the generated code may change while being still semantically the same as before. This change is marked as "breaking", because this may trigger change detection on files where the formatting changes.
+
 ## v0.8.4
 
 ### Fixed

--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -2048,7 +2048,7 @@ func (c *cli) partialEval() {
 		if err != nil {
 			fatalWithDetails(err, "unable to parse expression")
 		}
-		newexpr, err := ctx.PartialEval(expr)
+		newexpr, _, err := ctx.PartialEval(expr)
 		if err != nil {
 			fatalWithDetails(err, "partial eval %q", exprStr)
 		}

--- a/cmd/terramate/e2etests/core/exp_eval_test.go
+++ b/cmd/terramate/e2etests/core/exp_eval_test.go
@@ -44,7 +44,7 @@ func TestExpEval(t *testing.T) {
 				Stdout: addnl("false"),
 			},
 			wantPartial: RunExpected{
-				Stdout: addnl("true && false"),
+				Stdout: addnl("false"),
 			},
 		},
 		{
@@ -54,7 +54,7 @@ func TestExpEval(t *testing.T) {
 				Stdout: addnl("[1, 1, 2, 3, 5, 8]"),
 			},
 			wantPartial: RunExpected{
-				Stdout: addnl("[1, 1 + 0, 1 + 1, 1 + 2, 3 + 2, 5 + 3]"),
+				Stdout: addnl("[1, 1, 2, 3, 5, 8]"),
 			},
 		},
 		{
@@ -102,7 +102,7 @@ func TestExpEval(t *testing.T) {
 				Stdout: addnl(`50`),
 			},
 			wantPartial: RunExpected{
-				Stdout: addnl(`49 + 1`),
+				Stdout: addnl(`50`),
 			},
 		},
 		{
@@ -121,7 +121,7 @@ func TestExpEval(t *testing.T) {
 				Stdout: addnl(`20`),
 			},
 			wantPartial: RunExpected{
-				Stdout: addnl(`10 + 10`),
+				Stdout: addnl(`20`),
 			},
 		},
 		{

--- a/generate/genhcl/dynamic_test.go
+++ b/generate/genhcl/dynamic_test.go
@@ -1037,9 +1037,9 @@ func TestGenerateHCLDynamic(t *testing.T) {
 						condition: true,
 						body: Doc(
 							Block("references",
+								Bool("GLOBALKEY", true),
 								Bool("globalkey", true),
 								Bool("stack", true),
-								Bool("GLOBALKEY", true),
 								Bool("test", true),
 							),
 						),

--- a/generate/genhcl/genhcl.go
+++ b/generate/genhcl/genhcl.go
@@ -421,7 +421,7 @@ func copyBody(dest *hclwrite.Body, src *hclsyntax.Body, eval hcl.Evaluator) erro
 			Expression: attr.Expr.(hclsyntax.Expression),
 		}
 
-		newexpr, err := eval.PartialEval(expr)
+		newexpr, _, err := eval.PartialEval(expr)
 		if err != nil {
 			return errors.E(err, attr.Expr.Range())
 		}
@@ -482,7 +482,7 @@ func appendDynamicBlock(
 
 	attributeNames := map[string]struct{}{}
 	if attrs.attributes != nil {
-		attrsExpr, err := evaluator.PartialEval(attrs.attributes.Expr)
+		attrsExpr, _, err := evaluator.PartialEval(attrs.attributes.Expr)
 		if err != nil {
 			return errors.E(ErrDynamicAttrsEval, err, attrs.attributes.Range())
 		}
@@ -526,7 +526,7 @@ func appendDynamicBlock(
 						keyVal.Type().FriendlyName())
 				}
 
-				valExpr, err := evaluator.PartialEval(item.ValueExpr)
+				valExpr, _, err := evaluator.PartialEval(item.ValueExpr)
 				if err != nil {
 					return errors.E(
 						ErrDynamicAttrsEval,

--- a/generate/genhcl/genhcl_test.go
+++ b/generate/genhcl/genhcl_test.go
@@ -416,9 +416,9 @@ func TestGenerateHCL(t *testing.T) {
 							Bool("bool", true),
 							Number("number", 777),
 							EvalExpr(t, "obj", `{
-								string = "string"
-								number = 777
 								bool   = true
+								number = 777
+								string = "string"
 							}`),
 							Str("string", "string"),
 						),
@@ -487,9 +487,9 @@ func TestGenerateHCL(t *testing.T) {
 						condition: true,
 						body: Block("testblock2",
 							EvalExpr(t, "obj", `{
-								string = "string"
-								number = 777
 								bool   = true
+								number = 777
+								string = "string"
 							}`),
 						),
 					},
@@ -557,9 +557,9 @@ func TestGenerateHCL(t *testing.T) {
 						condition: true,
 						body: Block("testblock2",
 							EvalExpr(t, "obj", `{
-								string = "string"
-								number = 777
 								bool   = true
+								number = 777
+								string = "string"
 							}`),
 						),
 					},
@@ -659,9 +659,9 @@ func TestGenerateHCL(t *testing.T) {
 								Number("number", 777),
 								Block("block3",
 									EvalExpr(t, "obj", `{
-										string = "string"
-										number = 777
 										bool   = true
+										number = 777
+										string = "string"
 									}`),
 									Str("string", "string"),
 								),
@@ -781,9 +781,9 @@ func TestGenerateHCL(t *testing.T) {
 						condition: true,
 						body: Block("on_parent_block",
 							EvalExpr(t, "obj", `{
-								string = "string"
-								number = 777
 								bool   = true
+								number = 777
+								string = "string"
 							}`),
 						),
 					},
@@ -1449,9 +1449,9 @@ func TestGenerateHCL(t *testing.T) {
 							Bool("bool", true),
 							Number("number", 777),
 							EvalExpr(t, "obj", `{
-								string = "string"
-								number = 777
 								bool   = true
+								number = 777
+								string = "string"
 							}`),
 							Str("string", "string"),
 						),
@@ -1504,9 +1504,9 @@ func TestGenerateHCL(t *testing.T) {
 							Bool("bool", true),
 							Number("number", 777),
 							EvalExpr(t, "obj", `{
-								string = "string"
-								number = 777
 								bool   = true
+								number = 777
+								string = "string"
 							}`),
 							Str("string", "string"),
 						),
@@ -1555,9 +1555,9 @@ func TestGenerateHCL(t *testing.T) {
 							Bool("bool", true),
 							Number("number", 777),
 							EvalExpr(t, "obj", `{
-								string = "string"
-								number = 777
 								bool   = true
+								number = 777
+								string = "string"
 							}`),
 							Str("string", "string"),
 						),
@@ -1827,9 +1827,9 @@ func TestGenHCLTmGen(t *testing.T) {
 							Bool("bool", true),
 							Number("number", 777),
 							EvalExpr(t, "obj", `{
-								string = "string"
-								number = 777
 								bool   = true
+								number = 777
+								string = "string"
 							}`),
 							Str("stack_name", "stack"),
 							Str("string", "string"),

--- a/hcl/ast/expr.go
+++ b/hcl/ast/expr.go
@@ -5,13 +5,12 @@ package ast
 
 import (
 	"fmt"
+	"math/big"
 
 	"github.com/hashicorp/hcl/v2"
-	"github.com/hashicorp/hcl/v2/ext/customdecode"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/terramate-io/terramate/errors"
-	"github.com/zclconf/go-cty/cty"
 )
 
 // ParseExpression parses the expression str.
@@ -31,20 +30,9 @@ func TokensForExpression(expr hcl.Expression) hclwrite.Tokens {
 	return tokens
 }
 
-// TokensForValue returns the tokens for the provided value.
-func TokensForValue(value cty.Value) hclwrite.Tokens {
-	if value.Type() == customdecode.ExpressionClosureType {
-		closureExpr := value.EncapsulatedValue().(*customdecode.ExpressionClosure)
-		return TokensForExpression(closureExpr.Expression)
-	} else if value.Type() == customdecode.ExpressionType {
-		return TokensForExpression(customdecode.ExpressionFromVal(value))
-	}
-	return hclwrite.TokensForValue(value)
-}
-
 func tokensForExpression(expr hcl.Expression) hclwrite.Tokens {
 	builder := tokenBuilder{}
-	builder.build(expr)
+	builder.fromExpr(expr)
 	return builder.tokens
 }
 
@@ -56,7 +44,7 @@ func (builder *tokenBuilder) add(tokens ...*hclwrite.Token) {
 	builder.tokens = append(builder.tokens, tokens...)
 }
 
-func (builder *tokenBuilder) build(expr hcl.Expression) {
+func (builder *tokenBuilder) fromExpr(expr hcl.Expression) {
 	switch e := expr.(type) {
 	case *hclsyntax.LiteralValueExpr:
 		builder.literalTokens(e)
@@ -197,12 +185,12 @@ func (builder *tokenBuilder) templateTokens(tmpl *hclsyntax.TemplateExpr) {
 
 func (builder *tokenBuilder) templateWrapTokens(tmpl *hclsyntax.TemplateWrapExpr) {
 	builder.add(oquote(), interpBegin())
-	builder.build(tmpl.Wrapped)
+	builder.fromExpr(tmpl.Wrapped)
 	builder.add(interpEnd(), cquote())
 }
 
 func (builder *tokenBuilder) binOpTokens(binop *hclsyntax.BinaryOpExpr) {
-	builder.build(binop.LHS)
+	builder.fromExpr(binop.LHS)
 	var op *hclwrite.Token
 	switch binop.Op {
 	case hclsyntax.OpAdd:
@@ -237,7 +225,7 @@ func (builder *tokenBuilder) binOpTokens(binop *hclsyntax.BinaryOpExpr) {
 	op.SpacesBefore = 1
 	builder.add(op)
 	nexttok := len(builder.tokens)
-	builder.build(binop.RHS)
+	builder.fromExpr(binop.RHS)
 	builder.tokens[nexttok].SpacesBefore = 1
 }
 
@@ -250,19 +238,19 @@ func (builder *tokenBuilder) unaryOpTokens(unary *hclsyntax.UnaryOpExpr) {
 	default:
 		panic(fmt.Sprintf("value %+v is unexpected\n", unary.Op))
 	}
-	builder.build(unary.Val)
+	builder.fromExpr(unary.Val)
 }
 
 func (builder *tokenBuilder) parenExprTokens(parenExpr *hclsyntax.ParenthesesExpr) {
 	builder.add(oparen())
-	builder.build(parenExpr.Expression)
+	builder.fromExpr(parenExpr.Expression)
 	builder.add(cparen())
 }
 
 func (builder *tokenBuilder) tupleTokens(tuple *hclsyntax.TupleConsExpr) {
 	builder.add(obrack())
 	for i, expr := range tuple.Exprs {
-		builder.build(expr)
+		builder.fromExpr(expr)
 		if i+1 != len(tuple.Exprs) {
 			builder.add(comma())
 		}
@@ -276,10 +264,10 @@ func (builder *tokenBuilder) objectTokens(obj *hclsyntax.ObjectConsExpr) {
 		builder.add(nl())
 	}
 	for _, item := range obj.Items {
-		builder.build(item.KeyExpr)
+		builder.fromExpr(item.KeyExpr)
 		builder.add(assign(1))
 		nexttok := len(builder.tokens)
-		builder.build(item.ValueExpr)
+		builder.fromExpr(item.ValueExpr)
 		builder.tokens[nexttok].SpacesBefore = 1
 		builder.add(nl())
 	}
@@ -288,13 +276,13 @@ func (builder *tokenBuilder) objectTokens(obj *hclsyntax.ObjectConsExpr) {
 
 func (builder *tokenBuilder) objectKeyTokens(key *hclsyntax.ObjectConsKeyExpr) {
 	// TODO(i4k): review the case for key.ForceNonLiteral = true|false
-	builder.build(key.Wrapped)
+	builder.fromExpr(key.Wrapped)
 }
 
 func (builder *tokenBuilder) funcallTokens(fn *hclsyntax.FunctionCallExpr) {
 	builder.add(ident(fn.Name, 0), oparen())
 	for i, expr := range fn.Args {
-		builder.build(expr)
+		builder.fromExpr(expr)
 		if i+1 != len(fn.Args) {
 			builder.add(comma())
 		}
@@ -306,11 +294,11 @@ func (builder *tokenBuilder) funcallTokens(fn *hclsyntax.FunctionCallExpr) {
 }
 
 func (builder *tokenBuilder) conditionalTokens(cond *hclsyntax.ConditionalExpr) {
-	builder.build(cond.Condition)
+	builder.fromExpr(cond.Condition)
 	builder.add(question())
-	builder.build(cond.TrueResult)
+	builder.fromExpr(cond.TrueResult)
 	builder.add(colon())
-	builder.build(cond.FalseResult)
+	builder.fromExpr(cond.FalseResult)
 }
 
 func (builder *tokenBuilder) forExprTokens(forExpr *hclsyntax.ForExpr) {
@@ -339,11 +327,11 @@ func (builder *tokenBuilder) forExprTokens(forExpr *hclsyntax.ForExpr) {
 	builder.add(in...)
 	builder.add(colon())
 	if forExpr.KeyExpr != nil {
-		builder.build(forExpr.KeyExpr)
+		builder.fromExpr(forExpr.KeyExpr)
 		builder.add(arrow())
-		builder.build(forExpr.ValExpr)
+		builder.fromExpr(forExpr.ValExpr)
 	} else {
-		builder.build(forExpr.ValExpr)
+		builder.fromExpr(forExpr.ValExpr)
 	}
 	if forExpr.Group {
 		builder.add(ellipsis())
@@ -351,25 +339,25 @@ func (builder *tokenBuilder) forExprTokens(forExpr *hclsyntax.ForExpr) {
 	if forExpr.CondExpr != nil {
 		builder.add(ident("if", 1))
 		nexttok := len(builder.tokens)
-		builder.build(forExpr.CondExpr)
+		builder.fromExpr(forExpr.CondExpr)
 		builder.tokens[nexttok].SpacesBefore = 1
 	}
 	builder.add(end)
 }
 
 func (builder *tokenBuilder) indexTokens(index *hclsyntax.IndexExpr) {
-	builder.build(index.Collection)
+	builder.fromExpr(index.Collection)
 	builder.add(obrack())
-	builder.build(index.Key)
+	builder.fromExpr(index.Key)
 	builder.add(cbrack())
 }
 
 func (builder *tokenBuilder) splatTokens(splat *hclsyntax.SplatExpr) {
-	builder.build(splat.Source)
+	builder.fromExpr(splat.Source)
 	builder.add(obrack())
 	builder.add(star())
 	builder.add(cbrack())
-	builder.build(splat.Each)
+	builder.fromExpr(splat.Each)
 }
 
 func (builder *tokenBuilder) scopeTraversalTokens(scope *hclsyntax.ScopeTraversalExpr) {
@@ -397,7 +385,7 @@ func (builder *tokenBuilder) traversalTokens(traversals hcl.Traversal) {
 }
 
 func (builder *tokenBuilder) relTraversalTokens(traversal *hclsyntax.RelativeTraversalExpr) {
-	builder.build(traversal.Source)
+	builder.fromExpr(traversal.Source)
 	builder.traversalTokens(traversal.Traversal)
 }
 
@@ -484,6 +472,14 @@ func renderString(bytes []byte) []byte {
 		}
 	}
 	return out
+}
+
+func num(n *big.Float) *hclwrite.Token {
+	srcStr := n.Text('f', -1)
+	return &hclwrite.Token{
+		Type:  hclsyntax.TokenNumberLit,
+		Bytes: []byte(srcStr),
+	}
 }
 
 func obrace() *hclwrite.Token {

--- a/hcl/ast/value.go
+++ b/hcl/ast/value.go
@@ -1,0 +1,134 @@
+// Copyright 2024 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+package ast
+
+import (
+	"fmt"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/hashicorp/hcl/v2/ext/customdecode"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/terramate-io/terramate/errors"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// TokensForValue returns the tokens for the provided value.
+func TokensForValue(value cty.Value) hclwrite.Tokens {
+	builder := tokenBuilder{}
+	builder.fromValue(value)
+	return builder.tokens
+}
+
+func (builder *tokenBuilder) fromValue(val cty.Value) {
+	switch typ := val.Type(); {
+	case typ == customdecode.ExpressionClosureType:
+		closureExpr := val.EncapsulatedValue().(*customdecode.ExpressionClosure)
+		builder.fromExpr(closureExpr.Expression)
+	case typ == customdecode.ExpressionType:
+		builder.fromExpr(customdecode.ExpressionFromVal(val))
+	case val.IsNull():
+		builder.add(ident("null", 0))
+	case typ == cty.Bool:
+		if val.True() {
+			builder.add(ident("true", 0))
+		} else {
+			builder.add(ident("false", 0))
+		}
+	case typ == cty.Number:
+		builder.add(num(val.AsBigFloat()))
+	case typ == cty.String:
+		src := renderQuotedString(val.AsString())
+		builder.add(oquote())
+		if len(src) > 0 {
+			builder.add(&hclwrite.Token{
+				Type:  hclsyntax.TokenQuotedLit,
+				Bytes: src,
+			})
+		}
+		builder.add(cquote())
+	case typ.IsMapType() || typ.IsObjectType():
+		builder.add(obrace())
+		if val.LengthInt() > 0 {
+			builder.add(nl())
+		}
+		i := 0
+		for it := val.ElementIterator(); it.Next(); {
+			eKey, eVal := it.Element()
+			if hclsyntax.ValidIdentifier(eKey.AsString()) {
+				builder.add(ident(eKey.AsString(), 0))
+			} else {
+				builder.fromValue(eKey)
+			}
+			builder.add(assign(0))
+			builder.fromValue(eVal)
+			builder.add(nl())
+			i++
+		}
+		builder.add(cbrace())
+	case typ.IsListType() || typ.IsSetType() || typ.IsTupleType():
+		builder.add(obrack())
+		i := 0
+		for it := val.ElementIterator(); it.Next(); {
+			if i > 0 {
+				builder.add(comma())
+			}
+			_, eVal := it.Element()
+			builder.fromValue(eVal)
+			i++
+		}
+		builder.add(cbrack())
+
+	default:
+		panic(errors.E(errors.ErrInternal, "formatting for value type %s is not supported", val.Type().FriendlyName()))
+	}
+}
+
+func renderQuotedString(s string) []byte {
+	buf := make([]byte, 0, len(s))
+	for i, r := range s {
+		switch r {
+		case '\n':
+			buf = append(buf, '\\', 'n')
+		case '\r':
+			buf = append(buf, '\\', 'r')
+		case '\t':
+			buf = append(buf, '\\', 't')
+		case '"':
+			buf = append(buf, '\\', '"')
+		case '\\':
+			buf = append(buf, '\\', '\\')
+		case '$', '%':
+			buf = appendRune(buf, r)
+			remain := s[i+1:]
+			if len(remain) > 0 && remain[0] == '{' {
+				buf = appendRune(buf, r)
+			}
+		default:
+			if !unicode.IsPrint(r) {
+				var fmted string
+				if r < 65536 {
+					fmted = fmt.Sprintf("\\u%04x", r)
+				} else {
+					fmted = fmt.Sprintf("\\U%08x", r)
+				}
+				buf = append(buf, fmted...)
+			} else {
+				buf = appendRune(buf, r)
+			}
+		}
+	}
+	return buf
+}
+
+func appendRune(b []byte, r rune) []byte {
+	l := utf8.RuneLen(r)
+	for i := 0; i < l; i++ {
+		b = append(b, 0)
+	}
+	ch := b[len(b)-l:]
+	utf8.EncodeRune(ch, r)
+	return b
+}

--- a/hcl/eval/partial_eval.go
+++ b/hcl/eval/partial_eval.go
@@ -16,18 +16,17 @@ import (
 
 // Errors returned when doing partial evaluation.
 const (
-	ErrPartial             errors.Kind = "partial evaluation failed"
-	ErrInterpolation       errors.Kind = "interpolation failed"
-	ErrForExprDisallowEval errors.Kind = "`for` expression disallow globals/terramate variables"
+	ErrPartial       errors.Kind = "partial evaluation failed"
+	ErrInterpolation errors.Kind = "interpolation failed"
 )
 
-func (c *Context) partialEval(expr hhcl.Expression) (newexpr hhcl.Expression, err error) {
+func (c *Context) partialEval(expr hhcl.Expression) (newexpr hhcl.Expression, hasUnknowns bool, err error) {
 	switch e := expr.(type) {
 	case *ast.CloneExpression:
 		cloned := ast.CloneExpr(e.Expression)
 		return c.partialEval(cloned)
 	case *hclsyntax.LiteralValueExpr:
-		return expr, nil
+		return expr, false, nil
 	case *hclsyntax.UnaryOpExpr:
 		return c.partialEvalUnaryOp(e)
 	case *hclsyntax.BinaryOpExpr:
@@ -58,241 +57,411 @@ func (c *Context) partialEval(expr hhcl.Expression) (newexpr hhcl.Expression, er
 		return c.partialEvalRelTrav(e)
 	case *hclsyntax.ParenthesesExpr:
 		return c.partialEvalParenExpr(e)
+	case *hclsyntax.AnonSymbolExpr:
+		return expr, false, nil
 	default:
 		panic(fmt.Sprintf("not implemented %T", expr))
 	}
 }
 
-func (c *Context) partialEvalTemplate(tmpl *hclsyntax.TemplateExpr) (*hclsyntax.TemplateExpr, error) {
+func (c *Context) partialEvalTemplate(tmpl *hclsyntax.TemplateExpr) (*hclsyntax.TemplateExpr, bool, error) {
+	hasUnknowns := false
 	for i, part := range tmpl.Parts {
-		newexpr, err := c.partialEval(part)
+		newexpr, partHasUnknowns, err := c.partialEval(part)
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
+		hasUnknowns = hasUnknowns || partHasUnknowns
 		tmpl.Parts[i] = asSyntax(newexpr)
 	}
-	return tmpl, nil
+	return tmpl, hasUnknowns, nil
 }
 
-func (c *Context) partialEvalTmplWrap(wrap *hclsyntax.TemplateWrapExpr) (hhcl.Expression, error) {
-	newwrap, err := c.partialEval(wrap.Wrapped)
+func (c *Context) partialEvalTmplWrap(wrap *hclsyntax.TemplateWrapExpr) (hhcl.Expression, bool, error) {
+	newwrap, hasUnknowns, err := c.partialEval(wrap.Wrapped)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	if v, ok := newwrap.(*hclsyntax.LiteralValueExpr); ok {
-		// TODO(fix)
+		// TODO(i4k): check this case.
 		if v.Val.Type() == cty.String && strings.Contains(v.Val.AsString(), "${") {
-			panic(v.Val.AsString())
+			panic(errors.E(errors.ErrInternal, "unexpected case: %s", v.Val.AsString()))
 		}
-		return v, nil
+		return v, hasUnknowns, nil
 	}
 
 	wrap.Wrapped = asSyntax(newwrap)
-	return wrap, nil
+	return wrap, hasUnknowns, nil
 }
 
-func (c *Context) partialEvalTuple(tuple *hclsyntax.TupleConsExpr) (hclsyntax.Expression, error) {
+func (c *Context) partialEvalTuple(tuple *hclsyntax.TupleConsExpr) (hclsyntax.Expression, bool, error) {
+	hasUnknowns := false
 	for i, v := range tuple.Exprs {
-		newexpr, err := c.partialEval(v)
+		newexpr, itHasUnknowns, err := c.partialEval(v)
+		hasUnknowns = hasUnknowns || itHasUnknowns
 		if err != nil {
-			return nil, err
+			return nil, hasUnknowns, err
 		}
 		tuple.Exprs[i] = asSyntax(newexpr)
 	}
-	return tuple, nil
+	return tuple, hasUnknowns, nil
 }
 
-func (c *Context) partialEvalObject(obj *hclsyntax.ObjectConsExpr) (hclsyntax.Expression, error) {
+func (c *Context) partialEvalObject(obj *hclsyntax.ObjectConsExpr) (hclsyntax.Expression, bool, error) {
+	hasUnknowns := false
 	for i, elem := range obj.Items {
-		newkey, err := c.partialEval(elem.KeyExpr)
+		newkey, h1, err := c.partialEval(elem.KeyExpr)
+		hasUnknowns = hasUnknowns || h1
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
-		newval, err := c.partialEval(elem.ValueExpr)
+		newval, h2, err := c.partialEval(elem.ValueExpr)
+		hasUnknowns = hasUnknowns || h2
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 		elem.KeyExpr = asSyntax(newkey)
 		elem.ValueExpr = asSyntax(newval)
 		obj.Items[i] = elem
 	}
-	return obj, nil
+	return obj, hasUnknowns, nil
 }
 
-func (c *Context) partialEvalFunc(funcall *hclsyntax.FunctionCallExpr) (hhcl.Expression, error) {
+func (c *Context) partialEvalFunc(funcall *hclsyntax.FunctionCallExpr) (hhcl.Expression, bool, error) {
 	if strings.HasPrefix(funcall.Name, "tm_") {
 		val, err := c.Eval(funcall)
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 		return &hclsyntax.LiteralValueExpr{
 			Val:      val,
 			SrcRange: funcall.Range(),
-		}, nil
+		}, false, nil
 	}
+
+	// hasUnknowns is true because the function is not tm_ prefixed
+
 	for i, arg := range funcall.Args {
-		newexpr, err := c.partialEval(arg)
+		newexpr, _, err := c.partialEval(arg)
 		if err != nil {
-			return nil, err
+			return nil, true, err
 		}
 		funcall.Args[i] = asSyntax(newexpr)
 	}
-	return funcall, nil
+	return funcall, true, nil
 }
 
-func (c *Context) partialEvalIndex(index *hclsyntax.IndexExpr) (hhcl.Expression, error) {
-	newcol, err := c.partialEval(index.Collection)
+func (c *Context) partialEvalIndex(index *hclsyntax.IndexExpr) (hhcl.Expression, bool, error) {
+	hasUnknowns := false
+	newcol, h1, err := c.partialEval(index.Collection)
 	if err != nil {
-		return nil, err
-	}
-	newkey, err := c.partialEval(index.Key)
-	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	index.Collection = asSyntax(newcol)
-	index.Key = asSyntax(newkey)
-
-	if c.hasUnknownVars(index) {
-		return index, nil
+	hasUnknowns = h1
+	newkey, h2, err := c.partialEval(index.Key)
+	hasUnknowns = hasUnknowns || h2
+	if err != nil {
+		return nil, false, err
 	}
-
+	index.Key = asSyntax(newkey)
+	if hasUnknowns {
+		return index, hasUnknowns, nil
+	}
 	val, err := c.Eval(index)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	return &hclsyntax.LiteralValueExpr{
 		Val:      val,
 		SrcRange: index.SrcRange,
-	}, nil
+	}, false, nil
 }
 
-func (c *Context) partialEvalSplat(expr *hclsyntax.SplatExpr) (hhcl.Expression, error) {
-	newsrc, err := c.partialEval(expr.Source)
+func (c *Context) partialEvalSplat(expr *hclsyntax.SplatExpr) (hhcl.Expression, bool, error) {
+	newsrc, hasUnknowns, err := c.partialEval(expr.Source)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	expr.Source = asSyntax(newsrc)
-	if c.hasUnknownVars(expr.Source) {
-		return expr, nil
+	if hasUnknowns {
+		return expr, hasUnknowns, nil
 	}
-	if c.hasUnknownVars(expr.Each) {
-		return expr, nil
+	newEach, hasUnknowns, err := c.partialEval(expr.Each)
+	if err != nil {
+		return nil, false, err
+	}
+	expr.Each = asSyntax(newEach)
+	if hasUnknowns {
+		return expr, hasUnknowns, nil
 	}
 	val, err := c.Eval(expr)
 	if err != nil {
-		// this can happen in the case of using funcalls not prefixed with tm_
-		return expr, nil
+		return expr, false, err
 	}
 	return &hclsyntax.LiteralValueExpr{
 		Val:      val,
 		SrcRange: expr.Range(),
-	}, nil
+	}, false, nil
 }
 
-func (c *Context) hasUnknownVars(expr hclsyntax.Expression) bool {
-	for _, namespace := range expr.Variables() {
-		if !c.HasNamespace(namespace.RootName()) {
-			return true
-		}
-	}
-	return false
-}
-
-func (c *Context) hasTerramateVars(expr hclsyntax.Expression) bool {
-	for _, namespace := range expr.Variables() {
-		if c.HasNamespace(namespace.RootName()) {
-			return true
-		}
-	}
-	return false
-}
-
-func (c *Context) partialEvalObjectKey(key *hclsyntax.ObjectConsKeyExpr) (hhcl.Expression, error) {
+func (c *Context) partialEvalObjectKey(key *hclsyntax.ObjectConsKeyExpr) (hhcl.Expression, bool, error) {
 	var (
-		wrapped hhcl.Expression
-		err     error
+		err         error
+		wrapped     hhcl.Expression
+		hasUnknowns bool
 	)
 
 	switch vexpr := key.Wrapped.(type) {
 	case *hclsyntax.ScopeTraversalExpr:
-		wrapped, err = c.partialEvalScopeTrav(vexpr, partialEvalOption{
+		wrapped, hasUnknowns, err = c.partialEvalScopeTrav(vexpr, partialEvalOption{
 			// back-compatibility with old partial evaluator.
 			// global = 1
 			forbidRootEval: true,
 		})
 	case *hclsyntax.ParenthesesExpr:
-		wrapped, err = c.partialEvalParenExpr(vexpr, partialEvalOption{
+		wrapped, hasUnknowns, err = c.partialEvalParenExpr(vexpr, partialEvalOption{
 			// back-compatibility with old partial evaluator.
 			// (global) = 1
-			forbidRootEval: true,
+			forbidRootEval: false,
 		})
 	default:
-		wrapped, err = c.partialEval(key.Wrapped)
+		wrapped, hasUnknowns, err = c.partialEval(key.Wrapped)
 	}
 
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	key.Wrapped = asSyntax(wrapped)
-	return key, nil
+	return key, hasUnknowns, nil
 }
 
-func (c *Context) partialEvalForExpr(forExpr *hclsyntax.ForExpr) (hhcl.Expression, error) {
-	for _, expr := range []hclsyntax.Expression{
-		forExpr.KeyExpr,
-		forExpr.ValExpr,
-		forExpr.CollExpr,
-		forExpr.CondExpr,
-	} {
-		if expr != nil && c.hasTerramateVars(forExpr.CollExpr) {
-			return nil, errors.E(ErrForExprDisallowEval, "evaluating expression: %s", ast.TokensForExpression(forExpr.CollExpr).Bytes())
+func (c *Context) partialEvalForExpr(forExpr *hclsyntax.ForExpr) (hhcl.Expression, bool, error) {
+	resExpr, hasUnknowns, err := c.partialEval(forExpr.CollExpr)
+	if err != nil {
+		return nil, false, err
+	}
+	forExpr.CollExpr = asSyntax(resExpr)
+	if !hasUnknowns {
+		resExpr, hasUnknowns, err = c.evalForLoop(forExpr)
+		if err != nil {
+			return nil, false, err
+		}
+		if !hasUnknowns {
+			return resExpr, false, nil
 		}
 	}
 
-	return forExpr, nil
+	if forExpr.KeyExpr != nil {
+		resExpr, _, err = c.partialEval(forExpr.KeyExpr)
+		if err != nil {
+			return nil, false, err
+		}
+		forExpr.KeyExpr = asSyntax(resExpr)
+	}
+
+	if forExpr.ValExpr != nil {
+		resExpr, _, err := c.partialEval(forExpr.ValExpr)
+		if err != nil {
+			return nil, false, err
+		}
+		forExpr.ValExpr = asSyntax(resExpr)
+	}
+
+	if forExpr.CondExpr != nil {
+		resExpr, _, err := c.partialEval(forExpr.CondExpr)
+		if err != nil {
+			return nil, false, err
+		}
+		forExpr.CondExpr = asSyntax(resExpr)
+	}
+
+	return forExpr, true, nil
 }
 
-func (c *Context) partialEvalBinOp(binop *hclsyntax.BinaryOpExpr) (hhcl.Expression, error) {
-	lhs, err := c.partialEval(binop.LHS)
-	if err != nil {
-		return nil, err
+func (c *Context) evalForLoop(forExpr *hclsyntax.ForExpr) (hhcl.Expression, bool, error) {
+	if forExpr.KeyExpr != nil {
+		return c.evalForObjectLoop(forExpr)
 	}
-	rhs, err := c.partialEval(binop.RHS)
+	return c.evalForListLoop(forExpr)
+}
+
+func (c *Context) evalForObjectLoop(forExpr *hclsyntax.ForExpr) (hhcl.Expression, bool, error) {
+	res := make(map[string]cty.Value)
+	coll, err := c.Eval(forExpr.CollExpr)
 	if err != nil {
-		return nil, err
+		return nil, false, err
+	}
+	if !coll.CanIterateElements() {
+		return nil, false, errors.E("for-expr with non-iterable collection", forExpr.CollExpr.Range())
+	}
+	iterator := coll.ElementIterator()
+	for iterator.Next() {
+		k, v := iterator.Element()
+		childCtx := c.newChildContext()
+		childCtx.hclctx.Variables[forExpr.KeyVar] = k
+		childCtx.hclctx.Variables[forExpr.ValVar] = v
+
+		if forExpr.CondExpr != nil {
+			condExpr, hasUnknowns, err := childCtx.partialEval(&ast.CloneExpression{
+				Expression: forExpr.CondExpr,
+			})
+			if err != nil {
+				return nil, false, err
+			}
+			if hasUnknowns {
+				return forExpr, hasUnknowns, nil
+			}
+			condVal, err := childCtx.Eval(condExpr)
+			if err != nil {
+				return nil, false, err
+			}
+			if condVal.Type() != cty.Bool {
+				return nil, false, errors.E("condition is not a boolean but %s", condVal.Type().FriendlyName())
+			}
+			if condVal.False() {
+				continue
+			}
+		}
+		resKeyExpr, hasUnknowns, err := childCtx.partialEval(&ast.CloneExpression{
+			Expression: forExpr.KeyExpr,
+		})
+		if err != nil {
+			return nil, false, err
+		}
+
+		if hasUnknowns {
+			return forExpr, hasUnknowns, nil
+		}
+
+		resKeyVal, err := childCtx.Eval(resKeyExpr)
+		if err != nil {
+			return nil, false, err
+		}
+		if resKeyVal.Type() != cty.String {
+			return nil, false, errors.E("object key must be a string", forExpr.KeyExpr.Range())
+		}
+		resValExpr, hasUnknowns, err := childCtx.partialEval(&ast.CloneExpression{
+			Expression: forExpr.ValExpr,
+		})
+		if err != nil {
+			return nil, false, err
+		}
+		if hasUnknowns {
+			return forExpr, hasUnknowns, nil
+		}
+		resVal, err := childCtx.Eval(resValExpr)
+		if err != nil {
+			return nil, false, err
+		}
+		res[resKeyVal.AsString()] = resVal
+	}
+	return &hclsyntax.LiteralValueExpr{
+		Val:      cty.ObjectVal(res),
+		SrcRange: forExpr.SrcRange,
+	}, false, nil
+}
+
+func (c *Context) evalForListLoop(forExpr *hclsyntax.ForExpr) (hhcl.Expression, bool, error) {
+	var res []cty.Value
+	coll, err := c.Eval(forExpr.CollExpr)
+	if err != nil {
+		return nil, false, err
+	}
+	if !coll.CanIterateElements() {
+		return nil, false, errors.E("for-expr with non-iterable collection", forExpr.CollExpr.Range())
+	}
+	iterator := coll.ElementIterator()
+	for iterator.Next() {
+		k, v := iterator.Element()
+		childCtx := c.newChildContext()
+		childCtx.hclctx.Variables[forExpr.KeyVar] = k
+		childCtx.hclctx.Variables[forExpr.ValVar] = v
+
+		if forExpr.CondExpr != nil {
+			condExpr, hasUnknowns, err := childCtx.partialEval(&ast.CloneExpression{
+				Expression: forExpr.CondExpr,
+			})
+			if err != nil {
+				return nil, false, err
+			}
+			if hasUnknowns {
+				return forExpr, hasUnknowns, nil
+			}
+			condVal, err := childCtx.Eval(condExpr)
+			if err != nil {
+				return nil, false, err
+			}
+			if condVal.Type() != cty.Bool {
+				return nil, false, errors.E("condition is not a boolean but %s", condVal.Type().FriendlyName())
+			}
+			if condVal.False() {
+				continue
+			}
+		}
+
+		resValExpr, hasUnknowns, err := childCtx.partialEval(&ast.CloneExpression{
+			Expression: forExpr.ValExpr,
+		})
+		if err != nil {
+			return nil, false, err
+		}
+		if hasUnknowns {
+			return forExpr, hasUnknowns, nil
+		}
+		resVal, err := childCtx.Eval(resValExpr)
+		if err != nil {
+			return nil, false, err
+		}
+		res = append(res, resVal)
+	}
+	return &hclsyntax.LiteralValueExpr{
+		Val:      cty.TupleVal(res),
+		SrcRange: forExpr.SrcRange,
+	}, false, nil
+}
+
+func (c *Context) partialEvalBinOp(binop *hclsyntax.BinaryOpExpr) (hhcl.Expression, bool, error) {
+	lhs, h1, err := c.partialEval(binop.LHS)
+	if err != nil {
+		return nil, false, err
+	}
+	rhs, h2, err := c.partialEval(binop.RHS)
+	if err != nil {
+		return nil, false, err
 	}
 	binop.LHS = asSyntax(lhs)
 	binop.RHS = asSyntax(rhs)
-	return binop, nil
+	return binop, h1 || h2, nil
 }
 
-func (c *Context) partialEvalUnaryOp(unary *hclsyntax.UnaryOpExpr) (hhcl.Expression, error) {
-	val, err := c.partialEval(unary.Val)
+func (c *Context) partialEvalUnaryOp(unary *hclsyntax.UnaryOpExpr) (hhcl.Expression, bool, error) {
+	val, hasUnknowns, err := c.partialEval(unary.Val)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	unary.Val = asSyntax(val)
-	return unary, nil
+	return unary, hasUnknowns, nil
 }
 
-func (c *Context) partialEvalCondExpr(cond *hclsyntax.ConditionalExpr) (hhcl.Expression, error) {
-	newcond, err := c.partialEval(cond.Condition)
+func (c *Context) partialEvalCondExpr(cond *hclsyntax.ConditionalExpr) (hhcl.Expression, bool, error) {
+	newcond, h1, err := c.partialEval(cond.Condition)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
-	newtrue, err := c.partialEval(cond.TrueResult)
+	newtrue, h2, err := c.partialEval(cond.TrueResult)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
-	newfalse, err := c.partialEval(cond.FalseResult)
+	newfalse, h3, err := c.partialEval(cond.FalseResult)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	cond.Condition = asSyntax(newcond)
 	cond.TrueResult = asSyntax(newtrue)
 	cond.FalseResult = asSyntax(newfalse)
-	return cond, nil
+	return cond, h1 || h2 || h3, nil
 }
 
 type partialEvalOption struct {
@@ -300,35 +469,33 @@ type partialEvalOption struct {
 	forbidRootEval bool
 }
 
-func (c *Context) partialEvalScopeTrav(scope *hclsyntax.ScopeTraversalExpr, opts ...partialEvalOption) (hclsyntax.Expression, error) {
+func (c *Context) partialEvalScopeTrav(scope *hclsyntax.ScopeTraversalExpr, opts ...partialEvalOption) (hclsyntax.Expression, bool, error) {
 	assertPartialExprOpt(opts)
 	ns, ok := scope.Traversal[0].(hhcl.TraverseRoot)
 	if !ok {
-		return scope, nil
-	}
-	if !c.HasNamespace(ns.Name) {
-		return scope, nil
+		return scope, false, nil
 	}
 	forbidRootEval := false
 	if len(opts) == 1 {
 		forbidRootEval = opts[0].forbidRootEval
 	}
 	if len(scope.Traversal) == 1 && forbidRootEval {
-		return scope, nil
+		return scope, false, nil
 	}
-
+	if !c.HasNamespace(ns.Name) {
+		return scope, true, nil
+	}
 	val, err := c.Eval(scope)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
-
 	return &hclsyntax.LiteralValueExpr{
 		Val:      val,
 		SrcRange: scope.SrcRange,
-	}, nil
+	}, false, nil
 }
 
-func (c *Context) partialEvalParenExpr(paren *hclsyntax.ParenthesesExpr, opts ...partialEvalOption) (hhcl.Expression, error) {
+func (c *Context) partialEvalParenExpr(paren *hclsyntax.ParenthesesExpr, opts ...partialEvalOption) (hhcl.Expression, bool, error) {
 	assertPartialExprOpt(opts)
 	forbidRootEval := false
 	if len(opts) == 1 {
@@ -336,42 +503,43 @@ func (c *Context) partialEvalParenExpr(paren *hclsyntax.ParenthesesExpr, opts ..
 	}
 
 	var (
-		newexpr hhcl.Expression
-		err     error
+		hasUnknowns bool
+		newexpr     hhcl.Expression
+		err         error
 	)
 
 	if scope, ok := paren.Expression.(*hclsyntax.ScopeTraversalExpr); ok && forbidRootEval {
-		newexpr, err = c.partialEvalScopeTrav(scope, opts...)
+		newexpr, hasUnknowns, err = c.partialEvalScopeTrav(scope, opts...)
 	} else {
-		newexpr, err = c.partialEval(paren.Expression)
+		newexpr, hasUnknowns, err = c.partialEval(paren.Expression)
 	}
 
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	paren.Expression = asSyntax(newexpr)
-	return paren, nil
+	return paren, hasUnknowns, nil
 }
 
-func (c *Context) partialEvalRelTrav(rel *hclsyntax.RelativeTraversalExpr) (hhcl.Expression, error) {
-	newsrc, err := c.partialEval(rel.Source)
+func (c *Context) partialEvalRelTrav(rel *hclsyntax.RelativeTraversalExpr) (hhcl.Expression, bool, error) {
+	newsrc, hasUnknowns, err := c.partialEval(rel.Source)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	rel.Source = asSyntax(newsrc)
-	if c.hasUnknownVars(rel) {
-		return rel, nil
+	if hasUnknowns {
+		return rel, hasUnknowns, nil
 	}
 
 	val, err := c.Eval(rel)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	return &hclsyntax.LiteralValueExpr{
 		Val:      val,
 		SrcRange: rel.SrcRange,
-	}, nil
+	}, false, nil
 }
 
 func asSyntax(expr hhcl.Expression) hclsyntax.Expression {

--- a/hcl/eval/partial_eval_bench_test.go
+++ b/hcl/eval/partial_eval_bench_test.go
@@ -99,7 +99,7 @@ func BenchmarkPartialEvalComplex(b *testing.B) {
 		if diags.HasErrors() {
 			b.Fatalf(diags.Error())
 		}
-		_, err := ctx.PartialEval(expr)
+		_, _, err := ctx.PartialEval(expr)
 		if err != nil {
 			b.Fatal(err.Error())
 		}
@@ -118,7 +118,7 @@ func BenchmarkPartialEvalSmallString(b *testing.B) {
 		if diags.HasErrors() {
 			b.Fatalf(diags.Error())
 		}
-		_, err := ctx.PartialEval(expr)
+		_, _, err := ctx.PartialEval(expr)
 		if err != nil {
 			b.Fatal(err.Error())
 		}
@@ -137,7 +137,7 @@ func BenchmarkPartialEvalHugeString(b *testing.B) {
 		if diags.HasErrors() {
 			b.Fatalf(diags.Error())
 		}
-		_, err := ctx.PartialEval(expr)
+		_, _, err := ctx.PartialEval(expr)
 		if err != nil {
 			b.Fatal(err.Error())
 		}
@@ -156,7 +156,7 @@ func BenchmarkPartialEvalHugeInterpolatedString(b *testing.B) {
 		if diags.HasErrors() {
 			b.Fatalf(diags.Error())
 		}
-		_, err := ctx.PartialEval(expr)
+		_, _, err := ctx.PartialEval(expr)
 		if err != nil {
 			b.Fatal(err.Error())
 		}
@@ -180,7 +180,7 @@ func BenchmarkPartialEvalObject(b *testing.B) {
 		if diags.HasErrors() {
 			b.Fatalf(diags.Error())
 		}
-		_, err := ctx.PartialEval(expr)
+		_, _, err := ctx.PartialEval(expr)
 		if err != nil {
 			b.Fatal(err.Error())
 		}

--- a/hcl/eval/partial_fuzz_test.go
+++ b/hcl/eval/partial_fuzz_test.go
@@ -95,7 +95,7 @@ EOT`,
 		ctx.SetNamespace("global", globals)
 		ctx.SetNamespace("terramate", terramate)
 
-		gotExpr, err := ctx.PartialEval(parsedExpr)
+		gotExpr, _, err := ctx.PartialEval(parsedExpr)
 		if err != nil {
 			return
 		}

--- a/hcl/hcl.go
+++ b/hcl/hcl.go
@@ -322,7 +322,8 @@ type Evaluator interface {
 	// tokens that form the result of the partial evaluation. Any unknown
 	// namespace access are ignored and left as is, while known namespaces
 	// are substituted by its value.
-	PartialEval(hcl.Expression) (hcl.Expression, error)
+	// If any unknowns are found, the method returns hasUnknowns as true.
+	PartialEval(hcl.Expression) (expr hcl.Expression, hasUnknowns bool, err error)
 
 	// SetNamespace adds a new namespace, replacing any with the same name.
 	SetNamespace(name string, values map[string]cty.Value)

--- a/stdlib/ternary.go
+++ b/stdlib/ternary.go
@@ -51,13 +51,14 @@ func evalTernaryBranch(arg cty.Value) (cty.Value, error) {
 	closure := customdecode.ExpressionClosureFromVal(arg)
 
 	ctx := eval.NewContextFrom(closure.EvalContext)
-	newexpr, err := ctx.PartialEval(&ast.CloneExpression{
+	newexpr, _, err := ctx.PartialEval(&ast.CloneExpression{
 		Expression: closure.Expression.(hclsyntax.Expression),
 	})
 	if err != nil {
 		return cty.NilVal, errors.E(err, "evaluating tm_ternary branch")
 	}
 
+	// TODO(i4k): use our own hasUnknowns here.
 	if dependsOnUnknowns(newexpr, closure.EvalContext) {
 		return customdecode.ExpressionVal(newexpr), nil
 	}


### PR DESCRIPTION
## What this PR does / why we need it:

This change makes it possible to use Terramate variables in `[for k, v in collection : ... if cond]` and `{for k, v in collection : ... if cond}` when `collection` and `cond` *does not* depend on unknowns. In other words, the cases below are now possible:

```
globals {
  numbers = [1, 2, 3]
  strings = ["terramate", "is", "fun"]
  partials_config = {
    aws = "aws.vpc.id", 
    azre = "azure.thing"
  }
}

generate_hcl "example.tf" {
  content {
    square_numbers = [for n in global.numbers : n*n]
    upper_strings  = [for s in global.strings : tm_upper(s)]
    config = {for k, v in global.partials_config : k => tm_hcl_expression(v)}
  }
}
```

which generates the file `example.tf` below:
```
cat example.tf
// TERRAMATE: GENERATED AUTOMATICALLY DO NOT EDIT

config = {
  aws  = aws.vpc.id
  azre = azure.thing
}
square_numbers = [
  1,
  4,
  9,
]
upper_strings = [
  "TERRAMATE",
  "IS",
  "FUN",
]
```

## Which issue(s) this PR fixes:
Fixes #1419 
Fixes #1689 
Fixes #1676 

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
yes, introduces a feature.
```
