### PR TITLE
fix: experimental trigger must respect working directory.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 
 ### Fixed
 
+- Fix `terramate experimental trigger --status` to respect the `-C <dir>` flag.
+	- Now using `-C <dir>` (or `--chdir <dir>`) only triggers stacks inside the provided dir.
 - Fix the update of stack status to respect the configured parallelism option and only set stack status to be `running` before the command starts.
 
 ### Changed

--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -959,7 +959,7 @@ func (c *cli) triggerStackByFilter() {
 		fatalWithDetails(err, "unable to list stacks")
 	}
 
-	for _, st := range stacksReport.Stacks {
+	for _, st := range c.filterStacksByWorkingDir(stacksReport.Stacks) {
 		c.triggerStack(st.Stack.Dir.String())
 	}
 }


### PR DESCRIPTION
## What this PR does / why we need it:

The `-C` is not being respected by the `terramate experimental trigger --status` command.

## Which issue(s) this PR fixes:
none

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
yes, fixes a bug.
```
