### PR TITLE
fix: when targets experiment is disabled, the default must be used.

### DIFF
--- a/cmd/terramate/cli/cloud.go
+++ b/cmd/terramate/cli/cloud.go
@@ -516,12 +516,16 @@ func (c *cli) cloudDriftShow() {
 		}
 	})
 
+	if target == "" {
+		target = "default"
+	}
+
 	stackResp, found, err := c.cloud.client.GetStack(ctx, c.cloud.run.orgUUID, c.prj.prettyRepo(), target, st.ID)
 	if err != nil {
 		fatalWithDetails(err, "unable to fetch stack")
 	}
 	if !found {
-		if target != "" {
+		if target != "default" {
 			fatalf("Stack %s was not yet synced for target %s with the Terramate Cloud.", st.Dir.String(), target)
 		} else {
 			fatalf("Stack %s was not yet synced with the Terramate Cloud.", st.Dir.String())


### PR DESCRIPTION
## What this PR does / why we need it:

When targets experiment is disabled, the `default` target must be used in `terramate drift show`.

## Which issue(s) this PR fixes:
none

## Special notes for your reviewer:
This fixes an unreleased feature.
## Does this PR introduce a user-facing change?
```
no, because the feature is unreleased
```
