### PR TITLE
fix(generate): deletion of orphaned sharing files.

### DIFF
--- a/generate/generate.go
+++ b/generate/generate.go
@@ -1267,7 +1267,7 @@ func loadStackCodeCfgs(
 		if !ok {
 			return nil, errors.E("backend %s not found", backendName)
 		}
-		sharingFile, err := sharing.PrepareFile(backend.Filename, file.inputs, file.outputs)
+		sharingFile, err := sharing.PrepareFile(root, backend.Filename, file.inputs, file.outputs)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## What this PR does / why we need it:

Fixes the deletion of orphaned files configured by input/output blocks.
Depends on #1812 

## Which issue(s) this PR fixes:
none
## Special notes for your reviewer:

Depends #1812 

## Does this PR introduce a user-facing change?
```
no, the feature is not released.
```
