### PR TITLE
chore: improve warn messages in case GITHUB_TOKEN is not exported.

### DIFF
--- a/cmd/terramate/cli/run.go
+++ b/cmd/terramate/cli/run.go
@@ -579,10 +579,10 @@ func (c *cli) createCloudPreview(runs []stackCloudRun) map[string]string {
 	}
 
 	pullRequest := c.cloud.run.prFromGHAEvent
-	if pullRequest == nil || pullRequest.GetUpdatedAt().IsZero() {
+	if pullRequest == nil || pullRequest.GetUpdatedAt().IsZero() || c.cloud.run.reviewRequest == nil {
 		printer.Stderr.WarnWithDetails(
 			"unable to create preview: missing pull request information",
-			errors.E("--sync-preview can only be used in a GitHub Action workflow triggered by a pull request event"),
+			errors.E("--sync-preview can only be used when GITHUB_TOKEN is exported and Terramate runs in a GitHub Action workflow triggered by a pull request event"),
 		)
 		c.disableCloudFeatures(cloudError())
 		return map[string]string{}

--- a/cmd/terramate/e2etests/cloud/run_cloud_sync_preview_test.go
+++ b/cmd/terramate/e2etests/cloud/run_cloud_sync_preview_test.go
@@ -234,6 +234,7 @@ func TestCLIRunWithCloudSyncPreview(t *testing.T) {
 			env = append(env, "TMC_API_URL=http://"+addr)
 			env = append(env, "TM_GITHUB_API_URL=http://"+addr+"/")
 			env = append(env, "GITHUB_EVENT_PATH="+tc.githubEventPath)
+			env = append(env, "GITHUB_TOKEN=fake_token")
 			env = append(env, tc.env...)
 			cli := NewCLI(t, filepath.Join(s.RootDir(), filepath.FromSlash(tc.workingDir)), env...)
 			cli.PrependToPath(filepath.Dir(TerraformTestPath))

--- a/cmd/terramate/e2etests/cloud/run_script_cloud_sync_preview_test.go
+++ b/cmd/terramate/e2etests/cloud/run_script_cloud_sync_preview_test.go
@@ -240,6 +240,7 @@ func TestScriptRunWithCloudSyncPreview(t *testing.T) {
 			env = append(env, "TMC_API_URL=http://"+addr)
 			env = append(env, "TM_GITHUB_API_URL=http://"+addr+"/")
 			env = append(env, "GITHUB_EVENT_PATH="+tc.githubEventPath)
+			env = append(env, "GITHUB_TOKEN=fake_token")
 			env = append(env, tc.env...)
 			cli := NewCLI(t, filepath.Join(s.RootDir(), filepath.FromSlash(tc.workingDir)), env...)
 			cli.PrependToPath(filepath.Dir(TerraformTestPath))


### PR DESCRIPTION
## What this PR does / why we need it:

Improves the error messages when synchronizing commands and GITHUB_TOKEN is not exported.
Before it gave the error below:

```
2024-02-23T17:03:03Z WRN failed to retrieve commit information from GitHub API error="GET https://api.github.com/repos/terramate-io/terramate-quickstart-aws/commits/d74239b4e91562a2c12994cbd6de9b86680b1378: 404 Not Found []" github_repository=terramate-io/terramate-quickstart-aws head_commit=d74239b4e91562a2c12994cbd6de9b86680b1378 normalized_repository=github.com/terramate-io/terramate-quickstart-aws
2024-02-23T17:03:03Z WRN failed to retrieve pull requests associated with HEAD error="GET https://api.github.com/repos/terramate-io/terramate-quickstart-aws/commits/d74239b4e91562a2c12994cbd6de9b86680b1378/pulls?per_page=1: 404 Not Found []" github_repository=terramate-io/terramate-quickstart-aws head_commit=d74239b4e91562a2c12994cbd6de9b86680b1378 normalized_repository=github.com/terramate-io/terramate-quickstart-aws
Warning: unable to create preview
> invalid payload: missing "review_request" field
2024-02-23T17:03:03Z WRN disabling the cloud features error="unprocessable cloud feature"
```

but now it shows:

<img width="706" alt="Screenshot 2024-05-21 at 18 00 05" src="https://github.com/terramate-io/terramate/assets/251478/1caeea5d-4823-4218-99c9-6c57c9d7aa6e">

In the case of a preview sync without pull request information, now it shows:
<img width="1008" alt="Screenshot 2024-05-21 at 18 25 07" src="https://github.com/terramate-io/terramate/assets/251478/8fc44d4b-eeee-4002-a033-243ca2aa0b2f">

## Which issue(s) this PR fixes:
none

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
no
```
