### PR TITLE
feat: add trigger --recursive flag.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 - Add `script.lets` block for declaring variables that are local to the script.
 - Add `--ignore-change` flag to `terramate experimental trigger`, which makes the change detection ignore the given stacks.
   - It inverts the default trigger behavior.
+- Add `--recursive` flag to `terramate experimental trigger` for triggering all child stacks of given path.
 
 ### Fixed
 

--- a/e2etests/internal/runner/runner.go
+++ b/e2etests/internal/runner/runner.go
@@ -287,8 +287,7 @@ func (tm CLI) ListChangedStacks(args ...string) RunResult {
 	return tm.ListStacks(append([]string{"--changed"}, args...)...)
 }
 
-// TriggerStack is a helper for executing `terramate experimental trigger`.
-func (tm CLI) TriggerStack(kind trigger.Kind, stack string) RunResult {
+func triggerKindFlag(kind trigger.Kind) string {
 	var kindFlag string
 	switch kind {
 	case trigger.Changed:
@@ -298,8 +297,25 @@ func (tm CLI) TriggerStack(kind trigger.Kind, stack string) RunResult {
 	default:
 		panic(fmt.Sprintf("unsupported trigger kind: %s", kind))
 	}
+	return kindFlag
+}
 
+// TriggerStack is a helper for executing `terramate experimental trigger`.
+func (tm CLI) TriggerStack(kind trigger.Kind, stack string) RunResult {
+	kindFlag := triggerKindFlag(kind)
 	return tm.Run([]string{"experimental", "trigger", kindFlag, stack}...)
+}
+
+// TriggerRecursively is a helper for executing `terramate experimental trigger --recursively`.
+func (tm CLI) TriggerRecursively(kind trigger.Kind, base string) RunResult {
+	return tm.Trigger(triggerKindFlag(kind), "--recursive", base)
+}
+
+// Trigger is a helper for executing `terramate experimental trigger ...`.
+func (tm CLI) Trigger(flags ...string) RunResult {
+	args := []string{"experimental", "trigger"}
+	args = append(args, flags...)
+	return tm.Run(args...)
 }
 
 // AssertRun asserts that the provided run result is successfully and with no output.


### PR DESCRIPTION
## What this PR does / why we need it:
Add a `--recursive` flag to `terramate experimental trigger` for triggering all stacks of a given base path.

## Which issue(s) this PR fixes:
none

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
yes, adds a new feature.
```
