### PR TITLE
feat: add triggers of type ignore-change.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
     - `terramate list --status`
     - `terramate cloud drift show`
 - Add `script.lets` block for declaring variables that are local to the script.
+- Add `--ignore-change` flag to `terramate experimental trigger`, which makes the change detection ignore the given stacks.
+  - It inverts the default trigger behavior.
 
 ### Fixed
 

--- a/e2etests/internal/runner/runner.go
+++ b/e2etests/internal/runner/runner.go
@@ -18,6 +18,7 @@ import (
 	"github.com/golang-jwt/jwt"
 	"github.com/google/go-cmp/cmp"
 	"github.com/madlambda/spells/assert"
+	"github.com/terramate-io/terramate/stack/trigger"
 	"github.com/terramate-io/terramate/test"
 )
 
@@ -287,8 +288,18 @@ func (tm CLI) ListChangedStacks(args ...string) RunResult {
 }
 
 // TriggerStack is a helper for executing `terramate experimental trigger`.
-func (tm CLI) TriggerStack(stack string) RunResult {
-	return tm.Run([]string{"experimental", "trigger", stack}...)
+func (tm CLI) TriggerStack(kind trigger.Kind, stack string) RunResult {
+	var kindFlag string
+	switch kind {
+	case trigger.Changed:
+		kindFlag = "--change"
+	case trigger.Ignored:
+		kindFlag = "--ignore-change"
+	default:
+		panic(fmt.Sprintf("unsupported trigger kind: %s", kind))
+	}
+
+	return tm.Run([]string{"experimental", "trigger", kindFlag, stack}...)
 }
 
 // AssertRun asserts that the provided run result is successfully and with no output.

--- a/stack/trigger/trigger.go
+++ b/stack/trigger/trigger.go
@@ -32,25 +32,31 @@ const (
 	ErrParsing errors.Kind = "parsing trigger file"
 )
 
-// Info represents the parsed contents of a trigger
-// for triggers created by Terramate.
+// Kind is the trigger type/kind.
+type Kind string
+
+// Supported trigger kinds.
+const (
+	Changed Kind = "changed"
+	Ignored Kind = "ignore-change"
+)
+
+// Info represents the parsed contents of a trigger.
 type Info struct {
 	// Ctime is unix timestamp of when the trigger was created.
 	Ctime int64
 	// Reason is the reason why the trigger was created, if any.
 	Reason string
 	// Type is the trigger type.
-	Type string
+	Type Kind
 	// Context is the context of the trigger (only `stack` at the moment)
 	Context string
+	// StackPath is the path of the triggered stack.
+	StackPath project.Path
 }
 
 const (
-	// DefaultType is the default trigger type when not specified.
-	DefaultType = "changed"
-
-	// DefaultContext is the default context for the trigger file when not
-	// specified.
+	// DefaultContext is the default context for the trigger file when not specified.
 	DefaultContext = "stack"
 )
 
@@ -69,6 +75,24 @@ func StackPath(triggerFile project.Path) (project.Path, bool) {
 	stackPath := strings.TrimPrefix(triggerFile.String(), triggersPrefix)
 	stackPath = path.Dir(stackPath)
 	return project.NewPath(stackPath), true
+}
+
+// Is checks if the filename is a trigger file and if that's the case then it returns
+// the parsed trigger info and the triggered path.
+// If the trigger file exists, the exists returns true.
+// If the file is not inside the triggerDir then it returns an empty Info, empty path, false and no error.
+// If there's an error parsing the trigger file, it returns empty info, true and the error.
+// It only parses the file if it's inside the triggers directory (.tmtriggers).
+func Is(root *config.Root, filename project.Path) (info Info, stack project.Path, exists bool, err error) {
+	stackpath, exists := StackPath(filename)
+	if !exists {
+		return Info{}, stack, false, nil
+	}
+	info, err = ParseFile(filename.HostPath(root.HostDir()))
+	if err != nil {
+		return Info{}, stack, true, err
+	}
+	return info, stackpath, true, nil
 }
 
 // ParseFile will parse the given trigger file.
@@ -121,6 +145,7 @@ func ParseFile(path string) (Info, error) {
 
 	errs := errors.L()
 	info := Info{}
+
 	for _, attribute := range ast.SortRawAttributes(triggerContent.Attributes) {
 		if attribute.Name == "context" || attribute.Name == "type" {
 			// they are keywords so they must be handled separately.
@@ -137,10 +162,11 @@ func ParseFile(path string) (Info, error) {
 				}
 				info.Context = keyword
 			case "type":
-				if keyword != DefaultType {
+				keyword := Kind(keyword)
+				if keyword != Changed && keyword != Ignored {
 					errs.Append(errors.E(
-						"trigger: invalid trigger.type = %s (available options: %s)",
-						keyword, DefaultType,
+						"trigger: invalid trigger.type = %s (available options: %s, %s)",
+						keyword, Changed, Ignored,
 					))
 					continue
 				}
@@ -181,7 +207,7 @@ func ParseFile(path string) (Info, error) {
 
 	// for backward compatibility (<= v0.2.7)
 	if info.Type == "" {
-		info.Type = DefaultType
+		info.Type = Changed
 	}
 
 	if info.Context == "" {
@@ -207,7 +233,7 @@ func triggerFilename() (string, error) {
 
 // Create creates a trigger for a stack with the given path and the given reason
 // inside the project rootdir.
-func Create(root *config.Root, path project.Path, reason string) error {
+func Create(root *config.Root, path project.Path, kind Kind, reason string) error {
 	tree, ok := root.Lookup(path)
 	if !ok || !tree.IsStack() {
 		return errors.E(ErrTrigger, "path %s is not a stack directory", path)
@@ -227,7 +253,7 @@ func Create(root *config.Root, path project.Path, reason string) error {
 	triggerBody := gen.Body().AppendNewBlock("trigger", nil).Body()
 	triggerBody.SetAttributeValue("ctime", cty.NumberIntVal(ctime))
 	triggerBody.SetAttributeValue("reason", cty.StringVal(reason))
-	triggerBody.SetAttributeRaw("type", hclwrite.TokensForIdentifier(DefaultType))
+	triggerBody.SetAttributeRaw("type", hclwrite.TokensForIdentifier(string(kind)))
 	triggerBody.SetAttributeRaw("context", hclwrite.TokensForIdentifier(DefaultContext))
 
 	triggerPath := filepath.Join(triggerDir, filename)


### PR DESCRIPTION
## What this PR does / why we need it:

Introduce the `ignore-change` trigger. This kind of trigger can be used when a set of changes would trigger stacks when should not, then the user can now force them to not trigger as changed in the same PR.

Usage example:
```
$ terramate list --changed
my-stack
$ terramate experimental trigger --ignore-change my-stack
Created trigger for stack "/my-stack"

$ terramate list --changed
$ 
```

As you can see, after the trigger file is created with `--ignore-change` the stack is not listed as changed anymore. The same is true for the other features supporting `--changed`.

## Which issue(s) this PR fixes:
Fixes none

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
yes, adds a new feature.
```
