### PR TITLE
perf: avoid rescan of configuration.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -430,12 +430,17 @@ func loadTree(parentTree *Tree, cfgdir string, rootcfg *hcl.Config) (_ *Tree, er
 		rootcfg = &parentTree.RootTree().Node
 	}
 
-	if cfgdir != parentTree.RootDir() {
+	rootdir := parentTree.RootDir()
+	if cfgdir != rootdir {
 		tree := NewTree(cfgdir)
 
-		cfg, err := hcl.ParseDir(parentTree.RootDir(), cfgdir, rootcfg.Experiments()...)
+		cfg, err := hcl.ParseDir(rootdir, cfgdir, rootcfg.Experiments()...)
 		if err != nil {
 			return nil, err
+		}
+
+		if cfg.IsRootConfig() {
+			printer.Stderr.Warnf("root config found outside root dir: %s", cfgdir)
 		}
 
 		tree.Node = cfg

--- a/e2etests/core/general_test.go
+++ b/e2etests/core/general_test.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/terramate-io/terramate/cmd/terramate/cli"
 	. "github.com/terramate-io/terramate/e2etests/internal/runner"
 	"github.com/terramate-io/terramate/test"
 	"github.com/terramate-io/terramate/test/sandbox"
@@ -579,7 +578,7 @@ func TestE2ETerramateLogsWarningIfRootConfigIsNotAtProjectRoot(t *testing.T) {
 	tmcli.LogLevel = "warn"
 	AssertRunResult(t, tmcli.ListStacks(), RunExpected{
 		Stdout:      "stack\n",
-		StderrRegex: string(cli.ErrRootCfgInvalidDir),
+		StderrRegex: "root config found outside root dir",
 	})
 }
 

--- a/hcl/hcl.go
+++ b/hcl/hcl.go
@@ -852,6 +852,11 @@ func NewConfig(dir string) (Config, error) {
 	}, nil
 }
 
+// IsRootConfig tells if the Config is a root configuration.
+func (c Config) IsRootConfig() bool {
+	return c.Terramate != nil && c.Terramate.RequiredVersion != ""
+}
+
 // HasRunEnv returns true if the config has a terramate.config.run.env block defined
 func (c Config) HasRunEnv() bool {
 	return c.Terramate != nil &&


### PR DESCRIPTION
## What this PR does / why we need it:

A legacy code for detecting misconfiguration causes a rescan of the configuration tree while discovering the rootdir.

## Which issue(s) this PR fixes:
none

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
no
```
