### PR TITLE
fix: release locking resource when continuing through run loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 
 - Fix the repository normalization for Gitlab subgroups.
   - Now it supports repository URLs like `https://gitlab.com/my-company-name/my-group-name/my-other-group/repo-name`.
+- Fix a deadlock in the `terramate run` and `terramate script run` parallelism by
+  releasing the resources in case of errors or if dry-run mode is enabled.
 
 ## v0.10.0
 

--- a/cmd/terramate/cli/run.go
+++ b/cmd/terramate/cli/run.go
@@ -530,6 +530,7 @@ func (c *cli) runAll(
 			select {
 			case <-cancelCtx.Done():
 				c.cloudSyncAfter(cloudRun, runResult{ExitCode: -1}, errors.E(ErrRunCanceled))
+				releaseResource()
 				continue
 			default:
 			}
@@ -579,6 +580,7 @@ func (c *cli) runAll(
 			}
 
 			if opts.DryRun {
+				releaseResource()
 				continue
 			}
 


### PR DESCRIPTION
## What this PR does / why we need it:

At the moment, we can't run pipelines from fork contributions, then we need to cherry-pick the commits in a separate PR, to run CI and merge the contribution. The original authorship is kept.

## Which issue(s) this PR fixes:
none

## Special notes for your reviewer:

This apply the contribution from #1830 and add a CHANGELOG entry.

## Does this PR introduce a user-facing change?
```
yes, fixes a deadlock in the orchestration.
```
