### PR TITLE
fix: generate_file.context=root not handled in the safeguards.

### DIFF
--- a/e2etests/core/generate_test.go
+++ b/e2etests/core/generate_test.go
@@ -559,9 +559,7 @@ func TestE2EGenerateRespectsWorkingDirectory(t *testing.T) {
 	).String()
 
 	runFromDir := func(t *testing.T, generateWd string, runWd string, wantGenerate generate.Report, wantRun RunExpected) {
-		t.Helper()
 		t.Run(fmt.Sprintf("terramate -C %s generate", generateWd), func(t *testing.T) {
-			t.Helper()
 			t.Parallel()
 			s := sandbox.NoGit(t, true)
 			s.BuildTree([]string{

--- a/e2etests/core/safeguard_test.go
+++ b/e2etests/core/safeguard_test.go
@@ -444,7 +444,7 @@ func TestSafeguardCheckRemoteDisabled(t *testing.T) {
 				})
 		})
 
-	t.Run("re-enabled from config.disable_safegaurds by --disable-safeguards=none",
+	t.Run("re-enabled from config.disable_safeguards by --disable-safeguards=none",
 		func(t *testing.T) {
 			tmcli, file, s := setup(t)
 


### PR DESCRIPTION
## What this PR does / why we need it:

Fix the safeguard not triggering for `generate_file.context == root` case.

## Which issue(s) this PR fixes:
none

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
yes, fixes a bug.
```
