### PR TITLE
fix(gitlab): missing GITLAB_CI check in scripts.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 
 ## Unreleased
 
+### Fixed
+
+- Fix a missing check for `GITLAB_CI` environment variable.
+  - The previews feature can only be used in _Github Actions_ and _Gitlab CI/CD_ and a check for the latter was missing.
+
+
 ## v0.9.2
 
 ### Changed

--- a/cmd/terramate/cli/script_run.go
+++ b/cmd/terramate/cli/script_run.go
@@ -179,9 +179,11 @@ func (c *cli) prepareScriptForCloudSync(runs []stackRun) {
 		feats = append(feats, cloudFeatScriptSyncPreview)
 	}
 
-	if len(previewRuns) > 0 && os.Getenv("GITHUB_ACTIONS") == "" {
+	isCI := os.Getenv("GITHUB_ACTIONS") != "" || os.Getenv("GITLAB_CI") != ""
+	if len(previewRuns) > 0 && !isCI {
 		printer.Stderr.Warn(cloudSyncPreviewCICDWarning)
 		c.disableCloudFeatures(errors.E(cloudSyncPreviewCICDWarning))
+		return
 	}
 
 	if !c.prj.isRepo {


### PR DESCRIPTION
## What this PR does / why we need it:

When using `terramate script` there's a missing check for `GITLAB_CI` which prevents previews from being created.

You can circumvent the issue for now if you export `GITHUB_ACTIONS=1` in the Gitlab pipeline.

## Which issue(s) this PR fixes:
none
## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
yes
```
