### PR TITLE
fix: trigger type not used in the filename.

### DIFF
--- a/stack/trigger/trigger.go
+++ b/stack/trigger/trigger.go
@@ -223,12 +223,12 @@ func Dir(rootdir string) string {
 	return filepath.Join(rootdir, triggersDir)
 }
 
-func triggerFilename() (string, error) {
+func triggerFilename(kind Kind) (string, error) {
 	id, err := uuid.NewRandom()
 	if err != nil {
 		return "", errors.E(err, "creating trigger UUID")
 	}
-	return fmt.Sprintf("changed-%s.tm.hcl", id.String()), nil
+	return fmt.Sprintf("%s-%s.tm.hcl", kind, id.String()), nil
 }
 
 // Create creates a trigger for a stack with the given path and the given reason
@@ -238,7 +238,7 @@ func Create(root *config.Root, path project.Path, kind Kind, reason string) erro
 	if !ok || !tree.IsStack() {
 		return errors.E(ErrTrigger, "path %s is not a stack directory", path)
 	}
-	filename, err := triggerFilename()
+	filename, err := triggerFilename(kind)
 	if err != nil {
 		return errors.E(ErrTrigger, err)
 	}

--- a/stack/trigger/trigger_test.go
+++ b/stack/trigger/trigger_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/madlambda/spells/assert"
@@ -126,6 +127,10 @@ func testTrigger(t *testing.T, tc testcase) {
 		t.Fatalf("want 1 trigger file, got %d: %+v", len(entries), entries)
 	}
 
+	filename := entries[0].Name()
+	if !strings.HasPrefix(filename, string(tc.kind)) {
+		t.Fatalf("wrong trigger filename: %s (it must have a %q prefix)", filename, tc.kind)
+	}
 	triggerFile := filepath.Join(triggerDir, entries[0].Name())
 	triggerInfo, err := trigger.ParseFile(triggerFile)
 


### PR DESCRIPTION
## What this PR does / why we need it:

When using `trigger --ignore-change` the filename has the pattern `changed-.*` instead of `ignore-change-.*`.

## Which issue(s) this PR fixes:
None

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
yes but no changelog entry is needed because this is unreleased.
```
