### PR TITLE
fix(gitlab): commit SHA must come from the GitLab API.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 
 - Fix a missing check for `GITLAB_CI` environment variable.
   - The previews feature can only be used in _Github Actions_ and _Gitlab CI/CD_ and a check for the latter was missing.
-
+- Fix the synchronization of the GitLab Merge Request commit SHA.
 
 ## v0.9.2
 

--- a/cmd/terramate/cli/cloud.go
+++ b/cmd/terramate/cli/cloud.go
@@ -1243,7 +1243,7 @@ func (c *cli) newGitlabReviewRequest(mr gitlab.MR) *cloud.ReviewRequest {
 		Number:      mr.IID,
 		Title:       mr.Title,
 		Description: mr.Description,
-		CommitSHA:   c.prj.headCommit(),
+		CommitSHA:   mr.SHA,
 		Draft:       mr.Draft,
 		CreatedAt:   mrCreatedAt,
 		PushedAt:    c.cloud.run.rrEvent.pushedAt,


### PR DESCRIPTION
## What this PR does / why we need it:

The commit SHA used in the ReviewRequest payload must come from the Gitlab API.

## Which issue(s) this PR fixes:
none

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
yes, fixes the deployment review request in TMC sync.
```
