### PR TITLE
fix(tmc): outputs sharing failure cases not synced to TMC.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,11 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 - Backward compatibility in versions `0.0.z` is **not guaranteed** when `z` is increased.
 - Backward compatibility in versions `0.y.z` is **not guaranteed** when `y` is increased.
 
-# Unreleased
+## Unreleased
+
+### Fixed
+
+- Fix `outputs-sharing` failure cases not synchronizing to Terramate Cloud.
 
 ## v0.10.1
 

--- a/cmd/terramate/cli/cloud_sync_deployment.go
+++ b/cmd/terramate/cli/cloud_sync_deployment.go
@@ -135,7 +135,7 @@ func (c *cli) cloudSyncDeployment(run stackCloudRun, err error) {
 		status = deployment.OK
 	case errors.IsKind(err, ErrRunCanceled):
 		status = deployment.Canceled
-	case errors.IsAnyKind(err, ErrRunFailed, ErrRunCommandNotFound):
+	case errors.IsAnyKind(err, ErrRunFailed, ErrRunCommandNotExecuted):
 		status = deployment.Failed
 	default:
 		panic(errors.E(errors.ErrInternal, "unexpected run status"))

--- a/cmd/terramate/cli/cloud_sync_drift.go
+++ b/cmd/terramate/cli/cloud_sync_drift.go
@@ -31,7 +31,7 @@ func (c *cli) cloudSyncDriftStatus(run stackCloudRun, res runResult, err error) 
 		status = drift.OK
 	case res.ExitCode == 2:
 		status = drift.Drifted
-	case res.ExitCode == 1 || res.ExitCode > 2 || errors.IsAnyKind(err, ErrRunCommandNotFound, ErrRunFailed):
+	case res.ExitCode == 1 || res.ExitCode > 2 || errors.IsAnyKind(err, ErrRunCommandNotExecuted, ErrRunFailed):
 		status = drift.Failed
 	default:
 		// ignore exit codes < 0

--- a/cmd/terramate/cli/script_run.go
+++ b/cmd/terramate/cli/script_run.go
@@ -136,6 +136,9 @@ func (c *cli) runScript() {
 						task.MockOnFail = cmd.Options.MockOnFail
 					}
 					run.Tasks = append(run.Tasks, task)
+					if task.CloudSyncDeployment || task.CloudSyncDriftStatus || task.CloudSyncPreview {
+						run.SyncTaskIndex = len(run.Tasks) - 1
+					}
 				}
 			}
 

--- a/config/sharing_backend_test.go
+++ b/config/sharing_backend_test.go
@@ -149,7 +149,7 @@ func TestEvalSharingBackendInput(t *testing.T) {
 				return
 			}
 			// ignoring info.Range comparisons for now
-			if diff := cmp.Diff(tcase.want, got, cmpopts.IgnoreUnexported(info.Range{}, config.Input{}), cmpopts.IgnoreFields(config.Input{}, "Mock")); diff != "" {
+			if diff := cmp.Diff(tcase.want, got, cmpopts.IgnoreUnexported(info.Range{}, config.Input{})); diff != "" {
 				t.Fatalf("unexpected result\n%s", diff)
 			}
 			gotval, err := got.Value(hclctx)

--- a/e2etests/cloud/run_cloud_deployment_test.go
+++ b/e2etests/cloud/run_cloud_deployment_test.go
@@ -92,7 +92,7 @@ func TestCLIRunWithCloudSyncDeployment(t *testing.T) {
 			},
 		},
 		{
-			name:   "failed cmd cancels execution of subsequent stacks",
+			name:   "command not found cancels execution of subsequent stacks",
 			layout: []string{"s:s1:id=s1", "s:s1/s2:id=s2"},
 			cmd:    []string{"non-existent-command"},
 			want: want{
@@ -102,6 +102,21 @@ func TestCLIRunWithCloudSyncDeployment(t *testing.T) {
 				},
 				events: eventsResponse{
 					"s1": []string{"pending", "failed"},
+					"s2": []string{"pending", "canceled"},
+				},
+			},
+		},
+		{
+			name:   "failed cmd cancels execution of subsequent stacks",
+			layout: []string{"s:s1:id=s1", "s:s1/s2:id=s2"},
+			cmd:    []string{HelperPath, "exit", "1"},
+			want: want{
+				run: RunExpected{
+					Status:      1,
+					StderrRegex: "one or more commands failed",
+				},
+				events: eventsResponse{
+					"s1": []string{"pending", "running", "failed"},
 					"s2": []string{"pending", "canceled"},
 				},
 			},


### PR DESCRIPTION
## What this PR does / why we need it:

It fixes the `outputs-sharing` experiment not synchronizing failure cases to Terramate Cloud.

## Which issue(s) this PR fixes:
none
## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
yes, fixes a bug in v0.10.1
```
