### PR TITLE
fix: release locking resource when continuing through run loop

### DIFF
--- a/cmd/terramate/cli/run.go
+++ b/cmd/terramate/cli/run.go
@@ -530,6 +530,7 @@ func (c *cli) runAll(
 			select {
 			case <-cancelCtx.Done():
 				c.cloudSyncAfter(cloudRun, runResult{ExitCode: -1}, errors.E(ErrRunCanceled))
+				releaseResource()
 				continue
 			default:
 			}
@@ -579,6 +580,7 @@ func (c *cli) runAll(
 			}
 
 			if opts.DryRun {
+				releaseResource()
 				continue
 			}
 


### PR DESCRIPTION
## What this PR does / why we need it:
Parallel tasks executed by `terramate run` do not release their lock when continuing through the run loop, preventing other tasks from running or exiting when `parallelism < num. tasks`. This occurs during both context cancellation and dry runs. PR ensures that the lock is released under these conditions so that the program is able to terminate.

Tested locally.

## Which issue(s) this PR fixes:

Fixes #1828 

## Special notes for your reviewer:
TIA 🙂 

## Does this PR introduce a user-facing change?
No

