### PR TITLE
chore: increase go test timeout.

### DIFF
--- a/makefiles/unix.mk
+++ b/makefiles/unix.mk
@@ -38,7 +38,7 @@ test/helper:
 tempdir=$(shell ./bin/helper tempdir)
 test: test/helper build
 # 	Using `terramate` because it detects and fails if the generated files are outdated.
-	TM_TEST_ROOT_TEMPDIR=$(tempdir) ./bin/terramate run --no-recursive -- go test -race -count=1 ./...
+	TM_TEST_ROOT_TEMPDIR=$(tempdir) ./bin/terramate run --no-recursive -- go test -race -count=1 -timeout 30m ./...
 	./bin/helper rm $(tempdir)
 
 ## test/interop

--- a/makefiles/windows.mk
+++ b/makefiles/windows.mk
@@ -33,7 +33,7 @@ test/helper:
 tempdir=$(shell .\bin\helper.exe tempdir)
 test: test/helper build
 	set TM_TEST_ROOT_TEMPDIR=$(tempdir)
-	go test -timeout 20m -p 100 ./...
+	go test -timeout 30m -p 100 ./...
 	.\bin\helper.exe rm $(tempdir)
 	.\bin\terramate.exe run -- helper.exe true
 


### PR DESCRIPTION
The e2e `outputs-sharing` tests are slower due to the amount of commands executed by terramate in involved stacks, which made tests around 30% slower in my laptop.