### PR TITLE
chore: increase linting timeout.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,3 +14,6 @@ issues:
   exclude:
     - EXC0012
   exclude-use-default: false
+
+run:
+  timeout: 15m


### PR DESCRIPTION
## What this PR does / why we need it:

The default 5 minutes linting timeout is not enough anymore for Terramate. We are having sporadic Ci runs failing on main.

## Which issue(s) this PR fixes:
none
## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
no
```
