### PR TITLE
feat: add output block parser.

### DIFF
--- a/hcl/hcl.go
+++ b/hcl/hcl.go
@@ -80,6 +80,7 @@ type Config struct {
 	Scripts         []*Script
 	SharingBackends SharingBackends
 	Inputs          Inputs
+	Outputs         Outputs
 
 	Imported RawConfig
 
@@ -117,6 +118,9 @@ type SharingBackends []SharingBackend
 // Inputs is a list of Input blocks.
 type Inputs []Input
 
+// Outputs is a list of Output blocks.
+type Outputs []Output
+
 // SharingBackend holds the parsed values for the `sharing_backend` block.
 type SharingBackend struct {
 	Name     string
@@ -133,6 +137,15 @@ type Input struct {
 	Value       hcl.Expression
 	Sensitive   hcl.Expression
 	Mock        hcl.Expression
+}
+
+// Output holds the parsed value for the `output` block.
+type Output struct {
+	Name        string
+	Backend     hcl.Expression
+	Description hcl.Expression
+	Value       hcl.Expression
+	Sensitive   hcl.Expression
 }
 
 // These are the valid sharing_backend types.
@@ -2251,6 +2264,13 @@ func (p *TerramateParser) parseTerramateSchema() (Config, error) {
 				continue
 			}
 			config.Inputs = append(config.Inputs, input)
+		case "output":
+			output, err := p.parseOutput(block)
+			if err != nil {
+				errs.Append(err)
+				continue
+			}
+			config.Outputs = append(config.Outputs, output)
 		}
 	}
 

--- a/hcl/raw_config.go
+++ b/hcl/raw_config.go
@@ -49,6 +49,7 @@ func NewTopLevelRawConfig() RawConfig {
 		"import":          func(r *RawConfig, b *ast.Block) error { return nil },
 		"sharing_backend": (*RawConfig).addBlock,
 		"input":           (*RawConfig).addBlock,
+		"output":          (*RawConfig).addBlock,
 	})
 }
 

--- a/test/hcl.go
+++ b/test/hcl.go
@@ -85,7 +85,7 @@ func AssertTerramateConfig(t *testing.T, got, want hcl.Config) {
 		cmpopts.IgnoreFields(hcl.Config{}, "Imported"),
 
 		// Globals/Asserts/Scripts are mostly Attribute and Expr, which cannot be easily compared with cmp.Diff.
-		cmpopts.IgnoreFields(hcl.Config{}, "Globals", "Asserts", "Scripts", "Inputs"),
+		cmpopts.IgnoreFields(hcl.Config{}, "Globals", "Asserts", "Scripts", "Inputs", "Outputs"),
 		cmpopts.IgnoreFields(hcl.RunEnv{}, "Attributes"), // because Expr and Range
 		cmpopts.IgnoreFields(hcl.Config{}, "Generate"),
 	); diff != "" {


### PR DESCRIPTION
## What this PR does / why we need it:

Add the parser for the `output` block.
This is part of a new feature for sharing the output of stacks.

## Which issue(s) this PR fixes:
none

## Special notes for your reviewer:

Depends on #1802 

## Does this PR introduce a user-facing change?
```
yes.
```
