### PR TITLE
refactor: rename script attr to mock_on_fail.

### DIFF
--- a/config/script.go
+++ b/config/script.go
@@ -441,7 +441,7 @@ func unmarshalScriptCommandOptions(obj cty.Value, expr hhcl.Expression) (*Script
 			}
 			r.EnableSharing = v.True()
 
-		case "mock_sharing_on_fail":
+		case "mock_on_fail":
 			if v.Type() != cty.Bool {
 				errs.Append(errors.E(ErrScriptInvalidCmdOptions, expr.Range(),
 					"command option '%s' must be a bool, but has type %s",

--- a/e2etests/core/run_sharing_test.go
+++ b/e2etests/core/run_sharing_test.go
@@ -349,7 +349,7 @@ func TestRunSharing(t *testing.T) {
 								Expr("command", `[
 							"terraform", "apply", "-auto-approve", {
 								enable_sharing = true
-								mock_sharing_on_fail = true
+								mock_on_fail = true
 							}
 						]`),
 							),


### PR DESCRIPTION
## What this PR does / why we need it:

Renamed `mock_sharing_on_fail` -> `mock_on_fail` in the scripts command attribute.

## Which issue(s) this PR fixes:
none
## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
yes but the feature is not released.
```
