### PR TITLE
feat: add toml encoder/decoder functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 - Add `tm_endswith(string, suffix)`.
 - Add `tm_timecmp(t1, t2)`.
 - Add `tm_cidrcontains(cidr, ip)`
+- Add experimental support for `tm_tomlencode` and `tm_tomldecode`.
+  - Can be enabled with `terramate.config.experiments = ["toml-functions"]`.
 
 ## v0.10.1
 

--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -2258,7 +2258,7 @@ func (c *cli) setupEvalContext(st *config.Stack, overrideGlobals map[string]stri
 		tdir = c.wd()
 	}
 
-	ctx := eval.NewContext(stdlib.NoFS(tdir))
+	ctx := eval.NewContext(stdlib.NoFS(tdir, c.rootNode().Experiments()))
 	ctx.SetNamespace("terramate", runtime)
 
 	wdPath := prj.PrjAbsPath(c.rootdir(), tdir)

--- a/cmd/terramate/cli/script_run.go
+++ b/cmd/terramate/cli/script_run.go
@@ -250,7 +250,7 @@ func scriptEvalContext(root *config.Root, st *config.Stack, target string) (*eva
 		return nil, err
 	}
 
-	evalctx := eval.NewContext(stdlib.Functions(st.HostDir(root)))
+	evalctx := eval.NewContext(stdlib.Functions(st.HostDir(root), root.Tree().Node.Experiments()))
 	runtime := root.Runtime()
 	runtime.Merge(st.RuntimeValues(root))
 

