### PR TITLE
fix: only set status=running before executing the command.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 
 - Add support for `[for ...]` and `{for ...}` expressions containing Terramate variables and functions inside the `generate_hcl.content` block.
 
+### Fixed
+
+- Fix the update of stack status to respect the configured parallelism option and only set stack status to be `running` before the command starts.
+
 ### Changed
 
 - (**BREAKING CHANGE**) The format of the generated code may change while being still semantically the same as before. This change is marked as "breaking", because this may trigger change detection on files where the formatting changes.

--- a/cmd/terramate/cli/run.go
+++ b/cmd/terramate/cli/run.go
@@ -344,6 +344,16 @@ func (c *cli) runAll(
 		errs := errors.L()
 
 		for _, task := range run.Tasks {
+			acquireResource()
+
+			if !opts.Quiet && !opts.ScriptRun {
+				printer.Stderr.Println(printPrefix + " Entering stack in " + run.Stack.String())
+			}
+
+			if !opts.Quiet && opts.ScriptRun {
+				printScriptCommand(c.stderr, run.Stack, task)
+			}
+
 			environ := newEnvironFrom(stackEnvs[run.Stack.Dir])
 
 			// For cloud sync, we always assume that there's a single task per stack.
@@ -362,16 +372,6 @@ func (c *cli) runAll(
 				Stringer("stack", run.Stack).
 				Logger()
 
-			if opts.ScriptRun && !c.parsedArgs.Quiet {
-				printScriptCommand(c.stderr, run.Stack, task)
-			}
-
-			if !opts.Quiet && !opts.ScriptRun {
-				printer.Stderr.Println(printPrefix + " Entering stack in " + run.Stack.String())
-			}
-
-			c.cloudSyncBefore(cloudRun)
-
 			cmdPath, err := runutil.LookPath(task.Cmd[0], environ)
 			if err != nil {
 				c.cloudSyncAfter(cloudRun, runResult{ExitCode: -1}, errors.E(ErrRunCommandNotFound, err))
@@ -382,14 +382,6 @@ func (c *cli) runAll(
 
 				cancel()
 				return errs.AsError()
-			}
-
-			if !opts.Quiet && !opts.ScriptRun {
-				printer.Stderr.Println(printPrefix + " Executing command " + strconv.Quote(cmdStr))
-			}
-
-			if opts.DryRun {
-				continue
 			}
 
 			cmd := exec.Command(cmdPath, task.Cmd[1:]...)
@@ -414,7 +406,15 @@ func (c *cli) runAll(
 			cmd.Stdout = stdout
 			cmd.Stderr = stderr
 
-			acquireResource()
+			c.cloudSyncBefore(cloudRun)
+
+			if !opts.Quiet && !opts.ScriptRun {
+				printer.Stderr.Println(printPrefix + " Executing command " + strconv.Quote(cmdStr))
+			}
+
+			if opts.DryRun {
+				continue
+			}
 
 			startTime := time.Now().UTC()
 

--- a/cmd/terramate/e2etests/cloud/run_cloud_deployment_test.go
+++ b/cmd/terramate/e2etests/cloud/run_cloud_deployment_test.go
@@ -75,7 +75,7 @@ func TestCLIRunWithCloudSyncDeployment(t *testing.T) {
 					StderrRegex: "executable file not found",
 				},
 				events: eventsResponse{
-					"stack": []string{"pending", "running", "failed"},
+					"stack": []string{"pending", "failed"},
 				},
 			},
 		},
@@ -89,7 +89,7 @@ func TestCLIRunWithCloudSyncDeployment(t *testing.T) {
 					StderrRegex: "executable file not found",
 				},
 				events: eventsResponse{
-					"s1": []string{"pending", "running", "failed"},
+					"s1": []string{"pending", "failed"},
 					"s2": []string{"pending", "canceled"},
 				},
 			},
@@ -105,8 +105,8 @@ func TestCLIRunWithCloudSyncDeployment(t *testing.T) {
 					StderrRegex: "executable file not found",
 				},
 				events: eventsResponse{
-					"s1": []string{"pending", "running", "failed"},
-					"s2": []string{"pending", "running", "failed"},
+					"s1": []string{"pending", "failed"},
+					"s2": []string{"pending", "failed"},
 				},
 			},
 		},

--- a/cmd/terramate/e2etests/cloud/run_script_cloud_deployment_test.go
+++ b/cmd/terramate/e2etests/cloud/run_script_cloud_deployment_test.go
@@ -84,7 +84,7 @@ func TestCLIScriptRunWithCloudSyncDeployment(t *testing.T) {
 					StderrRegex: "executable file not found",
 				},
 				events: eventsResponse{
-					"stack": []string{"pending", "running", "failed"},
+					"stack": []string{"pending", "failed"},
 				},
 			},
 		},
@@ -109,7 +109,7 @@ func TestCLIScriptRunWithCloudSyncDeployment(t *testing.T) {
 					StderrRegex: "executable file not found",
 				},
 				events: eventsResponse{
-					"s1":    []string{"pending", "running", "failed"},
+					"s1":    []string{"pending", "failed"},
 					"s1_s2": []string{"pending", "canceled"},
 				},
 			},


### PR DESCRIPTION
## What this PR does / why we need it:

Currently, even if `--parallel=<n>` is provided, all stacks have its status changed to `running` right away, even if they are still queued to be executed.

## Which issue(s) this PR fixes:
none

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
yes, improves cloud experience.
```
