### PR TITLE
fix: create --all-terragrunt creates Terragrunt stacks with cycles.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 ### Fixed
 
 - Fix the command-line parsing of `run` and `script run` which were not failing from unknown flags.
+- Fix `create --all-terragrunt` creating Terragrunt stacks with cycles.
 
 ## v0.11.3
 


### PR DESCRIPTION
## What this PR does / why we need it:

When Terragrunt modules are nested, Terramate generates stacks with `after` references to parent stacks, then creates a cycle because child stacks have an implicit dependency on parent stacks.

## Which issue(s) this PR fixes:
Closes #1774 

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
yes, fixes a bug.
```
