### PR TITLE
fix: crash when tag list contains trailing comma

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 
 ## Unreleased
 
+### Fixed
+
+- Fix crash when supplying a tag list with a trailing comma separator.
+
 ## v0.9.0
 
 ### Added

--- a/config/filter/filter.go
+++ b/config/filter/filter.go
@@ -162,6 +162,9 @@ func parseTagClause(filter string) (TagClause, error) {
 	}
 	orBranches := strings.Split(filter, orSymbol)
 	for _, orNode := range orBranches {
+		if len(orNode) == 0 {
+			continue
+		}
 		andNodes := strings.Split(orNode, andSymbol)
 		if len(andNodes) == 1 {
 			op := EQ

--- a/config/filter/filter_test.go
+++ b/config/filter/filter_test.go
@@ -411,6 +411,22 @@ func TestFilterParserTags(t *testing.T) {
 			filters: []string{"valid:_invalid,validagain"},
 			err:     errors.E(tag.ErrInvalidTag),
 		},
+		{
+			filters: []string{"dont,crash,"},
+			want: TagClause{
+				Op: OR,
+				Children: []TagClause{
+					{
+						Op:  EQ,
+						Tag: "dont",
+					},
+					{
+						Op:  EQ,
+						Tag: "crash",
+					},
+				},
+			},
+		},
 	} {
 		t.Run(fmt.Sprintf("filters:%v", tc.filters), func(t *testing.T) {
 			got, hasClauses, err := parseInternalTagClauses(tc.filters...)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/terramate-io/terramate/blob/main/CONTRIBUTING.md
2. If the PR is unfinished, mark it as draft: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request
3. Please update the PR title using the Conventional Commits convention: https://www.conventionalcommits.org/en/v1.0.0/
    Example: feat: add support for XYZ.
-->

## What this PR does / why we need it:

This PR fixes a crash due to a missing bounds check when parsing a tag list that contains a trailing comma.

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Keep it empty if not applicable.
-->

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
<!--
If no, just write "no" in the block below.
If yes, please explain the change and update documentation and the CHANGELOG.md file accordingly.
-->
```
no
```
