### PR TITLE
fix: trigger with misleading error message when stack is not found.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 - Fix `terramate experimental trigger --status` to respect the `-C <dir>` flag.
 	- Now using `-C <dir>` (or `--chdir <dir>`) only triggers stacks inside the provided dir.
 - Fix the update of stack status to respect the configured parallelism option and only set stack status to be `running` before the command starts.
+- Fix `terramate experimental trigger` gives a misleading error message when a stack is not found.
 
 ### Changed
 

--- a/e2etests/core/exp_trigger_test.go
+++ b/e2etests/core/exp_trigger_test.go
@@ -37,6 +37,16 @@ func TestTriggerWorksWithRelativeStackPath(t *testing.T) {
 	AssertRunResult(t, cli.ListChangedStacks(), want)
 }
 
+func TestTriggerCorrectErrorWhenStackDoesNotExists(t *testing.T) {
+	t.Parallel()
+	s := sandbox.New(t)
+	cli := NewCLI(t, s.RootDir())
+	AssertRunResult(t, cli.TriggerStack(trigger.Changed, "non-existent"), RunExpected{
+		StderrRegex: "Error: stack not found",
+		Status:      1,
+	})
+}
+
 func TestTriggerFailsWithSymlinksInStackPath(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("symlink tests skipped on windows")


### PR DESCRIPTION
## What this PR does / why we need it:

When using the `terramate experimental trigger` providing a non-existent stack path, the error message complains about symlinks not being supported when in fact the error should be "stack not found".

## Which issue(s) this PR fixes:
none

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
yes, fixes a bug
```
