### PR TITLE
fix: install is broken because of replace directive.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 
 - Add `tm_hclencode()` and `tm_hcldecode()` functions for encoding and decoding HCL content.
 
+### Fixed
+
+- Fix `go install` by removing a not needed `replace` directive in the `go.mod`.
+
 ## v0.10.3
 
 ### Changed

--- a/go.mod
+++ b/go.mod
@@ -203,5 +203,3 @@ require (
 	golang.org/x/sys v0.21.0
 	golang.org/x/text v0.16.0 // indirect
 )
-
-replace github.com/hashicorp/hcl/v2 v2.20.1 => github.com/opentofu/hcl/v2 v2.0.0-20240814143621-8048794c5c52


### PR DESCRIPTION
## What this PR does / why we need it:

The `go install` stopped working because of an incorrect `replace` directive left in `go.mod`.

## Which issue(s) this PR fixes:
none

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
yes, fixes installation.
```