--- a/config/assert_test.go
+++ b/config/assert_test.go
@@ -175,7 +175,7 @@ func TestAssertConfigEval(t *testing.T) {
 		tcase := tcase
 		t.Run(tcase.name, func(t *testing.T) {
 			t.Parallel()
-			hclctx := eval.NewContext(stdlib.Functions(test.TempDir(t)))
+			hclctx := eval.NewContext(stdlib.Functions(test.TempDir(t), []string{}))
 
 			for k, v := range tcase.namespaces {
 				hclctx.SetNamespace(k, v.asCtyMap())

--- a/config/script_lets_test.go
+++ b/config/script_lets_test.go
@@ -336,7 +336,7 @@ func TestScriptLetsEval(t *testing.T) {
 
 func TestScriptLetsArelocalToTheirBlocks(t *testing.T) {
 	tempdir := test.TempDir(t)
-	hclctx := eval.NewContext(stdlib.Functions(tempdir))
+	hclctx := eval.NewContext(stdlib.Functions(tempdir, []string{}))
 	test.AppendFile(t, tempdir, "script.tm", Doc(
 		Script(
 			Labels("deploy1"),

--- a/config/script_test.go
+++ b/config/script_test.go
@@ -742,7 +742,7 @@ func testScriptEval(t *testing.T, tcase scriptTestcase) {
 
 	st, err := rootTree.Stack()
 	assert.NoError(t, err)
-	hclctx := eval.NewContext(stdlib.Functions(tempdir))
+	hclctx := eval.NewContext(stdlib.Functions(tempdir, []string{}))
 	hclctx.SetNamespace("global", tcase.globals)
 	runtime := cfg.Runtime()
 	runtime.Merge(st.RuntimeValues(cfg))

--- a/config/sharing_backend_test.go
+++ b/config/sharing_backend_test.go
@@ -129,7 +129,7 @@ func TestEvalSharingBackendInput(t *testing.T) {
 
 			st, err := rootTree.Stack()
 			assert.NoError(t, err)
-			hclctx := eval.NewContext(stdlib.Functions(tempdir))
+			hclctx := eval.NewContext(stdlib.Functions(tempdir, []string{}))
 			hclctx.SetNamespace("global", tcase.globals)
 			runtime := cfg.Runtime()
 			runtime.Merge(st.RuntimeValues(cfg))
@@ -231,7 +231,7 @@ func TestEvalSharingBackendOutput(t *testing.T) {
 
 			st, err := rootTree.Stack()
 			assert.NoError(t, err)
-			hclctx := eval.NewContext(stdlib.Functions(tempdir))
+			hclctx := eval.NewContext(stdlib.Functions(tempdir, []string{}))
 			hclctx.SetNamespace("global", tcase.globals)
 			runtime := cfg.Runtime()
 			runtime.Merge(st.RuntimeValues(cfg))

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -123,7 +123,7 @@ func Load(root *config.Root, vendorDir project.Path) ([]LoadResult, error) {
 			continue
 		}
 		res := LoadResult{Dir: dircfg.Dir()}
-		evalctx := eval.NewContext(stdlib.Functions(dircfg.HostDir()))
+		evalctx := eval.NewContext(stdlib.Functions(dircfg.HostDir(), root.Tree().Node.Experiments()))
 
 		var generated []GenFile
 		for _, block := range dircfg.Node.Generate.Files {
@@ -332,7 +332,7 @@ func doRootGeneration(root *config.Root, tree *config.Tree) Report {
 		Logger()
 
 	report := Report{}
-	evalctx := eval.NewContext(stdlib.Functions(root.HostDir()))
+	evalctx := eval.NewContext(stdlib.Functions(root.HostDir(), root.Tree().Node.Experiments()))
 	evalctx.SetNamespace("terramate", root.Runtime())
 
 	var files []GenFile

--- a/globals/stack.go
+++ b/globals/stack.go
@@ -12,7 +12,7 @@ import (
 // ForStack loads from the config tree all globals defined for a given stack.
 func ForStack(root *config.Root, stack *config.Stack) EvalReport {
 	ctx := eval.NewContext(
-		stdlib.Functions(stack.HostDir(root)),
+		stdlib.Functions(stack.HostDir(root), root.Tree().Node.Experiments()),
 	)
 	runtime := root.Runtime()
 	runtime.Merge(stack.RuntimeValues(root))

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/terramate-io/terramate
 
-go 1.21
+go 1.21.0
 
-toolchain go1.21.5
+toolchain go1.22.3
 
 require (
 	github.com/alecthomas/kong v0.7.1
@@ -24,6 +24,7 @@ require (
 	github.com/hectane/go-acl v0.0.0-20190604041725-da78bae5fc95
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/madlambda/spells v0.4.2
+	github.com/pelletier/go-toml/v2 v2.2.3
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/posener/complete v1.2.3
 	github.com/shurcooL/githubv4 v0.0.0-20240120211514-18a1ae0e79dc
@@ -202,3 +203,5 @@ require (
 	golang.org/x/sys v0.21.0
 	golang.org/x/text v0.16.0 // indirect
 )
+
+replace github.com/hashicorp/hcl/v2 v2.20.1 => github.com/opentofu/hcl/v2 v2.0.0-20240814143621-8048794c5c52

--- a/go.sum
+++ b/go.sum
@@ -852,6 +852,8 @@ github.com/ory/dockertest/v3 v3.10.0 h1:4K3z2VMe8Woe++invjaTB7VRyQXQy5UY+loujO4a
 github.com/ory/dockertest/v3 v3.10.0/go.mod h1:nr57ZbRWMqfsdGdFNLHz5jjNdDb7VVFnzAeW1n5N1Lg=
 github.com/packer-community/winrmcp v0.0.0-20180921211025-c76d91c1e7db/go.mod h1:f6Izs6JvFTdnRbziASagjZ2vmf55NSIkC/weStxCHqk=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
+github.com/pelletier/go-toml/v2 v2.2.3 h1:YmeHyLY8mFWbdkNWwpr+qIL2bEqT0o95WSdkNHvL12M=
+github.com/pelletier/go-toml/v2 v2.2.3/go.mod h1:MfCQTFTvCcUyyvvwm1+G6H/jORL20Xlb6rzQu9GuUkc=
 github.com/pjbgf/sha1cd v0.3.0 h1:4D5XXmUUBUl/xQ6IjCkEAbqXskkq/4O7LmGn0AqMDs4=
 github.com/pjbgf/sha1cd v0.3.0/go.mod h1:nZ1rrWOcGJ5uZgEEVL1VUM9iRQiZvWdbZjkKyFzPPsI=
 github.com/pkg/browser v0.0.0-20201207095918-0426ae3fba23/go.mod h1:N6UoU20jOqggOuDwUaBQpluzLNDqif3kq9z2wpdYEfQ=

--- a/hcl/eval/eval_test.go
+++ b/hcl/eval/eval_test.go
@@ -79,7 +79,7 @@ func TestEvalTmFuncall(t *testing.T) {
 			if basedir == "" {
 				basedir = root(t)
 			}
-			ctx := eval.NewContext(stdlib.Functions(basedir))
+			ctx := eval.NewContext(stdlib.Functions(basedir, []string{}))
 
 			const attrname = "value"
 

--- a/hcl/eval/partial_eval_bench_test.go
+++ b/hcl/eval/partial_eval_bench_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func setupContext() *eval.Context {
-	ctx := eval.NewContext(stdlib.Functions(os.TempDir()))
+	ctx := eval.NewContext(stdlib.Functions(os.TempDir(), []string{}))
 	ctx.SetNamespace("global", map[string]cty.Value{
 		"true":   cty.True,
 		"false":  cty.False,

--- a/hcl/eval/partial_eval_test.go
+++ b/hcl/eval/partial_eval_test.go
@@ -484,8 +484,8 @@ EOT
 	} {
 		tc := tc
 		t.Run(tc.expr, func(t *testing.T) {
-			//t.Parallel()
-			ctx := eval.NewContext(stdlib.Functions(os.TempDir()))
+			t.Parallel()
+			ctx := eval.NewContext(stdlib.Functions(os.TempDir(), []string{}))
 			ctx.SetNamespace("global", map[string]cty.Value{
 				"number": cty.NumberIntVal(10),
 				"string": cty.StringVal("terramate"),

--- a/hcl/hcl.go
+++ b/hcl/hcl.go
@@ -478,7 +478,7 @@ func NewTerramateParser(rootdir string, dir string, experiments ...string) (*Ter
 		files:       map[string][]byte{},
 		hclparser:   hclparse.NewParser(),
 		parsedFiles: make(map[string]parsedFile),
-		evalctx:     eval.NewContext(stdlib.Functions(dir)),
+		evalctx:     eval.NewContext(stdlib.Functions(dir, experiments)),
 	}, nil
 }
 

--- a/run/env.go
+++ b/run/env.go
@@ -49,7 +49,7 @@ func LoadEnv(root *config.Root, st *config.Stack) (EnvVars, error) {
 		return nil, errors.E(ErrLoadingGlobals, err)
 	}
 
-	evalctx := eval.NewContext(stdlib.Functions(st.HostDir(root)))
+	evalctx := eval.NewContext(stdlib.Functions(st.HostDir(root), root.Tree().Node.Experiments()))
 	runtime := root.Runtime()
 	runtime.Merge(st.RuntimeValues(root))
 	evalctx.SetNamespace("terramate", runtime)

--- a/stack/eval.go
+++ b/stack/eval.go
@@ -18,7 +18,7 @@ type EvalCtx struct {
 
 // NewEvalCtx creates a new stack evaluation context.
 func NewEvalCtx(root *config.Root, stack *config.Stack, globals *eval.Object) *EvalCtx {
-	evalctx := eval.NewContext(stdlib.Functions(stack.HostDir(root)))
+	evalctx := eval.NewContext(stdlib.Functions(stack.HostDir(root), root.Tree().Node.Experiments()))
 	evalwrapper := &EvalCtx{
 		Context: evalctx,
 		root:    root,

--- a/stdlib/funcs.go
+++ b/stdlib/funcs.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 
 	resyntax "regexp/syntax"
@@ -34,7 +35,7 @@ func init() {
 
 // Functions returns all the Terramate default functions.
 // The `basedir` must be an absolute path for an existent directory or it panics.
-func Functions(basedir string) map[string]function.Function {
+func Functions(basedir string, experiments []string) map[string]function.Function {
 	if !filepath.IsAbs(basedir) {
 		panic(errors.E(errors.ErrInternal, "context created with relative path: %q", basedir))
 	}
@@ -75,13 +76,18 @@ func Functions(basedir string) map[string]function.Function {
 	tmfuncs["tm_try"] = TryFunc()
 
 	tmfuncs["tm_version_match"] = VersionMatch()
+
+	if slices.Contains(experiments, "toml-functions") {
+		tmfuncs["tm_tomlencode"] = TomlEncode()
+		tmfuncs["tm_tomldecode"] = TomlDecode()
+	}
 	return tmfuncs
 }
 
 // NoFS returns all Terramate functions but excluding fs-related
 // functions.
-func NoFS(basedir string) map[string]function.Function {
-	funcs := Functions(basedir)
+func NoFS(basedir string, experiments []string) map[string]function.Function {
+	funcs := Functions(basedir, experiments)
 	fsFuncNames := []string{
 		"tm_abspath",
 		"tm_file",

--- a/stdlib/funcs_bench_test.go
+++ b/stdlib/funcs_bench_test.go
@@ -16,7 +16,7 @@ import (
 
 func BenchmarkTmAllTrueLiteralList(b *testing.B) {
 	b.StopTimer()
-	evalctx := eval.NewContext(stdlib.Functions(test.TempDir(b)))
+	evalctx := eval.NewContext(stdlib.Functions(test.TempDir(b), nil))
 	expr, err := ast.ParseExpression(`tm_alltrue([
 		false,
 		tm_element(tm_range(0, 100), 0) == 0,
@@ -35,7 +35,7 @@ func BenchmarkTmAllTrueLiteralList(b *testing.B) {
 
 func BenchmarkTmAllTrueFuncall(b *testing.B) {
 	b.StopTimer()
-	evalctx := eval.NewContext(stdlib.Functions(test.TempDir(b)))
+	evalctx := eval.NewContext(stdlib.Functions(test.TempDir(b), []string{}))
 	expr, err := ast.ParseExpression(`tm_alltrue(tm_distinct([for i in tm_range(0, 3) : i == 2 ? true : false]))`, `bench-test`)
 	assert.NoError(b, err)
 	b.StartTimer()
@@ -50,7 +50,7 @@ func BenchmarkTmAllTrueFuncall(b *testing.B) {
 
 func BenchmarkTmAnyTrueLiteralList(b *testing.B) {
 	b.StopTimer()
-	evalctx := eval.NewContext(stdlib.Functions(test.TempDir(b)))
+	evalctx := eval.NewContext(stdlib.Functions(test.TempDir(b), []string{}))
 	expr, err := ast.ParseExpression(`tm_anytrue([
 		true,
 		tm_element(tm_range(0, 100), 0) != 0,
@@ -69,7 +69,7 @@ func BenchmarkTmAnyTrueLiteralList(b *testing.B) {
 
 func BenchmarkTmAnyTrueFuncall(b *testing.B) {
 	b.StopTimer()
-	evalctx := eval.NewContext(stdlib.Functions(test.TempDir(b)))
+	evalctx := eval.NewContext(stdlib.Functions(test.TempDir(b), []string{}))
 	expr, err := ast.ParseExpression(`tm_anytrue(tm_distinct([for i in tm_range(0, 3) : i == 2 ? true : false]))`, `bench-test`)
 	assert.NoError(b, err)
 	b.StartTimer()
@@ -84,7 +84,7 @@ func BenchmarkTmAnyTrueFuncall(b *testing.B) {
 
 func BenchmarkTmTernary(b *testing.B) {
 	b.StopTimer()
-	evalctx := eval.NewContext(stdlib.Functions(test.TempDir(b)))
+	evalctx := eval.NewContext(stdlib.Functions(test.TempDir(b), []string{}))
 	expr, err := ast.ParseExpression(`tm_ternary(false, tm_unknown_function(), "result")`, `bench-test`)
 	assert.NoError(b, err)
 	b.StartTimer()
@@ -99,7 +99,7 @@ func BenchmarkTmTernary(b *testing.B) {
 
 func BenchmarkTmTryUnknownFunc(b *testing.B) {
 	b.StopTimer()
-	evalctx := eval.NewContext(stdlib.Functions(test.TempDir(b)))
+	evalctx := eval.NewContext(stdlib.Functions(test.TempDir(b), []string{}))
 	expr, err := ast.ParseExpression(`tm_try(tm_unknown_function(), "result")`, `bench-test`)
 	assert.NoError(b, err)
 	b.StartTimer()
@@ -114,7 +114,7 @@ func BenchmarkTmTryUnknownFunc(b *testing.B) {
 
 func BenchmarkTmTryUnknownVariable(b *testing.B) {
 	b.StopTimer()
-	evalctx := eval.NewContext(stdlib.Functions(test.TempDir(b)))
+	evalctx := eval.NewContext(stdlib.Functions(test.TempDir(b), []string{}))
 	expr, err := ast.ParseExpression(`tm_try(unknown_variable, "result")`, `bench-test`)
 	assert.NoError(b, err)
 	b.StartTimer()
@@ -129,7 +129,7 @@ func BenchmarkTmTryUnknownVariable(b *testing.B) {
 
 func BenchmarkTmTryUnknownObjectKey(b *testing.B) {
 	b.StopTimer()
-	evalctx := eval.NewContext(stdlib.Functions(test.TempDir(b)))
+	evalctx := eval.NewContext(stdlib.Functions(test.TempDir(b), []string{}))
 	evalctx.SetNamespaceRaw("let", cty.ObjectVal(map[string]cty.Value{
 		"some": cty.ObjectVal(map[string]cty.Value{}),
 	}))

--- a/stdlib/funcs_test.go
+++ b/stdlib/funcs_test.go
@@ -5,6 +5,7 @@ package stdlib_test
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/madlambda/spells/assert"
@@ -129,7 +130,7 @@ func TestTmVendor(t *testing.T) {
 			vendordir := project.NewPath(tcase.vendorDir)
 			targetdir := project.NewPath(tcase.targetDir)
 
-			funcs := stdlib.Functions(rootdir)
+			funcs := stdlib.Functions(rootdir, []string{})
 			funcs[stdlib.Name("vendor")] = stdlib.VendorFunc(targetdir, vendordir, events)
 			ctx := eval.NewContext(funcs)
 
@@ -162,7 +163,7 @@ func TestTmVendor(t *testing.T) {
 			// piggyback on the current tests to validate that
 			// it also works with a nil channel (no interest on events).
 			t.Run("works with nil events channel", func(t *testing.T) {
-				funcs := stdlib.Functions(rootdir)
+				funcs := stdlib.Functions(rootdir, []string{})
 				funcs["tm_vendor"] = stdlib.VendorFunc(targetdir, vendordir, nil)
 				ctx := eval.NewContext(funcs)
 
@@ -285,7 +286,7 @@ func TestStdlibTmVersionMatch(t *testing.T) {
 		tc := tc
 		t.Run(tc.expr, func(t *testing.T) {
 			rootdir := test.TempDir(t)
-			ctx := eval.NewContext(stdlib.Functions(rootdir))
+			ctx := eval.NewContext(stdlib.Functions(rootdir, []string{}))
 			val, err := ctx.Eval(test.NewExpr(t, tc.expr))
 			errors.Assert(t, err, tc.wantErr)
 			if err != nil {
@@ -304,7 +305,7 @@ func TestStdlibNewFunctionsMustPanicIfRelativeBaseDir(t *testing.T) {
 			t.Fatal("eval.NewContext() did not panic with relative basedir")
 		}
 	}()
-	_ = stdlib.Functions("relative")
+	_ = stdlib.Functions("relative", []string{})
 }
 
 func TestStdlibNewFunctionsMustPanicIfBasedirIsNonExistent(t *testing.T) {
@@ -315,7 +316,7 @@ func TestStdlibNewFunctionsMustPanicIfBasedirIsNonExistent(t *testing.T) {
 		}
 	}()
 
-	stdlib.Functions(filepath.Join(test.TempDir(t), "non-existent"))
+	stdlib.Functions(filepath.Join(test.TempDir(t), "non-existent"), []string{})
 }
 
 func TestStdlibNewFunctionsFailIfBasedirIsNotADirectory(t *testing.T) {
@@ -327,7 +328,7 @@ func TestStdlibNewFunctionsFailIfBasedirIsNotADirectory(t *testing.T) {
 	}()
 
 	path := test.WriteFile(t, test.TempDir(t), "somefile.txt", ``)
-	_ = stdlib.Functions(path)
+	_ = stdlib.Functions(path, []string{})
 }
 
 func TestStdlibTofuSanityCheck(t *testing.T) {
@@ -370,7 +371,7 @@ func TestStdlibTofuSanityCheck(t *testing.T) {
 		tc := tc
 		t.Run(tc.expr, func(t *testing.T) {
 			rootdir := test.TempDir(t)
-			ctx := eval.NewContext(stdlib.Functions(rootdir))
+			ctx := eval.NewContext(stdlib.Functions(rootdir, []string{}))
 			val, err := ctx.Eval(test.NewExpr(t, tc.expr))
 			errors.Assert(t, err, tc.wantErr)
 			if err != nil {
@@ -381,6 +382,8 @@ func TestStdlibTofuSanityCheck(t *testing.T) {
 		})
 	}
 }
+
+func nljoin(strs ...string) string { return strings.Join(strs, "\n") + "\n" }
 
 func init() {
 	zerolog.SetGlobalLevel(zerolog.Disabled)

--- a/stdlib/toml.go
+++ b/stdlib/toml.go
@@ -1,0 +1,109 @@
+// Copyright 2024 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+package stdlib
+
+import (
+	"bytes"
+	stdjson "encoding/json"
+	errstd "errors"
+	"strings"
+
+	"github.com/pelletier/go-toml/v2"
+	"github.com/terramate-io/terramate/errors"
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/function"
+	"github.com/zclconf/go-cty/cty/json"
+)
+
+// TomlExperimentName is the name for the TOML experiment.
+const TomlExperimentName = "toml-functions"
+
+// ErrTomlDecode represents errors happening during decoding of TOML content.
+const ErrTomlDecode errors.Kind = "failed to decode toml content"
+
+// TomlEncode implements the `tm_tomlencode()` function.
+func TomlEncode() function.Function {
+	return function.New(&function.Spec{
+		Params: []function.Parameter{
+			{
+				Name: "val",
+				Type: cty.DynamicPseudoType,
+			},
+		},
+		Type: function.StaticReturnType(cty.String),
+		Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
+			return tomlEncode(args[0])
+		},
+	})
+}
+
+// TomlDecode implements the `tm_tomldecode` function.
+func TomlDecode() function.Function {
+	return function.New(&function.Spec{
+		Params: []function.Parameter{
+			{
+				Name: "content",
+				Type: cty.String,
+			},
+		},
+		Type: function.StaticReturnType(cty.DynamicPseudoType),
+		Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
+			return tomlDecode(args[0].AsString())
+		},
+	})
+}
+
+func tomlEncode(val cty.Value) (cty.Value, error) {
+	data, err := json.Marshal(val, cty.DynamicPseudoType)
+	if err != nil {
+		return cty.NilVal, err
+	}
+	d := stdjson.NewDecoder(bytes.NewBuffer(data))
+	var out bytes.Buffer
+	e := toml.NewEncoder(&out)
+	var v map[string]interface{}
+	err = d.Decode(&v)
+	if err != nil {
+		return cty.NilVal, err
+	}
+	err = e.Encode(v["value"])
+	if err != nil {
+		return cty.NilVal, err
+	}
+	return cty.StringVal(out.String()), nil
+}
+
+func tomlDecode(content string) (cty.Value, error) {
+	var v interface{}
+
+	d := toml.NewDecoder(strings.NewReader(content))
+	err := d.Decode(&v)
+	if err != nil {
+		var derr *toml.DecodeError
+		if errstd.As(err, &derr) {
+			row, col := derr.Position()
+			return cty.NilVal, errors.E("%s\nerror occurred at row %d column %d", derr.String(), row, col)
+		}
+		return cty.NilVal, err
+	}
+
+	var jsonOut bytes.Buffer
+	e := stdjson.NewEncoder(&jsonOut)
+
+	err = e.Encode(v)
+	if err != nil {
+		return cty.NilVal, errors.E(ErrTomlDecode, err)
+	}
+
+	jsonBytes := jsonOut.Bytes()
+	t, err := json.ImpliedType(jsonBytes)
+	if err != nil {
+		return cty.NilVal, errors.E(ErrTomlDecode, "cannot determine an HCL type for decoded toml content")
+	}
+	val, err := json.Unmarshal(jsonBytes, t)
+	if err != nil {
+		return cty.NilVal, errors.E(ErrTomlDecode, "unmarshaling from json: %s", err.Error())
+	}
+	return val, nil
+}

--- a/stdlib/toml_test.go
+++ b/stdlib/toml_test.go
@@ -1,0 +1,120 @@
+// Copyright 2024 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+package stdlib_test
+
+import (
+	"testing"
+
+	"github.com/madlambda/spells/assert"
+	"github.com/terramate-io/terramate/hcl/ast"
+	"github.com/terramate-io/terramate/hcl/eval"
+	"github.com/terramate-io/terramate/stdlib"
+	"github.com/terramate-io/terramate/test"
+)
+
+func TestStdlibTomlEncode(t *testing.T) {
+	t.Parallel()
+	type testcase struct {
+		expr string
+		want string
+	}
+
+	for _, tc := range []testcase{
+		{
+			expr: `tm_tomlencode(true)`,
+			want: `true`,
+		},
+		{
+			expr: `tm_tomlencode(1)`,
+			want: `1.0`,
+		},
+		{
+			expr: `tm_tomlencode(1.5)`,
+			want: `1.5`,
+		},
+		{
+			expr: `tm_tomlencode({})`,
+			want: ``,
+		},
+		{
+			expr: `tm_tomlencode({a = 1})`,
+			want: nljoin(`a = 1.0`),
+		},
+		{
+			expr: `tm_tomlencode({a = 1, b = "hello"})`,
+			want: nljoin(
+				`a = 1.0`,
+				`b = 'hello'`,
+			),
+		},
+	} {
+		tc := tc
+		t.Run(tc.expr, func(t *testing.T) {
+			rootdir := test.TempDir(t)
+			ctx := eval.NewContext(stdlib.Functions(rootdir, []string{stdlib.TomlExperimentName}))
+			val, err := ctx.Eval(test.NewExpr(t, tc.expr))
+			assert.NoError(t, err)
+			got := val.AsString()
+			assert.EqualStrings(t, got, tc.want)
+		})
+	}
+}
+
+func TestStdlibTomlDecode(t *testing.T) {
+	t.Parallel()
+	type testcase struct {
+		expr string
+		want string
+	}
+
+	for _, tc := range []testcase{
+		{
+			expr: `tm_tomldecode(<<-EOF
+			    project = "Terramate"
+			  EOF
+			)`,
+			want: `{project = "Terramate"}`,
+		},
+		{
+			expr: `tm_tomldecode(<<-EOF
+			    age = 37
+			  EOF
+			)`,
+			want: `{age = 37}`,
+		},
+		{
+			expr: `tm_tomldecode(<<-EOF
+			  [project]
+			    name = "Terramate"
+				url = "https://terramate.io"
+			    created = 2021
+				tags = ["iac", "terraform", "cloud"]
+			  EOF
+			)`,
+			want: `{
+			  project = {
+			    name = "Terramate"
+				url = "https://terramate.io"
+				created = 2021
+				tags = ["iac", "terraform", "cloud"]
+			  }
+		    }`,
+		},
+	} {
+		tc := tc
+		t.Run(tc.expr, func(t *testing.T) {
+			rootdir := test.TempDir(t)
+			ctx := eval.NewContext(stdlib.Functions(rootdir, []string{stdlib.TomlExperimentName}))
+			got, err := ctx.Eval(test.NewExpr(t, tc.expr))
+			assert.NoError(t, err)
+			gotStr := string(ast.TokensForValue(got).Bytes())
+			wantExpr, err := ast.ParseExpression(tc.want, "want.hcl")
+			assert.NoError(t, err)
+			wantVal, err := ctx.Eval(wantExpr)
+			assert.NoError(t, err)
+			wantStr := string(ast.TokensForValue(wantVal).Bytes())
+			assert.EqualStrings(t, gotStr, wantStr)
+		})
+	}
+}

--- a/stdlib/try_test.go
+++ b/stdlib/try_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestTmTry(t *testing.T) {
 	dir := test.TempDir(t)
-	funcs := stdlib.Functions(dir)
+	funcs := stdlib.Functions(dir, []string{})
 
 	t.Run("single value number", func(t *testing.T) {
 		evalctx := eval.NewContext(funcs)


### PR DESCRIPTION
## What this PR does / why we need it:

Add `tm_tomlencode()` and `tm_tomldecode` functions.

## Which issue(s) this PR fixes:
Closes #1804 

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
yes, add a new feature.
```
