### PR TITLE
fix: git URI normalization failed for projects with leading number.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 
 - Add `tm_hclencode()` and `tm_hcldecode()` functions for encoding and decoding HCL content.
 
+### Fixed
+
+- Fix `git` URI normalization in the case project path component begin with a number.
+
 ## v0.10.3
 
 ### Changed

--- a/e2etests/cmd/helper/main.go
+++ b/e2etests/cmd/helper/main.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/terramate-io/terramate/git"
 	"github.com/terramate-io/terramate/project"
 	"github.com/terramate-io/tfjson"
 	"github.com/terramate-io/tfjson/sanitize"
@@ -69,6 +70,8 @@ func main() {
 		tfPlanSanitize(os.Args[2])
 	case "fibonacci":
 		fibonacci()
+	case "git-normalization":
+		gitnorm(os.Args[2])
 	default:
 		log.Fatalf("unknown command %s", os.Args[1])
 	}
@@ -220,6 +223,18 @@ func tfPlanSanitize(fname string) {
 	newPlanData, err := json.Marshal(newPlan)
 	checkerr(err)
 	fmt.Print(string(newPlanData))
+}
+
+func gitnorm(rawURL string) {
+	repo, err := git.NormalizeGitURI(rawURL)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("host:  %s\n", repo.Host)
+	fmt.Printf("owner: %s\n", repo.Owner)
+	fmt.Printf("name:  %s\n", repo.Name)
+	fmt.Printf("normalized repository: %s\n", repo.Repo)
 }
 
 func checkerr(err error) {

--- a/git/url_test.go
+++ b/git/url_test.go
@@ -83,6 +83,17 @@ func TestNormalizeGitURL(t *testing.T) {
 			},
 		},
 		{
+			name: "github url with org name starting with number",
+			raw:  "git@github.com:123terramate-io/terramate.git",
+			normalized: git.Repository{
+				RawURL: "git@github.com:123terramate-io/terramate.git",
+				Repo:   "github.com/123terramate-io/terramate",
+				Host:   "github.com",
+				Owner:  "123terramate-io",
+				Name:   "terramate",
+			},
+		},
+		{
 			name: "basic gitlab ssh url",
 			raw:  "git@gitlab.com:terramate-io/terramate.git",
 			normalized: git.Repository{
@@ -162,9 +173,9 @@ func TestNormalizeGitURL(t *testing.T) {
 		},
 		{
 			name: "vcs provider URL with port",
-			raw:  "git@github.com:8888:terramate-io/terramate.git",
+			raw:  "git@github.com:8888/terramate-io/terramate.git",
 			normalized: git.Repository{
-				RawURL: "git@github.com:8888:terramate-io/terramate.git",
+				RawURL: "git@github.com:8888/terramate-io/terramate.git",
 				Repo:   "github.com:8888/terramate-io/terramate",
 				Host:   "github.com:8888",
 				Owner:  "terramate-io",
@@ -223,7 +234,7 @@ func TestIsURL(t *testing.T) {
 		{
 			name: "scp-like with no user",
 			url:  "example.com:owner/repo",
-			want: false,
+			want: true,
 		},
 		{
 			name: "ssh",


### PR DESCRIPTION
## What this PR does / why we need it:

Fix the git URI normalization in the case that URI path component begin with a number. Eg.: `git@github.com:123me/project.git`
The number was misinterpreted as a port number.

## Which issue(s) this PR fixes:
none

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
yes, fixes a bug.
```
