### PR TITLE
feat: terramate list --deployment-status=<status> and --drift-status=<status>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 - Add `--ignore-change` flag to `terramate experimental trigger`, which makes the change detection ignore the given stacks.
   - It inverts the default trigger behavior.
 - Add `--recursive` flag to `terramate experimental trigger` for triggering all child stacks of given path.
+- Add cloud filters `--deployment-status=<status>` and `--drift-status` to commands below:
+  - `terramate list`
+  - `terramate run`
+  - `terramate experimental trigger`
 - Add support for generating files relative to working directory. Both examples below only generate files inside `some/dir`:
   - `terramate -C some/dir generate`
   - `cd some/dir && terramate generate`

--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -21,6 +21,8 @@ import (
 	hversion "github.com/apparentlymart/go-versions/versions"
 	"github.com/rs/zerolog"
 	"github.com/terramate-io/terramate"
+	"github.com/terramate-io/terramate/cloud/deployment"
+	"github.com/terramate-io/terramate/cloud/drift"
 	"github.com/terramate-io/terramate/cloud/stack"
 	"github.com/terramate-io/terramate/errors"
 	"github.com/terramate-io/terramate/strconv"
@@ -134,15 +136,21 @@ func (c *Client) MemberOrganizations(ctx context.Context) (orgs MemberOrganizati
 
 // StacksByStatus returns all stacks for the given organization.
 // It paginates as needed and returns the total stacks response.
-func (c *Client) StacksByStatus(ctx context.Context, orgUUID UUID, repository string, target string, status stack.FilterStatus) ([]StackObject, error) {
+func (c *Client) StacksByStatus(ctx context.Context, orgUUID UUID, repository string, target string, stackFilters StatusFilters) ([]StackObject, error) {
 	path := path.Join(StacksPath, string(orgUUID))
 	query := url.Values{}
 	query.Set("repository", repository)
 	if target != "" {
 		query.Set("target", target)
 	}
-	if status != stack.NoFilter {
-		query.Set("status", status.String())
+	if stackFilters.StackStatus != stack.NoFilter {
+		query.Set("status", stackFilters.StackStatus.String())
+	}
+	if stackFilters.DeploymentStatus != deployment.NoFilter {
+		query.Set("deployment_status", stackFilters.DeploymentStatus.String())
+	}
+	if stackFilters.DriftStatus != drift.NoFilter {
+		query.Set("drift_status", stackFilters.DriftStatus.String())
 	}
 	query.Set("per_page", strconv.Itoa64(pageSize))
 	url := c.URL(path)

--- a/cloud/cloud_test.go
+++ b/cloud/cloud_test.go
@@ -160,7 +160,7 @@ func TestCommonAPIFailCases(t *testing.T) {
 					"e4c81294-dcf8-45e2-ba95-25f96514a61b",
 					"dummy/repo",
 					"",
-					stack.NoFilter,
+					cloud.NoStatusFilters(),
 				)
 				errtest.Assert(t, err, tc.err)
 			}()
@@ -520,7 +520,9 @@ func TestCloudStacks(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), timeout)
 			defer cancel()
 
-			stacksResp, err := sdk.StacksByStatus(ctx, cloud.UUID(tc.org), "dummy/repo", "", tc.filter)
+			stacksResp, err := sdk.StacksByStatus(ctx, cloud.UUID(tc.org), "dummy/repo", "", cloud.StatusFilters{
+				StackStatus: tc.filter,
+			})
 			errtest.Assert(t, err, tc.want.err)
 			if err != nil {
 				return

--- a/cloud/deployment/status.go
+++ b/cloud/deployment/status.go
@@ -5,8 +5,8 @@
 package deployment
 
 import (
+	"bytes"
 	"encoding/json"
-	"fmt"
 	"math/bits"
 	"strconv"
 
@@ -16,26 +16,47 @@ import (
 const (
 	// ErrInvalidStatus represents an invalid deployment status error.
 	ErrInvalidStatus errors.Kind = "invalid deployment status"
+
+	// ErrInvalidFilterStatus represents an invalid deployment status filter error.
+	ErrInvalidFilterStatus errors.Kind = "invalid filter deployment status"
 )
 
-// Status of a stack or deployment
-type Status uint8
+type (
+	// Status of a deployment.
+	Status uint8
+
+	// FilterStatus represents a filter for deployment statuses.
+	FilterStatus Status
+)
 
 const (
-	OK       Status = 1 << iota // OK status is used when the stack ran successfully.
-	Pending                     // Pending is a temporary status set when the deployment is about to commence.
-	Running                     // Running is a temporary status as part of an still ongoing deployment.
-	Failed                      // Failed status indicates the deployment of the stack failed.
-	Canceled                    // Canceled indicates the deployment of the stack was canceled.
+	OK           Status = 1 << iota // OK status is used when the stack ran successfully.
+	Pending                         // Pending is a temporary status set when the deployment is about to commence.
+	Running                         // Running is a temporary status as part of an still ongoing deployment.
+	Failed                          // Failed status indicates the deployment of the stack failed.
+	Canceled                        // Canceled indicates the deployment of the stack was canceled.
+	Unrecognized                    // Unrecognized indicates any deployment status returned from TMC but not recognized by this client version.
+	lastStatus
+)
 
-	lastStatus = Canceled
+const (
+	// UnhealthyFilter status is used for filtering not OK deployment status.
+	UnhealthyFilter FilterStatus = FilterStatus(^OK) // assumes only 1 status is healthy
+
+	// HealthyFilter status is used for filtering healthy statuses. Just [OK] for now.
+	HealthyFilter FilterStatus = FilterStatus(OK)
+
+	// AllFilter filters for any stacks statuses.
+	AllFilter FilterStatus = HealthyFilter | UnhealthyFilter
+	// NoFilter disables the filtering for statuses.
+	NoFilter FilterStatus = 0
 )
 
 // NewStatus creates a new stack status from a string.
-func NewStatus(str string) (Status, error) {
+func NewStatus(str string) Status {
 	var s Status
-	err := s.UnmarshalJSON([]byte(strconv.Quote(str)))
-	return s, err
+	_ = s.UnmarshalJSON([]byte(strconv.Quote(str)))
+	return s
 }
 
 // Validate the status.
@@ -80,7 +101,7 @@ func (s *Status) UnmarshalJSON(b []byte) error {
 	case "canceled":
 		*s = Canceled
 	default:
-		return errors.E(ErrInvalidStatus, str)
+		*s = Unrecognized
 	}
 	return nil
 }
@@ -98,6 +119,50 @@ func (s Status) String() string {
 		return "failed"
 	case Canceled:
 		return "canceled"
+	default:
+		return "unrecognized (" + strconv.Itoa(int(s)) + ")"
 	}
-	panic(fmt.Sprintf("unrecognized status: %d", s))
+}
+
+// Is tells if status matches the provided filter.
+func (s Status) Is(filter FilterStatus) bool {
+	return FilterStatus(s)&filter != 0
+}
+
+// NewStatusFilter creates a new filter for deployment statuses.
+func NewStatusFilter(str string) (FilterStatus, error) {
+	if str == "unhealthy" {
+		return UnhealthyFilter, nil
+	} else if str == "healthy" {
+		return HealthyFilter, nil
+	}
+
+	s := NewStatus(str)
+	if s == Unrecognized {
+		return FilterStatus(0), errors.E("unrecognized deployment status filter: %s", str)
+	}
+	return FilterStatus(s), nil
+}
+
+// Is tells if the filter matches the provided status.
+func (f FilterStatus) Is(status Status) bool {
+	return status.Is(f)
+}
+
+func (f FilterStatus) String() string {
+	if f == UnhealthyFilter {
+		return "unhealthy"
+	}
+	var out bytes.Buffer
+
+	for i := OK; i <= Canceled; i *= 2 {
+		s := Status(i)
+		if Status(f)&s > 0 {
+			if out.Len() > 0 {
+				_, _ = out.WriteRune('|')
+			}
+			_, _ = out.WriteString(s.String())
+		}
+	}
+	return out.String()
 }

--- a/cloud/drift/status.go
+++ b/cloud/drift/status.go
@@ -5,8 +5,8 @@
 package drift
 
 import (
+	"bytes"
 	"encoding/json"
-	"fmt"
 	"math/bits"
 	"strconv"
 
@@ -16,24 +16,41 @@ import (
 const (
 	// ErrInvalidStatus represents an invalid drift status error.
 	ErrInvalidStatus errors.Kind = "invalid drift status"
+	// ErrInvalidFilterStatus represents an invalid drift status filter error.
+	ErrInvalidFilterStatus errors.Kind = "invalid drift stack filter"
 )
 
-// Status of a drift.
-type Status uint8
+type (
+	// Status of a drift.
+	Status uint8
+
+	// FilterStatus represents a filter for drift statuses.
+	FilterStatus Status
+)
 
 const (
-	OK         Status = 1 << iota // OK status is used when the stack is not drifted.
-	Unknown                       // Unknown indicates the drift detection was not executed yet.
-	Drifted                       // Drifted status indicates the stack is drifted.
-	Failed                        // Failed status indicates the drift detection of the stack failed.
-	lastStatus = Failed
+	OK           Status = 1 << iota // OK status is used when the stack is not drifted.
+	Unknown                         // Unknown indicates the drift detection was not executed yet.
+	Drifted                         // Drifted status indicates the stack is drifted.
+	Failed                          // Failed status indicates the drift detection of the stack failed.
+	Unrecognized                    // Unrecognized indicates any drift status returned from TMC but not recognized by this client version.
+	lastStatus   = Failed
+)
+
+const (
+	// UnhealthyFilter status is used for filtering not OK drift status.
+	UnhealthyFilter FilterStatus = FilterStatus(^OK)
+	// HealthyFilter status is used for filtering for healthy statuses. Just [OK] for now.
+	HealthyFilter FilterStatus = FilterStatus(OK)
+	// NoFilter disables the filtering for statuses.
+	NoFilter FilterStatus = 0
 )
 
 // NewStatus creates a new stack drift status from a string.
-func NewStatus(str string) (Status, error) {
+func NewStatus(str string) Status {
 	var s Status
-	err := s.UnmarshalJSON([]byte(strconv.Quote(str)))
-	return s, err
+	_ = s.UnmarshalJSON([]byte(strconv.Quote(str)))
+	return s
 }
 
 // Validate the status.
@@ -69,7 +86,7 @@ func (s *Status) UnmarshalJSON(b []byte) error {
 	case "failed":
 		*s = Failed
 	default:
-		return errors.E(ErrInvalidStatus, str)
+		*s = Unrecognized
 	}
 	return nil
 }
@@ -85,6 +102,50 @@ func (s Status) String() string {
 		return "drifted"
 	case Failed:
 		return "failed"
+	default:
+		return "unrecognized (" + strconv.Itoa(int(s)) + ")"
 	}
-	panic(fmt.Sprintf("unrecognized status: %d", s))
+}
+
+// Is tells if status matches the provided filter.
+func (s Status) Is(filter FilterStatus) bool {
+	return FilterStatus(s)&filter != 0
+}
+
+// NewStatusFilter creates a new filter for drift statuses.
+func NewStatusFilter(str string) (FilterStatus, error) {
+	if str == "unhealthy" {
+		return UnhealthyFilter, nil
+	} else if str == "healthy" {
+		return HealthyFilter, nil
+	}
+
+	s := NewStatus(str)
+	if s == Unrecognized {
+		return FilterStatus(0), errors.E("unrecognized drift status filter: %s", str)
+	}
+	return FilterStatus(s), nil
+}
+
+// Is tells if the filter matches the provided status.
+func (f FilterStatus) Is(status Status) bool {
+	return status.Is(f)
+}
+
+func (f FilterStatus) String() string {
+	if f == UnhealthyFilter {
+		return "unhealthy"
+	}
+	var out bytes.Buffer
+
+	for i := OK; i <= Failed; i *= 2 {
+		s := Status(i)
+		if Status(f)&s > 0 {
+			if out.Len() > 0 {
+				_, _ = out.WriteRune('|')
+			}
+			_, _ = out.WriteString(s.String())
+		}
+	}
+	return out.String()
 }

--- a/cloud/stack/status.go
+++ b/cloud/stack/status.go
@@ -117,22 +117,17 @@ func (s Status) Is(filter FilterStatus) bool {
 }
 
 // NewStatusFilter creates a new filter for stack statuses.
-func NewStatusFilter(str string) FilterStatus {
+func NewStatusFilter(str string) (FilterStatus, error) {
 	if str == "unhealthy" {
-		return UnhealthyFilter
+		return UnhealthyFilter, nil
 	} else if str == "healthy" {
-		return HealthyFilter
+		return HealthyFilter, nil
 	}
-
-	return FilterStatus(NewStatus(str))
-}
-
-// Validate the status filter.
-func (f FilterStatus) Validate() error {
-	if f > UnhealthyFilter {
-		return errors.E(ErrInvalidFilterStatus)
+	s := NewStatus(str)
+	if s == Unrecognized {
+		return FilterStatus(0), errors.E("unrecognized status filter: %s", str)
 	}
-	return nil
+	return FilterStatus(s), nil
 }
 
 // Is tells if the filter matches the provided status.

--- a/cloud/types.go
+++ b/cloud/types.go
@@ -317,6 +317,13 @@ type (
 		PerPage int64 `json:"per_page"`
 	}
 
+	// StatusFilters defines multiple statuses stack filters.
+	StatusFilters struct {
+		StackStatus      stack.FilterStatus
+		DeploymentStatus deployment.FilterStatus
+		DriftStatus      drift.FilterStatus
+	}
+
 	// UUID represents an UUID string.
 	UUID string
 )
@@ -697,4 +704,18 @@ func (c LogChannel) String() string {
 		return "stderr"
 	}
 	return "unknown"
+}
+
+// NoStatusFilters returns a StatusFilters with no filter.
+func NoStatusFilters() StatusFilters {
+	return StatusFilters{
+		StackStatus:      stack.NoFilter,
+		DeploymentStatus: deployment.NoFilter,
+		DriftStatus:      drift.NoFilter,
+	}
+}
+
+// HasFilter tells if StackFilter has any filter set.
+func (f StatusFilters) HasFilter() bool {
+	return f.StackStatus != stack.NoFilter || f.DeploymentStatus != deployment.NoFilter || f.DriftStatus != drift.NoFilter
 }

--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -19,6 +19,8 @@ import (
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/terramate-io/go-checkpoint"
 	"github.com/terramate-io/terramate/cloud"
+	"github.com/terramate-io/terramate/cloud/deployment"
+	"github.com/terramate-io/terramate/cloud/drift"
 	"github.com/terramate-io/terramate/cloud/preview"
 	cloudstack "github.com/terramate-io/terramate/cloud/stack"
 	"github.com/terramate-io/terramate/cmd/terramate/cli/cliconfig"
@@ -141,17 +143,15 @@ type cliSpec struct {
 	} `cmd:"" help:"Format configuration files."`
 
 	List struct {
-		Why                bool   `help:"Shows the reason why the stack has changed."`
-		ExperimentalStatus string `hidden:"" help:"Filter by status (Deprecated)"`
-		CloudStatus        string `hidden:""`
-		Status             string `help:"Filter by Terramate Cloud status of the stack."`
-		Target             string `help:"Select the deployment target of the filtered stacks."`
-		RunOrder           bool   `default:"false" help:"Sort listed stacks by order of execution"`
+		Why bool `help:"Shows the reason why the stack has changed."`
+
+		cloudFilterFlags
+		Target   string `help:"Select the deployment target of the filtered stacks."`
+		RunOrder bool   `default:"false" help:"Sort listed stacks by order of execution"`
 	} `cmd:"" help:"List stacks."`
 
 	Run struct {
-		CloudStatus          string `hidden:""`
-		Status               string `help:"Filter by Terramate Cloud status of the stack."`
+		cloudFilterFlags
 		Target               string `help:"Set the deployment target for stacks synchronized to Terramate Cloud."`
 		FromTarget           string `help:"Migrate stacks from given deployment target."`
 		CloudSyncDeployment  bool   `hidden:""`
@@ -195,8 +195,7 @@ type cliSpec struct {
 			Cmds []string `arg:"" optional:"true" passthrough:"" help:"Script to show info for."`
 		} `cmd:"" help:"Show detailed information about a script"`
 		Run struct {
-			CloudStatus     string `hidden:""`
-			Status          string `help:"Filter by Terramate Cloud status of the stack."`
+			cloudFilterFlags
 			Target          string `help:"Set the deployment target for stacks synchronized to Terramate Cloud."`
 			FromTarget      string `help:"Migrate stacks from given deployment target."`
 			NoRecursive     bool   `default:"false" help:"Do not recurse into nested child stacks."`
@@ -244,14 +243,12 @@ type cliSpec struct {
 		} `cmd:"" help:"Clone a stack."`
 
 		Trigger struct {
-			Stack              string `arg:"" optional:"true" name:"stack" predictor:"file" help:"The stacks path."`
-			Recursive          bool   `default:"false" help:"Recursively triggers all child stacks of the given path"`
-			Change             bool   `default:"false" help:"Trigger stacks as changed"`
-			IgnoreChange       bool   `default:"false" help:"Trigger stacks to be ignored by change detection"`
-			Reason             string `default:"" name:"reason" help:"Set a reason for triggering the stack."`
-			ExperimentalStatus string `hidden:"" help:"Filter by Terramate Cloud status of the stack. (deprecated)"`
-			CloudStatus        string `hidden:""`
-			Status             string `help:"Filter by Terramate Cloud status of the stack."`
+			Stack        string `arg:"" optional:"true" name:"stack" predictor:"file" help:"The stacks path."`
+			Recursive    bool   `default:"false" help:"Recursively triggers all child stacks of the given path"`
+			Change       bool   `default:"false" help:"Trigger stacks as changed"`
+			IgnoreChange bool   `default:"false" help:"Trigger stacks to be ignored by change detection"`
+			Reason       string `default:"" name:"reason" help:"Set a reason for triggering the stack."`
+			cloudFilterFlags
 		} `cmd:"" help:"Mark a stack as changed so it will be triggered in Change Detection."`
 
 		RunGraph struct {
@@ -323,6 +320,14 @@ type safeguards struct {
 	DisableCheckGenerateOutdatedCheck bool
 
 	reEnabled bool
+}
+
+type cloudFilterFlags struct {
+	ExperimentalStatus string `hidden:"" help:"Filter by status (Deprecated)"`
+	CloudStatus        string `hidden:""`
+	Status             string `help:"Filter by Terramate Cloud status of the stack."`
+	DeploymentStatus   string `help:"Filter by Terramate Cloud deployment status of the stack"`
+	DriftStatus        string `help:"Filter by Terramate Cloud drift status of the stack"`
 }
 
 // Exec will execute terramate with the provided flags defined on args.
@@ -955,12 +960,14 @@ func (c *cli) triggerStackByFilter() {
 	if statusStr == "" {
 		fatal("trigger command expects either a stack path or the --status flag")
 	}
-
-	status := parseStatusFilter(statusStr)
-	if status != cloudstack.NoFilter && c.parsedArgs.Experimental.Trigger.Recursive {
+	statusFilter := parseStatusFilter(statusStr)
+	if statusFilter != cloudstack.NoFilter && c.parsedArgs.Experimental.Trigger.Recursive {
 		fatal("cloud filters such as --status are incompatible with --recursive flag")
 	}
-	stacksReport, err := c.listStacks(false, "", status)
+	stackFilter := cloud.StatusFilters{
+		StackStatus: statusFilter,
+	}
+	stacksReport, err := c.listStacks(false, "", stackFilter)
 	if err != nil {
 		fatalWithDetails(err, "unable to list stacks")
 	}
@@ -1033,7 +1040,7 @@ func (c *cli) triggerStack(basePath string) {
 		stacks = append(stacks, st.Sortable())
 	} else {
 		var err error
-		stacksReport, err := c.listStacks(false, cloudstack.AnyTarget, cloudstack.NoFilter)
+		stacksReport, err := c.listStacks(false, cloudstack.AnyTarget, cloud.NoStatusFilters())
 		if err != nil {
 			fatalWithDetails(err, "computing selected stacks")
 		}
@@ -1217,7 +1224,7 @@ func (c *cli) gitSafeguardDefaultBranchIsReachable() {
 	}
 }
 
-func (c *cli) listStacks(isChanged bool, target string, status cloudstack.FilterStatus) (*stack.Report, error) {
+func (c *cli) listStacks(isChanged bool, target string, stackFilters cloud.StatusFilters) (*stack.Report, error) {
 	var (
 		err    error
 		report *stack.Report
@@ -1237,7 +1244,7 @@ func (c *cli) listStacks(isChanged bool, target string, status cloudstack.Filter
 		c.affectedStacks = report.Stacks
 	}
 
-	if status != cloudstack.NoFilter {
+	if stackFilters.HasFilter() {
 		err := c.setupCloudConfig([]string{cloudFeatStatus})
 		if err != nil {
 			return nil, err
@@ -1250,12 +1257,12 @@ func (c *cli) listStacks(isChanged bool, target string, status cloudstack.Filter
 
 		repository := cloud.NormalizeGitURI(repoURL)
 		if repository == "local" {
-			return nil, errors.E("%s status filter does not work with filesystem based remotes: %s", status.String(), repoURL)
+			return nil, errors.E("status filters does not work with filesystem based remotes")
 		}
 
 		ctx, cancel := context.WithTimeout(context.Background(), defaultCloudTimeout)
 		defer cancel()
-		cloudStacks, err := c.cloud.client.StacksByStatus(ctx, c.cloud.run.orgUUID, repository, target, status)
+		cloudStacks, err := c.cloud.client.StacksByStatus(ctx, c.cloud.run.orgUUID, repository, target, stackFilters)
 		if err != nil {
 			return nil, err
 		}
@@ -1687,19 +1694,27 @@ func (c *cli) printStacks() {
 	if cloudStatus != "" {
 		statusStr = cloudStatus
 	}
-
+	deploymentStatusStr := c.parsedArgs.List.DeploymentStatus
+	driftStatusStr := c.parsedArgs.List.DriftStatus
 	c.checkTargetsConfiguration(c.parsedArgs.List.Target, "", func(isTargetSet bool) {
 		isStatusSet := statusStr != ""
+		isDeploymentStatusSet := deploymentStatusStr != ""
+		isDriftStatusSet := driftStatusStr != ""
 
-		if isTargetSet && !isStatusSet {
-			fatalWithDetails(errors.E("--target must be used together with --status"), "Invalid args")
-		} else if !isTargetSet && isStatusSet {
-			fatalWithDetails(errors.E("--status requires --target when terramate.config.cloud.targets.enabled is true"), "Invalid args")
+		if isTargetSet && (!isStatusSet && !isDeploymentStatusSet && !isDriftStatusSet) {
+			fatalWithDetails(errors.E("--target must be used together with --status or --deployment-status or --drift-status"), "Invalid args")
+		} else if !isTargetSet && (isStatusSet || isDeploymentStatusSet || isDriftStatusSet) {
+			fatalWithDetails(errors.E("--status, --deployment-status and --drift-status requires --target when terramate.config.cloud.targets.enabled is true"), "Invalid args")
 		}
 	})
 
-	status := parseStatusFilter(statusStr)
-	report, err := c.listStacks(c.parsedArgs.Changed, c.parsedArgs.List.Target, status)
+	cloudFilters := cloud.StatusFilters{
+		StackStatus:      parseStatusFilter(statusStr),
+		DeploymentStatus: parseDeploymentStatusFilter(deploymentStatusStr),
+		DriftStatus:      parseDriftStatusFilter(driftStatusStr),
+	}
+
+	report, err := c.listStacks(c.parsedArgs.Changed, c.parsedArgs.List.Target, cloudFilters)
 	if err != nil {
 		fatal(err)
 	}
@@ -1744,19 +1759,41 @@ func (c *cli) printStacksList(allStacks []stack.Entry, why bool, runOrder bool) 
 	}
 }
 
-func parseStatusFilter(strStatus string) cloudstack.FilterStatus {
-	status := cloudstack.NoFilter
-	if strStatus != "" {
-		status = cloudstack.NewStatusFilter(strStatus)
-		if status.Is(cloudstack.Unrecognized) {
-			fatalf("unrecognized stack filter: %s", strStatus)
-		}
+func parseStatusFilter(filterStr string) cloudstack.FilterStatus {
+	if filterStr == "" {
+		return cloudstack.NoFilter
 	}
-	return status
+	filter, err := cloudstack.NewStatusFilter(filterStr)
+	if err != nil {
+		fatalWithDetails(err, "unrecognized stack filter")
+	}
+	return filter
+}
+
+func parseDeploymentStatusFilter(filterStr string) deployment.FilterStatus {
+	if filterStr == "" {
+		return deployment.NoFilter
+	}
+	filter, err := deployment.NewStatusFilter(filterStr)
+	if err != nil {
+		fatalWithDetails(err, "unrecognized deployment filter")
+	}
+	return filter
+}
+
+func parseDriftStatusFilter(filterStr string) drift.FilterStatus {
+	if filterStr == "" {
+		return drift.NoFilter
+	}
+	filter, err := drift.NewStatusFilter(filterStr)
+	if err != nil {
+		fatalWithDetails(err, "unrecognized drift filter")
+	}
+	return filter
 }
 
 func (c *cli) printRuntimeEnv() {
-	report, err := c.listStacks(c.parsedArgs.Changed, cloudstack.AnyTarget, cloudstack.NoFilter)
+	report, err := c.listStacks(c.parsedArgs.Changed, cloudstack.AnyTarget, cloud.NoStatusFilters())
 	if err != nil {
 		fatalWithDetails(err, "listing stacks")
 	}
@@ -1906,7 +1943,7 @@ func (c *cli) printRunOrder(friendlyFmt bool) {
 		Str("workingDir", c.wd()).
 		Logger()
 
-	stacks, err := c.computeSelectedStacks(false, "", cloudstack.NoFilter)
+	stacks, err := c.computeSelectedStacks(false, cloudstack.AnyTarget, cloud.NoStatusFilters())
 	if err != nil {
 		fatalWithDetails(err, "computing selected stacks")
 	}
@@ -1943,7 +1980,7 @@ func (c *cli) generateDebug() {
 	// TODO(KATCIPIS): When we introduce config defined on root context
 	// we need to know blocks that have root context, since they should
 	// not be filtered by stack selection.
-	stacks, err := c.computeSelectedStacks(false, "", cloudstack.NoFilter)
+	stacks, err := c.computeSelectedStacks(false, cloudstack.AnyTarget, cloud.NoStatusFilters())
 	if err != nil {
 		fatalWithDetails(err, "generate debug: selecting stacks")
 	}
@@ -1987,7 +2024,7 @@ func (c *cli) generateDebug() {
 }
 
 func (c *cli) printStacksGlobals() {
-	report, err := c.listStacks(c.parsedArgs.Changed, cloudstack.AnyTarget, cloudstack.NoFilter)
+	report, err := c.listStacks(c.parsedArgs.Changed, cloudstack.AnyTarget, cloud.NoStatusFilters())
 	if err != nil {
 		fatalWithDetails(err, "listing stacks globals: listing stacks")
 	}
@@ -2016,7 +2053,7 @@ func (c *cli) printMetadata() {
 		Str("action", "cli.printMetadata()").
 		Logger()
 
-	report, err := c.listStacks(c.parsedArgs.Changed, cloudstack.AnyTarget, cloudstack.NoFilter)
+	report, err := c.listStacks(c.parsedArgs.Changed, cloudstack.AnyTarget, cloud.NoStatusFilters())
 	if err != nil {
 		fatalWithDetails(err, "loading metadata: listing stacks")
 	}
@@ -2075,7 +2112,7 @@ func (c *cli) checkGenCode() bool {
 }
 
 func (c *cli) ensureStackID() {
-	report, err := c.listStacks(false, cloudstack.AnyTarget, cloudstack.NoFilter)
+	report, err := c.listStacks(false, cloudstack.AnyTarget, cloud.NoStatusFilters())
 	if err != nil {
 		fatalWithDetails(err, "listing stacks")
 	}
@@ -2329,8 +2366,8 @@ func (c *cli) friendlyFmtDir(dir string) (string, bool) {
 	return prj.FriendlyFmtDir(c.rootdir(), c.wd(), dir)
 }
 
-func (c *cli) computeSelectedStacks(ensureCleanRepo bool, target string, cloudStatus cloudstack.FilterStatus) (config.List[*config.SortableStack], error) {
-	report, err := c.listStacks(c.parsedArgs.Changed, target, cloudStatus)
+func (c *cli) computeSelectedStacks(ensureCleanRepo bool, target string, stackFilters cloud.StatusFilters) (config.List[*config.SortableStack], error) {
+	report, err := c.listStacks(c.parsedArgs.Changed, target, stackFilters)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/terramate/cli/run.go
+++ b/cmd/terramate/cli/run.go
@@ -134,7 +134,14 @@ func (c *cli) runOnStacks() {
 		stacks = append(stacks, st.Sortable())
 	} else {
 		var err error
-		stacks, err = c.computeSelectedStacks(true, c.parsedArgs.Run.Target, parseStatusFilter(c.parsedArgs.Run.Status))
+		stackFilter := parseStatusFilter(c.parsedArgs.Run.Status)
+		deploymentFilter := parseDeploymentStatusFilter(c.parsedArgs.Run.DeploymentStatus)
+		driftFilter := parseDriftStatusFilter(c.parsedArgs.Run.DriftStatus)
+		stacks, err = c.computeSelectedStacks(true, c.parsedArgs.Run.Target, cloud.StatusFilters{
+			StackStatus:      stackFilter,
+			DeploymentStatus: deploymentFilter,
+			DriftStatus:      driftFilter,
+		})
 		if err != nil {
 			fatalWithDetails(err, "computing selected stacks")
 		}

--- a/cmd/terramate/cli/script_info.go
+++ b/cmd/terramate/cli/script_info.go
@@ -12,6 +12,7 @@ import (
 	"github.com/fatih/color"
 	hhcl "github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/terramate-io/terramate/cloud"
 	cloudstack "github.com/terramate-io/terramate/cloud/stack"
 	"github.com/terramate-io/terramate/config"
 	"github.com/terramate-io/terramate/hcl"
@@ -24,7 +25,7 @@ import (
 func (c *cli) printScriptInfo() {
 	labels := c.parsedArgs.Script.Info.Cmds
 
-	stacks, err := c.computeSelectedStacks(false, "", cloudstack.NoFilter)
+	stacks, err := c.computeSelectedStacks(false, cloudstack.AnyTarget, cloud.NoStatusFilters())
 	if err != nil {
 		fatalWithDetails(err, "computing selected stacks")
 	}

--- a/cmd/terramate/cli/script_run.go
+++ b/cmd/terramate/cli/script_run.go
@@ -54,7 +54,14 @@ func (c *cli) runScript() {
 		stacks = append(stacks, st.Sortable())
 	} else {
 		var err error
-		stacks, err = c.computeSelectedStacks(true, c.parsedArgs.Script.Run.Target, parseStatusFilter(c.parsedArgs.Script.Run.Status))
+		statusFilter := parseStatusFilter(c.parsedArgs.Script.Run.Status)
+		deploymentFilter := parseDeploymentStatusFilter(c.parsedArgs.Script.Run.DeploymentStatus)
+		driftFilter := parseDriftStatusFilter(c.parsedArgs.Script.Run.DriftStatus)
+		stacks, err = c.computeSelectedStacks(true, c.parsedArgs.Script.Run.Target, cloud.StatusFilters{
+			StackStatus:      statusFilter,
+			DeploymentStatus: deploymentFilter,
+			DriftStatus:      driftFilter,
+		})
 		if err != nil {
 			fatalWithDetails(err, "failed to compute selected stacks")
 		}

--- a/e2etests/cloud/exp_trigger_cloud_test.go
+++ b/e2etests/cloud/exp_trigger_cloud_test.go
@@ -101,7 +101,7 @@ func TestCloudTriggerUnhealthy(t *testing.T) {
 			want: want{
 				trigger: RunExpected{
 					Status:      1,
-					StderrRegex: "unhealthy status filter does not work with filesystem based remotes",
+					StderrRegex: "status filters does not work with filesystem based remotes",
 				},
 			},
 		},


### PR DESCRIPTION
## What this PR does / why we need it:

Introduce `terramate [list,run] --[deployment,drift]-status=<status>` flags.

## Which issue(s) this PR fixes:
none

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
yes, adds a new feature.
```
