### PR TITLE
Backport: fix: release locking resource when continuing through run loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 
 - Fix the repository normalization for Gitlab subgroups.
   - Now it supports repository URLs like `https://gitlab.com/my-company-name/my-group-name/my-other-group/repo-name`.
+- Fix a deadlock in the `terramate run` and `terramate script run` parallelism by
+  releasing the resources in case of errors or if dry-run mode is enabled.
 
 
 ## v0.9.4

--- a/cmd/terramate/cli/run.go
+++ b/cmd/terramate/cli/run.go
@@ -392,6 +392,7 @@ func (c *cli) runAll(
 			select {
 			case <-cancelCtx.Done():
 				c.cloudSyncAfter(cloudRun, runResult{ExitCode: -1}, errors.E(ErrRunCanceled))
+				releaseResource()
 				continue
 			default:
 			}
@@ -443,6 +444,7 @@ func (c *cli) runAll(
 			}
 
 			if opts.DryRun {
+				releaseResource()
 				continue
 			}
 


### PR DESCRIPTION
Backport #1831 to v0.9.x