### PR TITLE
feat(cloud): sync plan serial with changeset data

### DIFF
--- a/cloud/types.go
+++ b/cloud/types.go
@@ -81,6 +81,7 @@ type (
 		Provisioner    string `json:"provisioner"`
 		ChangesetASCII string `json:"changeset_ascii,omitempty"`
 		ChangesetJSON  string `json:"changeset_json,omitempty"`
+		Serial         *int64 `json:"serial,omitempty"`
 	}
 
 	// StacksResponse represents the stacks object response.

--- a/e2etests/cloud/run_script_cloud_drift_test.go
+++ b/e2etests/cloud/run_script_cloud_drift_test.go
@@ -36,6 +36,10 @@ func TestScriptRunDriftStatus(t *testing.T) {
 		want          want
 	}
 
+	makeSerial := func(serial int64) *int64 {
+		return &serial
+	}
+
 	absPlanFilePath := test.WriteFile(t, test.TempDir(t), "out.tfplan", ``)
 	absPlanFilePathAsHCL := fmt.Sprintf(`${tm_chomp(<<-EOF
 		%s
@@ -398,6 +402,7 @@ func TestScriptRunDriftStatus(t *testing.T) {
 							Details: &cloud.ChangesetDetails{
 								Provisioner:   "terraform",
 								ChangesetJSON: loadJSONPlan(t, "testdata/cloud-sync-drift-plan-file/sanitized.plan.json"),
+								Serial:        makeSerial(0),
 							},
 							Metadata: expectedMetadata,
 						},
@@ -420,6 +425,7 @@ func TestScriptRunDriftStatus(t *testing.T) {
 							Details: &cloud.ChangesetDetails{
 								Provisioner:   "terraform",
 								ChangesetJSON: loadJSONPlan(t, "testdata/cloud-sync-drift-plan-file/sanitized.plan.json"),
+								Serial:        makeSerial(0),
 							},
 							Metadata: expectedMetadata,
 						},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/terramate-io/terramate/blob/main/CONTRIBUTING.md
2. If the PR is unfinished, mark it as draft: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request
3. Please update the PR title using the Conventional Commits convention: https://www.conventionalcommits.org/en/v1.0.0/
    Example: feat: add support for XYZ.
-->

## What this PR does / why we need it:

This PR sends the serial from the Terraform tfstate alongside the changeset details. This allows TMC to potentially discard data from older plans that would otherwise replace newer data.

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Keep it empty if not applicable.
-->

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
<!--
If no, just write "no" in the block below.
If yes, please explain the change and update documentation and the CHANGELOG.md file accordingly.
-->
```
no
```
