### PR TITLE
fix(gitlab): only set rr.pushed_at in previews.

### DIFF
--- a/cmd/terramate/cli/cloud.go
+++ b/cmd/terramate/cli/cloud.go
@@ -1246,7 +1246,6 @@ func (c *cli) newGitlabReviewRequest(mr gitlab.MR) *cloud.ReviewRequest {
 		CommitSHA:   mr.SHA,
 		Draft:       mr.Draft,
 		CreatedAt:   mrCreatedAt,
-		PushedAt:    c.cloud.run.rrEvent.pushedAt,
 		UpdatedAt:   &mrUpdatedAt,
 		Status:      mr.State,
 		Author: cloud.Author{
@@ -1255,6 +1254,7 @@ func (c *cli) newGitlabReviewRequest(mr gitlab.MR) *cloud.ReviewRequest {
 		},
 		Branch:     mr.SourceBranch,
 		BaseBranch: mr.TargetBranch,
+		// Note(i4k): PushedAt will be set only in previews.
 	}
 
 	for _, l := range mr.Labels {

--- a/cmd/terramate/cli/run.go
+++ b/cmd/terramate/cli/run.go
@@ -617,6 +617,8 @@ func (c *cli) createCloudPreview(runs []stackCloudRun, target, fromTarget string
 		return map[string]string{}
 	}
 
+	c.cloud.run.reviewRequest.PushedAt = c.cloud.run.rrEvent.pushedAt
+
 	technology := "other"
 	technologyLayer := "default"
 	for _, run := range runs {


### PR DESCRIPTION
## What this PR does / why we need it:

The `pushed_at` information cannot be obtained in drifts or deployments.

## Which issue(s) this PR fixes:
none

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
no
```
