### PR TITLE
feat: introduce script.lets.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
     - `terramate run --status`
     - `terramate list --status`
     - `terramate cloud drift show`
+- Add `script.lets` block for declaring variables that are local to the script.
 
 ### Changed
 

--- a/config/script_lets_test.go
+++ b/config/script_lets_test.go
@@ -1,0 +1,393 @@
+// Copyright 2024 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+package config_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/madlambda/spells/assert"
+	"github.com/terramate-io/terramate/config"
+	"github.com/terramate-io/terramate/hcl/eval"
+	"github.com/terramate-io/terramate/hcl/info"
+	"github.com/terramate-io/terramate/project"
+	"github.com/terramate-io/terramate/stdlib"
+	"github.com/terramate-io/terramate/test"
+	errtest "github.com/terramate-io/terramate/test/errors"
+	. "github.com/terramate-io/terramate/test/hclwrite/hclutils"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestScriptLetsEval(t *testing.T) {
+	t.Parallel()
+
+	labels := []string{"some", "label"}
+
+	for _, tc := range []scriptTestcase{
+		{
+			name: "script with unused lets",
+			config: Script(
+				Labels(labels...),
+				Str("description", "some description"),
+				Lets(
+					Str("test", "some unused string"),
+				),
+				Block("job",
+					Expr("commands", `[["echo", "hello"]]`),
+				),
+			),
+			want: config.Script{
+				Labels:      labels,
+				Description: "some description",
+				Jobs: []config.ScriptJob{
+					{
+						Cmds: []*config.ScriptCmd{
+							{
+								Args: []string{"echo", "hello"},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "script with simple lets",
+			config: Script(
+				Labels(labels...),
+				Str("description", "some description"),
+				Lets(
+					Str("test", "some string"),
+				),
+				Block("job",
+					Expr("commands", `[["echo", let.test]]`),
+				),
+			),
+			want: config.Script{
+				Labels:      labels,
+				Description: "some description",
+				Jobs: []config.ScriptJob{
+					{
+						Cmds: []*config.ScriptCmd{
+							{
+								Args: []string{"echo", "some string"},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "script with lets referencing terramate.*",
+			config: Script(
+				Labels(labels...),
+				Str("description", "some description"),
+				Lets(
+					Expr("command", `[["ls", "-lha", terramate.stack.path.absolute]]`),
+				),
+				Block("job",
+					Expr("commands", `let.command`),
+				),
+			),
+			want: config.Script{
+				Labels:      labels,
+				Description: "some description",
+				Jobs: []config.ScriptJob{
+					{
+						Cmds: []*config.ScriptCmd{
+							{
+								Args: []string{"ls", "-lha", "/"},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "script with lets referencing global.*",
+			globals: map[string]cty.Value{
+				"path": cty.StringVal("/test.txt"),
+			},
+			config: Script(
+				Labels(labels...),
+				Str("description", "some description"),
+				Lets(
+					Expr("command", `[["ls", "-lha", global.path]]`),
+				),
+				Block("job",
+					Expr("commands", `let.command`),
+				),
+			),
+			want: config.Script{
+				Labels:      labels,
+				Description: "some description",
+				Jobs: []config.ScriptJob{
+					{
+						Cmds: []*config.ScriptCmd{
+							{
+								Args: []string{"ls", "-lha", "/test.txt"},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "script with command lets",
+			config: Script(
+				Labels(labels...),
+				Str("description", "some description"),
+				Lets(
+					Expr("cmd", `["echo", "hello"]`),
+				),
+				Block("job",
+					Expr("command", `let.cmd`),
+				),
+			),
+			want: config.Script{
+				Labels:      labels,
+				Description: "some description",
+				Jobs: []config.ScriptJob{
+					{
+						Cmd: &config.ScriptCmd{
+							Args: []string{"echo", "hello"},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "script with commands lets",
+			config: Script(
+				Labels(labels...),
+				Str("description", "some description"),
+				Lets(
+					Expr("cmd", `[
+						["echo", "hello"],
+						["echo", "world"],
+					]`),
+				),
+				Block("job",
+					Expr("commands", `let.cmd`),
+				),
+			),
+			want: config.Script{
+				Labels:      labels,
+				Description: "some description",
+				Jobs: []config.ScriptJob{
+					{
+						Cmds: []*config.ScriptCmd{
+							{
+								Args: []string{"echo", "hello"},
+							},
+							{
+								Args: []string{"echo", "world"},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "script with multiple lets",
+			config: Script(
+				Labels(labels...),
+				Str("description", "some description"),
+				Lets(
+					Expr("cmd1", `[["echo", "hello"]]`),
+					Expr("cmd2", `[["echo", "world"]]`),
+					Expr("cmds", `tm_concat(let.cmd1, let.cmd2)`),
+				),
+				Block("job",
+					Expr("commands", `let.cmds`),
+				),
+			),
+			want: config.Script{
+				Labels:      labels,
+				Description: "some description",
+				Jobs: []config.ScriptJob{
+					{
+						Cmds: []*config.ScriptCmd{
+							{
+								Args: []string{"echo", "hello"},
+							},
+							{
+								Args: []string{"echo", "world"},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "script with multiple lets blocks are merged",
+			config: Script(
+				Labels(labels...),
+				Str("description", "some description"),
+				Lets(
+					Expr("cmd1", `[["echo", "hello"]]`),
+				),
+				Lets(
+					Expr("cmd2", `[["echo", "world"]]`),
+				),
+				Lets(
+					Expr("cmds", `tm_concat(let.cmd1, let.cmd2)`),
+				),
+				Block("job",
+					Expr("commands", `let.cmds`),
+				),
+			),
+			want: config.Script{
+				Labels:      labels,
+				Description: "some description",
+				Jobs: []config.ScriptJob{
+					{
+						Cmds: []*config.ScriptCmd{
+							{
+								Args: []string{"echo", "hello"},
+							},
+							{
+								Args: []string{"echo", "world"},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "lets variables have implicit order",
+			config: Script(
+				Labels(labels...),
+				Str("description", "some description"),
+				Lets(
+					Expr("cmds", `tm_concat(let.cmd1, let.cmd2)`),
+				),
+				Lets(
+					Expr("cmd1", `[["echo", "hello"]]`),
+				),
+				Lets(
+					Expr("cmd2", `[["echo", "world"]]`),
+				),
+				Block("job",
+					Expr("commands", `let.cmds`),
+				),
+			),
+			want: config.Script{
+				Labels:      labels,
+				Description: "some description",
+				Jobs: []config.ScriptJob{
+					{
+						Cmds: []*config.ScriptCmd{
+							{
+								Args: []string{"echo", "hello"},
+							},
+							{
+								Args: []string{"echo", "world"},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "lets variables can be used in script.name, script.description, script.job.name and script.job.description",
+			config: Script(
+				Labels(labels...),
+				Expr("name", `let.name`),
+				Expr("description", `let.desc`),
+				Lets(
+					Expr("name", `tm_upper(let.hello)`),
+					Expr("desc", `tm_upper(let.name)`),
+					Str("hello", "hello"),
+				),
+				Block("job",
+					Expr("name", `let.name`),
+					Expr("description", `let.desc`),
+					Expr("commands", `[["echo", let.name, let.desc]]`),
+				),
+			),
+			want: config.Script{
+				Labels:      labels,
+				Name:        "HELLO",
+				Description: "HELLO",
+				Jobs: []config.ScriptJob{
+					{
+						Name:        "HELLO",
+						Description: "HELLO",
+						Cmds: []*config.ScriptCmd{
+							{
+								Args: []string{"echo", "HELLO", "HELLO"},
+							},
+						},
+					},
+				},
+			},
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			testScriptEval(t, tc)
+		})
+	}
+
+}
+
+func TestScriptLetsArelocalToTheirBlocks(t *testing.T) {
+	tempdir := test.TempDir(t)
+	hclctx := eval.NewContext(stdlib.Functions(tempdir))
+	test.AppendFile(t, tempdir, "script.tm", Doc(
+		Script(
+			Labels("deploy1"),
+			Lets(
+				Str("A", "A"),
+			),
+			Block("job",
+				Expr("command", `[let.A]`),
+			),
+		),
+		Script(
+			Labels("deploy2"),
+			Block("job",
+				Expr("command", `[let.A]`),
+			),
+		),
+	).String())
+	test.AppendFile(t, tempdir, "terramate.tm", Terramate(
+		Config(
+			Expr("experiments", `["scripts"]`),
+		),
+	).String())
+
+	cfg, err := config.LoadRoot(tempdir)
+	assert.NoError(t, err)
+
+	rootTree, ok := cfg.Lookup(project.NewPath("/"))
+	if !ok {
+		panic("root tree not found")
+	}
+	if len(rootTree.Node.Scripts) != 2 {
+		panic("test expects two scripts")
+	}
+	got, err := config.EvalScript(hclctx, *rootTree.Node.Scripts[0])
+	assert.NoError(t, err)
+
+	want := config.Script{
+		Labels: []string{"deploy1"},
+		Jobs: []config.ScriptJob{
+			{
+				Cmd: &config.ScriptCmd{
+					Args: []string{"A"},
+				},
+			},
+		},
+	}
+	if diff := cmp.Diff(want, got, cmpopts.IgnoreUnexported(info.Range{})); diff != "" {
+		t.Fatalf("unexpected result\n%s", diff)
+	}
+
+	// must fail because let.A is not set
+	_, err = config.EvalScript(hclctx, *rootTree.Node.Scripts[1])
+	errtest.AssertIsKind(t, err, config.ErrScriptSchema)
+}

--- a/config/script_test.go
+++ b/config/script_test.go
@@ -4,164 +4,167 @@
 package config_test
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	hhcl "github.com/hashicorp/hcl/v2"
 	"github.com/madlambda/spells/assert"
 	"github.com/terramate-io/terramate/config"
 	"github.com/terramate-io/terramate/errors"
 	"github.com/terramate-io/terramate/hcl"
-	"github.com/terramate-io/terramate/hcl/ast"
 	"github.com/terramate-io/terramate/hcl/eval"
 	"github.com/terramate-io/terramate/hcl/info"
+	"github.com/terramate-io/terramate/project"
 	"github.com/terramate-io/terramate/stdlib"
 	"github.com/terramate-io/terramate/test"
+	errtest "github.com/terramate-io/terramate/test/errors"
 
-	. "github.com/terramate-io/terramate/test/hclutils"
-	. "github.com/terramate-io/terramate/test/hclutils/info"
+	. "github.com/terramate-io/terramate/test/hclwrite/hclutils"
 	"github.com/zclconf/go-cty/cty"
 )
+
+type scriptTestcase struct {
+	name    string
+	config  fmt.Stringer
+	globals map[string]cty.Value
+	want    config.Script
+	wantErr error
+}
 
 func TestScriptEval(t *testing.T) {
 	t.Parallel()
 
-	makeAttribute := func(t *testing.T, name string, expr string) *ast.Attribute {
-		t.Helper()
-		return &ast.Attribute{
-			Attribute: &hhcl.Attribute{
-				Name: name,
-				Expr: test.NewExpr(t, expr),
-			},
-		}
-	}
-
-	makeCommand := func(t *testing.T, expr string) *hcl.Command {
-		t.Helper()
-		attr := makeAttribute(t, "command", expr)
-		parsed := hcl.Command(*attr)
-		return &parsed
-	}
-
-	makeCommands := func(t *testing.T, expr string) *hcl.Commands {
-		t.Helper()
-		attr := makeAttribute(t, "commands", expr)
-		parsed := hcl.Commands(*attr)
-		return &parsed
-	}
-
 	labels := []string{"some", "label"}
 
-	type testcase struct {
-		name    string
-		script  hcl.Script
-		globals map[string]cty.Value
-		want    config.Script
-		wantErr error
-	}
-
-	tcases := []testcase{
+	tcases := []scriptTestcase{
 		{
 			name: "no description attribute",
-			script: hcl.Script{
-				Labels: labels,
-			},
+			config: Script(
+				Labels(labels...),
+				Block("job",
+					Command("echo", "hello"),
+				),
+			),
 			want: config.Script{
 				Labels: labels,
+				Jobs: []config.ScriptJob{
+					{Cmd: &config.ScriptCmd{Args: []string{"echo", "hello"}}},
+				},
 			},
 		},
 		{
 			name: "description attribute wrong type",
-			script: hcl.Script{
-				Labels:      labels,
-				Description: makeAttribute(t, "description", `666`),
-			},
+			config: Script(
+				Labels(labels...),
+				Number("description", 666),
+				Block("job", Command("echo", "hello")),
+			),
 			wantErr: errors.E(config.ErrScriptInvalidType),
 		},
 		{
 			name: "description attribute with functions",
-			script: hcl.Script{
-				Labels:      labels,
-				Description: makeAttribute(t, "description", `tm_upper("some description")`),
-			},
+			config: Script(
+				Labels(labels...),
+				Expr("description", `tm_upper("some description")`),
+				Block("job", Command("echo", "hello")),
+			),
 			want: config.Script{
 				Labels:      labels,
 				Description: "SOME DESCRIPTION",
+				Jobs: []config.ScriptJob{
+					{Cmd: &config.ScriptCmd{Args: []string{"echo", "hello"}}},
+				},
 			},
 		},
 		{
 			name: "description attribute with functions and globals",
-			script: hcl.Script{
-				Range:       Range("script.tm", Start(1, 1, 0), End(3, 2, 37)),
-				Labels:      labels,
-				Description: makeAttribute(t, "description", `tm_upper(global.some_string_var)`),
-			},
+			config: Script(
+				Labels(labels...),
+				Expr("description", `tm_upper(global.some_string_var)`),
+				Block("job", Command("echo", "hello")),
+			),
 			globals: map[string]cty.Value{
 				"some_string_var": cty.StringVal("terramate"),
 			},
 			want: config.Script{
 				Labels:      labels,
 				Description: "TERRAMATE",
+				Jobs: []config.ScriptJob{
+					{Cmd: &config.ScriptCmd{Args: []string{"echo", "hello"}}},
+				},
 			},
 		},
 		{
 			name: "name attribute with wrong type",
-			script: hcl.Script{
-				Labels:      labels,
-				Name:        makeAttribute(t, "name", `666`),
-				Description: makeAttribute(t, "description", `"some desc"`),
-			},
+			config: Script(
+				Labels(labels...),
+				Number("name", 666),
+				Str("description", "some desc"),
+				Block("job", Command("echo", "hello")),
+			),
 			wantErr: errors.E(config.ErrScriptInvalidType),
 		},
 		{
 			name: "name attribute with string",
-			script: hcl.Script{
-				Labels:      labels,
-				Name:        makeAttribute(t, "name", `"some name"`),
-				Description: makeAttribute(t, "description", `"some desc"`),
-			},
+			config: Script(
+				Labels(labels...),
+				Str("name", "some name"),
+				Str("description", "some desc"),
+				Block("job", Command("echo", "hello")),
+			),
 			want: config.Script{
 				Labels:      labels,
 				Name:        "some name",
 				Description: "some desc",
+				Jobs: []config.ScriptJob{
+					{Cmd: &config.ScriptCmd{Args: []string{"echo", "hello"}}},
+				},
 			},
 		},
 		{
 			name: "name attribute exceeds maximum allowed characters - truncation",
-			script: hcl.Script{
-				Labels:      labels,
-				Name:        makeAttribute(t, "name", `"`+strings.Repeat("A", 150)+`"`),
-				Description: makeAttribute(t, "description", `"some desc"`),
-			},
+			config: Script(
+				Labels(labels...),
+				Str("name", strings.Repeat("A", 150)),
+				Str("description", "some desc"),
+				Block("job", Command("echo", "hello")),
+			),
 			want: config.Script{
 				Labels:      labels,
 				Name:        strings.Repeat("A", 128),
 				Description: "some desc",
+				Jobs: []config.ScriptJob{
+					{Cmd: &config.ScriptCmd{Args: []string{"echo", "hello"}}},
+				},
 			},
 		},
 		{
 			name: "name attribute with functions",
-			script: hcl.Script{
-				Labels:      labels,
-				Name:        makeAttribute(t, "name", `tm_upper("some name")`),
-				Description: makeAttribute(t, "description", `"some desc"`),
-			},
+			config: Script(
+				Labels(labels...),
+				Expr("name", `tm_upper("some name")`),
+				Str("description", "some desc"),
+				Block("job", Command("echo", "hello")),
+			),
 			want: config.Script{
 				Labels:      labels,
 				Name:        "SOME NAME",
 				Description: "some desc",
+				Jobs: []config.ScriptJob{
+					{Cmd: &config.ScriptCmd{Args: []string{"echo", "hello"}}},
+				},
 			},
 		},
 		{
 			name: "name attribute with interpolation, functions and globals",
-			script: hcl.Script{
-				Range:       Range("script.tm", Start(1, 1, 0), End(3, 2, 37)),
-				Labels:      labels,
-				Name:        makeAttribute(t, "name", `"my name is ${tm_upper(global.name_var)}!!!"`),
-				Description: makeAttribute(t, "description", `"some desc"`),
-			},
+			config: Script(
+				Labels(labels...),
+				Expr("name", `"my name is ${tm_upper(global.name_var)}!!!"`),
+				Str("description", "some desc"),
+				Block("job", Command("echo", "hello")),
+			),
 			globals: map[string]cty.Value{
 				"name_var": cty.StringVal("terramate"),
 			},
@@ -169,19 +172,20 @@ func TestScriptEval(t *testing.T) {
 				Labels:      labels,
 				Name:        "my name is TERRAMATE!!!",
 				Description: "some desc",
+				Jobs: []config.ScriptJob{
+					{Cmd: &config.ScriptCmd{Args: []string{"echo", "hello"}}},
+				},
 			},
 		},
 		{
-			name: "command attribute wrong type",
-			script: hcl.Script{
-				Labels:      labels,
-				Description: makeAttribute(t, "description", `"some description"`),
-				Jobs: []*hcl.ScriptJob{
-					{
-						Command: makeCommand(t, `"echo"`),
-					},
-				},
-			},
+			name: "command attribute wrong type - must be a list",
+			config: Script(
+				Labels(labels...),
+				Str("description", "some desc"),
+				Block("job",
+					Str("command", "echo"),
+				),
+			),
 			globals: map[string]cty.Value{
 				"some_string_var": cty.StringVal("terramate"),
 			},
@@ -189,28 +193,24 @@ func TestScriptEval(t *testing.T) {
 		},
 		{
 			name: "command attribute wrong element type",
-			script: hcl.Script{
-				Labels:      labels,
-				Description: makeAttribute(t, "description", `"some description"`),
-				Jobs: []*hcl.ScriptJob{
-					{
-						Command: makeCommand(t, `["echo", 666]`),
-					},
-				},
-			},
+			config: Script(
+				Labels(labels...),
+				Str("description", "some desc"),
+				Block("job",
+					Expr("command", `["echo", 666]`),
+				),
+			),
 			wantErr: errors.E(config.ErrScriptInvalidTypeCommand),
 		},
 		{
 			name: "command attribute with functions and globals",
-			script: hcl.Script{
-				Labels:      labels,
-				Description: makeAttribute(t, "description", `"some description"`),
-				Jobs: []*hcl.ScriptJob{
-					{
-						Command: makeCommand(t, `["echo", tm_upper("hello ${global.some_string_var}")]`),
-					},
-				},
-			},
+			config: Script(
+				Labels(labels...),
+				Str("description", "some description"),
+				Block("job",
+					Expr("command", `["echo", tm_upper("hello ${global.some_string_var}")]`),
+				),
+			),
 			globals: map[string]cty.Value{
 				"some_string_var": cty.StringVal("terramate"),
 			},
@@ -228,15 +228,12 @@ func TestScriptEval(t *testing.T) {
 		},
 		{
 			name: "command attribute with list type",
-			script: hcl.Script{
-				Labels:      labels,
-				Description: makeAttribute(t, "description", `"some description"`),
-				Jobs: []*hcl.ScriptJob{
-					{
-						Command: makeCommand(t, `true ? tm_concat(["echo"], ["something"]) : []`),
-					},
-				},
-			},
+			config: Script(
+				Labels(labels...),
+				Str("description", "some description"),
+				Block("job",
+					Expr("command", `true ? tm_concat(["echo"], ["something"]) : []`)),
+			),
 			globals: map[string]cty.Value{
 				"some_string_var": cty.StringVal("terramate"),
 			},
@@ -254,15 +251,13 @@ func TestScriptEval(t *testing.T) {
 		},
 		{
 			name: "commands attribute with list type",
-			script: hcl.Script{
-				Labels:      labels,
-				Description: makeAttribute(t, "description", `"some description"`),
-				Jobs: []*hcl.ScriptJob{
-					{
-						Commands: makeCommands(t, `true ? tm_concat([["echo", "something"]], [["echo", "other", "thing"]]) : []`),
-					},
-				},
-			},
+			config: Script(
+				Labels(labels...),
+				Str("description", "some description"),
+				Block("job",
+					Expr("commands", `true ? tm_concat([["echo", "something"]], [["echo", "other", "thing"]]) : []`),
+				),
+			),
 			globals: map[string]cty.Value{
 				"some_string_var": cty.StringVal("terramate"),
 			},
@@ -285,15 +280,13 @@ func TestScriptEval(t *testing.T) {
 		},
 		{
 			name: "command with first item interpolated",
-			script: hcl.Script{
-				Labels:      labels,
-				Description: makeAttribute(t, "description", `"some description"`),
-				Jobs: []*hcl.ScriptJob{
-					{
-						Command: makeCommand(t, `["${global.some_command_name}", "--version"]`),
-					},
-				},
-			},
+			config: Script(
+				Labels(labels...),
+				Str("description", "some description"),
+				Block("job",
+					Expr("command", `["${global.some_command_name}", "--version"]`),
+				),
+			),
 			globals: map[string]cty.Value{
 				"some_command_name": cty.StringVal("ls"),
 			},
@@ -311,15 +304,13 @@ func TestScriptEval(t *testing.T) {
 		},
 		{
 			name: "commands attribute wrong type",
-			script: hcl.Script{
-				Labels:      labels,
-				Description: makeAttribute(t, "description", `"some description"`),
-				Jobs: []*hcl.ScriptJob{
-					{
-						Commands: makeCommands(t, `"echo"`),
-					},
-				},
-			},
+			config: Script(
+				Labels(labels...),
+				Str("description", "some description"),
+				Block("job",
+					Str("commands", "echo"),
+				),
+			),
 			globals: map[string]cty.Value{
 				"some_string_var": cty.StringVal("terramate"),
 			},
@@ -327,81 +318,65 @@ func TestScriptEval(t *testing.T) {
 		},
 		{
 			name: "commands attribute wrong element type",
-			script: hcl.Script{
-				Labels:      labels,
-				Description: makeAttribute(t, "description", `"some description"`),
-				Jobs: []*hcl.ScriptJob{
-					{
-						Commands: makeCommands(t, `
-						  [
-							["echo", "hello"],
-							666,
-						  ]
-						`),
-					},
-				},
-			},
+			config: Script(
+				Labels(labels...),
+				Str("description", "some description"),
+				Block("job",
+					Str("commands", "test"),
+				),
+			),
 			wantErr: errors.E(config.ErrScriptInvalidTypeCommands),
 		},
 		{
 			name: "commands evaluating to empty list",
-			script: hcl.Script{
-				Labels:      labels,
-				Description: makeAttribute(t, "description", `"some description"`),
-				Jobs: []*hcl.ScriptJob{
-					{
-						Commands: makeCommands(t, `[]`),
-					},
-				},
-			},
+			config: Script(
+				Labels(labels...),
+				Str("description", "some description"),
+				Block("job",
+					Expr("commands", `[]`),
+				),
+			),
 			wantErr: errors.E(config.ErrScriptEmptyCmds),
 		},
 		{
 			name: "commands item evaluating to empty list",
-			script: hcl.Script{
-				Labels:      labels,
-				Description: makeAttribute(t, "description", `"some description"`),
-				Jobs: []*hcl.ScriptJob{
-					{
-						Commands: makeCommands(t, `[
-							["echo", "hello"],
-							[],
-							["echo", "other"]
-						]`),
-					},
-				},
-			},
+			config: Script(
+				Labels(labels...),
+				Str("description", "some description"),
+				Block("job",
+					Expr("commands", `[
+								["echo", "hello"],
+								[],
+								["echo", "other"]
+							]`),
+				),
+			),
 			wantErr: errors.E(config.ErrScriptEmptyCmds),
 		},
 		{
 			name: "command evaluating to empty list",
-			script: hcl.Script{
-				Labels:      labels,
-				Description: makeAttribute(t, "description", `"some description"`),
-				Jobs: []*hcl.ScriptJob{
-					{
-						Command: makeCommand(t, `[]`),
-					},
-				},
-			},
+			config: Script(
+				Labels(labels...),
+				Str("description", "some description"),
+				Block("job",
+					Expr("command", `[]`),
+				),
+			),
 			wantErr: errors.E(config.ErrScriptEmptyCmds),
 		},
 		{
 			name: "commands attribute with functions and globals",
-			script: hcl.Script{
-				Labels:      labels,
-				Description: makeAttribute(t, "description", `"some description"`),
-				Jobs: []*hcl.ScriptJob{
-					{
-						Commands: makeCommands(t, `
-						  [
-							["echo", tm_upper("hello ${global.some_string_var}")],
-							["stat", "."],
-						  ]
-						`),
-					},
-				},
-			},
+			config: Script(
+				Labels(labels...),
+				Str("description", "some description"),
+				Block("job",
+					Expr("commands", `[
+								["echo", tm_upper("hello ${global.some_string_var}")],
+								["stat", "."],
+							  ]
+							`),
+				),
+			),
 			globals: map[string]cty.Value{
 				"some_string_var": cty.StringVal("terramate"),
 			},
@@ -420,29 +395,24 @@ func TestScriptEval(t *testing.T) {
 		},
 		{
 			name: "multiple jobs",
-			script: hcl.Script{
-				Labels:      labels,
-				Description: makeAttribute(t, "description", `"some description"`),
-				Jobs: []*hcl.ScriptJob{
-					{
-						Name: makeAttribute(t, "name", `"job name"`),
-						Commands: makeCommands(t, `
-						  [
-							["echo", tm_upper("hello ${global.some_string_var}")],
-							["stat", "."],
-						  ]
-						`),
-					},
-					{
-						Commands: makeCommands(t, `
-						  [
-							["echo", tm_upper("hello ${global.some_string_var}")],
-							["ls", "-l"],
-						  ]
-						`),
-					},
-				},
-			},
+			config: Script(
+				Labels(labels...),
+				Str("description", "some description"),
+				Block("job",
+					Str("name", "job name"),
+					Expr("commands", `[
+								["echo", tm_upper("hello ${global.some_string_var}")],
+								["stat", "."],
+							  ]`),
+				),
+				Block("job",
+					Expr("commands", `[
+								["echo", tm_upper("hello ${global.some_string_var}")],
+								["ls", "-l"],
+							  ]
+							`),
+				),
+			),
 			globals: map[string]cty.Value{
 				"some_string_var": cty.StringVal("terramate"),
 			},
@@ -468,20 +438,14 @@ func TestScriptEval(t *testing.T) {
 		},
 		{
 			name: "job.name attribute exceeds maximum allowed characters - truncation",
-			script: hcl.Script{
-				Labels:      labels,
-				Description: makeAttribute(t, "description", `"some desc"`),
-				Jobs: []*hcl.ScriptJob{
-					{
-						Name: makeAttribute(t, "name", `"`+strings.Repeat("A", 150)+`"`),
-						Commands: makeCommands(t, `
-						  [
-							["echo", "hello"],
-						  ]
-						`),
-					},
-				},
-			},
+			config: Script(
+				Labels(labels...),
+				Str("description", "some desc"),
+				Block("job",
+					Str("name", strings.Repeat("A", 150)),
+					Expr("commands", `[["echo", "hello"]]`),
+				),
+			),
 			want: config.Script{
 				Labels:      labels,
 				Description: "some desc",
@@ -497,20 +461,14 @@ func TestScriptEval(t *testing.T) {
 		},
 		{
 			name: "job.description attribute exceeds maximum allowed characters - truncation",
-			script: hcl.Script{
-				Labels:      labels,
-				Description: makeAttribute(t, "description", `"some desc"`),
-				Jobs: []*hcl.ScriptJob{
-					{
-						Description: makeAttribute(t, "description", `"`+strings.Repeat("A", config.MaxScriptDescRunes+100)+`"`),
-						Commands: makeCommands(t, `
-						  [
-							["echo", "hello"],
-						  ]
-						`),
-					},
-				},
-			},
+			config: Script(
+				Labels(labels...),
+				Str("description", "some desc"),
+				Block("job",
+					Str("description", strings.Repeat("A", config.MaxScriptDescRunes+100)),
+					Expr("commands", `[["echo", "hello"]]`),
+				),
+			),
 			want: config.Script{
 				Labels:      labels,
 				Description: "some desc",
@@ -526,65 +484,56 @@ func TestScriptEval(t *testing.T) {
 		},
 		{
 			name: "command options with sync_deployment and sync_preview",
-			script: hcl.Script{
-				Labels:      labels,
-				Description: makeAttribute(t, "description", `"some description"`),
-				Jobs: []*hcl.ScriptJob{
-					{
-						Commands: makeCommands(t, `
-						  [
-							["echo", "hello", {
-								sync_deployment = true
-								sync_preview = true
-								terraform_plan_file = "plan_a"
-							}],
-						  ]
-						`),
-					},
-				},
-			},
+			config: Script(
+				Labels(labels...),
+				Str("description", "some description"),
+				Block("job",
+					Expr("commands", `[
+								["echo", "hello", {
+									sync_deployment = true
+									sync_preview = true
+									terraform_plan_file = "plan_a"
+								}],
+							  ]
+							`),
+				),
+			),
 			wantErr: errors.E(config.ErrScriptInvalidCmdOptions),
 		},
 		{
 			name: "command options with invalid layer",
-			script: hcl.Script{
-				Labels:      labels,
-				Description: makeAttribute(t, "description", `"some description"`),
-				Jobs: []*hcl.ScriptJob{
-					{
-						Commands: makeCommands(t, `
-						  [
-							["echo", "hello", {
-								sync_preview = true
-								terraform_plan_file = "plan_a"
-								layer = "a+b"
-							}],
-						  ]
-						`),
-					},
-				},
-			},
+			config: Script(
+				Labels(labels...),
+				Str("description", "some description"),
+				Block("job",
+					Expr("commands", `[
+								["echo", "hello", {
+									sync_preview = true
+									terraform_plan_file = "plan_a"
+									layer = "a+b"
+								}],
+							  ]
+							`),
+				),
+			),
 			wantErr: errors.E(config.ErrScriptInvalidCmdOptions),
 		},
 		{
 			name: "command options with sync_preview + planfile + layer",
-			script: hcl.Script{
-				Labels:      labels,
-				Description: makeAttribute(t, "description", `"some description"`),
-				Jobs: []*hcl.ScriptJob{
-					{
-						Commands: makeCommands(t, `
-						  [
-							["echo", "hello", {
-								sync_preview = true
-								terraform_plan_file = "plan_a"
-								layer = "staging"
-							}],
-						  ]
-						`),
-					},
-				},
-			},
+			config: Script(
+				Labels(labels...),
+				Str("description", "some description"),
+				Block("job",
+					Expr("commands", `[
+								["echo", "hello", {
+									sync_preview = true
+									terraform_plan_file = "plan_a"
+									layer = "staging"
+								}],
+							  ]
+							`),
+				),
+			),
 			want: config.Script{
 				Labels:      labels,
 				Description: "some description",
@@ -607,30 +556,25 @@ func TestScriptEval(t *testing.T) {
 		},
 		{
 			name: "command options",
-			script: hcl.Script{
-				Labels:      labels,
-				Description: makeAttribute(t, "description", `"some description"`),
-				Jobs: []*hcl.ScriptJob{
-					{
-						Commands: makeCommands(t, `
-						  [
-							["echo", "hello", {
-								sync_deployment = false
-								terraform_plan_file = "plan_a"
-							}],
-						  ]
-						`),
-					},
-					{
-						Command: makeCommand(t, `
-							["echo", "hello", {
-								sync_deployment = true
-								terraform_plan_file = "plan_b"
-							}]
-						`),
-					},
-				},
-			},
+			config: Script(
+				Labels(labels...),
+				Str("description", "some description"),
+				Block("job",
+					Expr("commands", `[
+								["echo", "hello", {
+									sync_deployment = false
+									terraform_plan_file = "plan_a"
+								}],
+							  ]
+							`),
+				),
+				Block("job",
+					Expr("command", `["echo", "hello", {
+									sync_deployment = true
+									terraform_plan_file = "plan_b"
+								}]`),
+				),
+			),
 			want: config.Script{
 				Labels:      labels,
 				Description: "some description",
@@ -660,23 +604,20 @@ func TestScriptEval(t *testing.T) {
 		},
 		{
 			name: "command options with planfile + terragrunt",
-			script: hcl.Script{
-				Labels:      labels,
-				Description: makeAttribute(t, "description", `"some description"`),
-				Jobs: []*hcl.ScriptJob{
-					{
-						Commands: makeCommands(t, `
-						  [
-							["echo", "hello", {
-								sync_deployment = true
-								terraform_plan_file = "plan_a"
-								terragrunt = true
-							}],
-						  ]
-						`),
-					},
-				},
-			},
+			config: Script(
+				Labels(labels...),
+				Str("description", "some description"),
+				Block("job",
+					Expr("commands", `[
+								["echo", "hello", {
+									sync_deployment = true
+									terraform_plan_file = "plan_a"
+									terragrunt = true
+								}],
+							  ]
+							`),
+				),
+			),
 			want: config.Script{
 				Labels:      labels,
 				Description: "some description",
@@ -698,85 +639,70 @@ func TestScriptEval(t *testing.T) {
 		},
 		{
 			name: "invalid command option",
-			script: hcl.Script{
-				Labels:      labels,
-				Description: makeAttribute(t, "description", `"some description"`),
-				Jobs: []*hcl.ScriptJob{
-					{
-						Commands: makeCommands(t, `
-						  [
-							["echo", "hello", {
-								sync_deploymenttttttt = false
-							}],
-						  ]
-						`),
-					},
-				},
-			},
+			config: Script(
+				Labels(labels...),
+				Str("description", "some description"),
+				Block("job",
+					Expr("commands", `[
+								["echo", "hello", {
+									sync_deploymenttttttt = false
+								}],
+							  ]
+							`),
+				),
+			),
 			wantErr: errors.E(config.ErrScriptInvalidCmdOptions),
 		},
 		{
 			name: "invalid command options object",
-			script: hcl.Script{
-				Labels:      labels,
-				Description: makeAttribute(t, "description", `"some description"`),
-				Jobs: []*hcl.ScriptJob{
-					{
-						Commands: makeCommands(t, `
-						  [
-							["echo", "hello", ["list"]],
-						  ]
-						`),
-					},
-				},
-			},
+			config: Script(
+				Labels(labels...),
+				Str("description", "some description"),
+				Block("job",
+					Expr("commands", `[
+								["echo", "hello", ["list"]],
+							  ]
+							`),
+				),
+			),
 			wantErr: errors.E(config.ErrScriptInvalidTypeCommand),
 		},
 		{
-			name: "invalid command option type",
-			script: hcl.Script{
-				Labels:      labels,
-				Description: makeAttribute(t, "description", `"some description"`),
-				Jobs: []*hcl.ScriptJob{
-					{
-						Commands: makeCommands(t, `
-						  [
-							["echo", "hello", {
-								sync_deployment = "false"
-							}],
-						  ]
-						`),
-					},
-				},
-			},
+			name: "invalid command option type - option must be boolean",
+			config: Script(
+				Labels(labels...),
+				Str("description", "some description"),
+				Block("job",
+					Expr("commands", `[
+								["echo", "hello", {
+									sync_deployment = "false"
+								}],
+							  ]
+							`),
+				),
+			),
 			wantErr: errors.E(config.ErrScriptInvalidCmdOptions),
 		},
 		{
 			name: "multiple sync_deployments",
-			script: hcl.Script{
-				Labels:      labels,
-				Description: makeAttribute(t, "description", `"some description"`),
-				Jobs: []*hcl.ScriptJob{
-					{
-						Commands: makeCommands(t, `
-							  [
-								["echo", "hello", {
-									sync_deployment = true
-									terraform_plan_file = "plan_a"
-								}],
-							  ]
-							`),
-					},
-					{
-						Command: makeCommand(t, `
-								["echo", "hello", {
-									sync_deployment = true
-									terraform_plan_file = "plan_a"
-								}]
-							`),
-					},
-				},
-			},
+			config: Script(
+				Labels(labels...),
+				Str("description", "some description"),
+				Block("job",
+					Expr("commands", `[
+									["echo", "hello", {
+										sync_deployment = true
+										terraform_plan_file = "plan_a"
+									}],
+								  ]`),
+				),
+				Block("job",
+					Expr("commands", `[["echo", "hello", {
+										sync_deployment = true
+										terraform_plan_file = "plan_a"
+									}]]`),
+				),
+			),
 			wantErr: errors.E(config.ErrScriptInvalidCmdOptions),
 		},
 	}
@@ -785,15 +711,50 @@ func TestScriptEval(t *testing.T) {
 		tcase := tcase
 		t.Run(tcase.name, func(t *testing.T) {
 			t.Parallel()
-			hclctx := eval.NewContext(stdlib.Functions(test.TempDir(t)))
-			hclctx.SetNamespace("global", tcase.globals)
-
-			got, err := config.EvalScript(hclctx, tcase.script)
-			assert.IsError(t, err, tcase.wantErr)
-			// ignoring info.Range comparisons for now
-			if diff := cmp.Diff(tcase.want, got, cmpopts.IgnoreUnexported(info.Range{})); diff != "" {
-				t.Fatalf("unexpected result\n%s", diff)
-			}
+			testScriptEval(t, tcase)
 		})
+	}
+}
+
+func testScriptEval(t *testing.T, tcase scriptTestcase) {
+	t.Helper()
+	tempdir := test.TempDir(t)
+	test.AppendFile(t, tempdir, "stack.tm", Block("stack").String())
+	test.AppendFile(t, tempdir, "script.tm", tcase.config.String())
+	test.AppendFile(t, tempdir, "terramate.tm", Terramate(
+		Config(
+			Expr("experiments", `["scripts"]`),
+		),
+	).String())
+
+	cfg, err := config.LoadRoot(tempdir)
+	if errors.IsAnyKind(tcase.wantErr, hcl.ErrHCLSyntax, hcl.ErrTerramateSchema) {
+		errtest.Assert(t, err, tcase.wantErr)
+		return
+	}
+
+	assert.NoError(t, err)
+
+	rootTree, ok := cfg.Lookup(project.NewPath("/"))
+	if !ok {
+		panic("root tree not found")
+	}
+
+	st, err := rootTree.Stack()
+	assert.NoError(t, err)
+	hclctx := eval.NewContext(stdlib.Functions(tempdir))
+	hclctx.SetNamespace("global", tcase.globals)
+	runtime := cfg.Runtime()
+	runtime.Merge(st.RuntimeValues(cfg))
+	hclctx.SetNamespace("terramate", runtime)
+
+	if len(rootTree.Node.Scripts) != 1 {
+		panic("test expects one script")
+	}
+	got, err := config.EvalScript(hclctx, *rootTree.Node.Scripts[0])
+	assert.IsError(t, err, tcase.wantErr)
+	// ignoring info.Range comparisons for now
+	if diff := cmp.Diff(tcase.want, got, cmpopts.IgnoreUnexported(info.Range{})); diff != "" {
+		t.Fatalf("unexpected result\n%s", diff)
 	}
 }

--- a/hcl/eval/eval.go
+++ b/hcl/eval/eval.go
@@ -36,7 +36,8 @@ func NewContext(funcs map[string]function.Function) *Context {
 	}
 }
 
-func (c *Context) newChildContext() *Context {
+// ChildContext creates a new child HCL context that inherits all parent HCL variables and functions.
+func (c *Context) ChildContext() *Context {
 	child := NewContext(c.hclctx.Functions)
 	for k, v := range c.hclctx.Variables {
 		child.hclctx.Variables[k] = v

--- a/hcl/eval/partial_eval.go
+++ b/hcl/eval/partial_eval.go
@@ -299,7 +299,7 @@ func (c *Context) evalForObjectLoop(forExpr *hclsyntax.ForExpr) (hhcl.Expression
 	iterator := coll.ElementIterator()
 	for iterator.Next() {
 		k, v := iterator.Element()
-		childCtx := c.newChildContext()
+		childCtx := c.ChildContext()
 		childCtx.hclctx.Variables[forExpr.KeyVar] = k
 		childCtx.hclctx.Variables[forExpr.ValVar] = v
 
@@ -375,7 +375,7 @@ func (c *Context) evalForListLoop(forExpr *hclsyntax.ForExpr) (hhcl.Expression, 
 	iterator := coll.ElementIterator()
 	for iterator.Next() {
 		k, v := iterator.Element()
-		childCtx := c.newChildContext()
+		childCtx := c.ChildContext()
 		childCtx.hclctx.Variables[forExpr.KeyVar] = k
 		childCtx.hclctx.Variables[forExpr.ValVar] = v
 

--- a/hcl/hcl_script_test.go
+++ b/hcl/hcl_script_test.go
@@ -515,6 +515,42 @@ func TestHCLScript(t *testing.T) {
 			},
 		},
 		{
+			name: "script with lets with unrecognized subblocks -- fails",
+			input: []cfgfile{
+				{
+					filename: "cfg.tm",
+					body: `
+					  terramate {
+						  config {
+							  experiments = ["scripts"]
+						  }
+					  }
+					`,
+				},
+				{
+					filename: "script.tm",
+					body: `
+					  script "group1" "script1" {
+						description = "some description"
+						lets {
+							whatever {
+
+							}
+						}
+						job {
+						  command = ["ls", "-l"]
+						}
+					  }
+					`,
+				},
+			},
+			want: want{
+				errs: []error{
+					errors.E(hcl.ErrUnrecognizedBlock),
+				},
+			},
+		},
+		{
 			name: "script with multiple jobs",
 			input: []cfgfile{
 				{

--- a/hcl/hcl_test.go
+++ b/hcl/hcl_test.go
@@ -1667,7 +1667,9 @@ func TestHCLParserTerramateBlocksMerging(t *testing.T) {
 }
 
 func testParser(t *testing.T, tc testcase) {
+	t.Helper()
 	t.Run(tc.name, func(t *testing.T) {
+		t.Helper()
 		t.Parallel()
 		configsDir := test.TempDir(t)
 		for _, inputConfigFile := range tc.input {

--- a/test/hclwrite/hclutils/utils.go
+++ b/test/hclwrite/hclutils/utils.go
@@ -4,6 +4,7 @@
 package hclutils
 
 import (
+	"bytes"
 	"strings"
 	"testing"
 
@@ -30,6 +31,31 @@ func Config(builders ...hclwrite.BlockBuilder) *hclwrite.Block {
 // Run is a helper for a "run" block.
 func Run(builders ...hclwrite.BlockBuilder) *hclwrite.Block {
 	return Block("run", builders...)
+}
+
+// Script is a helper for a "script" block.
+func Script(builders ...hclwrite.BlockBuilder) *hclwrite.Block {
+	return Block("script", builders...)
+}
+
+// Command is a helper for a "command" attribute.
+func Command(args ...string) hclwrite.BlockBuilder {
+	expr := `["` + strings.Join(args, `","`) + `"]`
+	return Expr("command", expr)
+}
+
+// Commands is a helper for a "commands" attribute.
+func Commands(args ...[]string) hclwrite.BlockBuilder {
+	buf := bytes.Buffer{}
+	buf.WriteString("[")
+	for i, arg := range args {
+		buf.WriteString(`[` + strings.Join(arg, ",") + `]`)
+		if i != len(args)-1 {
+			buf.WriteString(",")
+		}
+	}
+	buf.WriteString("]")
+	return Expr("commands", buf.String())
 }
 
 // Vendor is a helper for a "vendor" block.


### PR DESCRIPTION
## What this PR does / why we need it:

Add support for `lets` variables in the `script` block.
The block work in the same way as the `lets` block in the `generate_*` blocks.
Multiple blocks are merged into the same. See example below:

```
script "deploy" {
  lets {
    name = "script name"
    cmd = ["echo", "hello ${let.project}"]
  }
  lets {
    project = "my project"
  }
  job {
    command = let.cmd
  }
}
```
The script above works and it's the same as if all lets variables were defined in the same block.

## Which issue(s) this PR fixes:
Fixes #1382 

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
yes, new feature
```
