### PR TITLE
Backport: fix(parallel): deadlock in case command does not exist

### DIFF
--- a/cmd/terramate/cli/run.go
+++ b/cmd/terramate/cli/run.go
@@ -407,6 +407,7 @@ func (c *cli) runAll(
 			if err != nil {
 				c.cloudSyncAfter(cloudRun, runResult{ExitCode: -1}, errors.E(ErrRunCommandNotFound, err))
 				errs.Append(errors.E(err, "running `%s` in stack %s", cmdStr, run.Stack.Dir))
+				releaseResource()
 				if continueOnError {
 					break
 				}


### PR DESCRIPTION
Backport #1832 to v0.9.x

Note: The PR was adjusted because "sharing-outputs" experiment is only in v0.10.x