### PR TITLE
feat: make inputs of type 'any' by default.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 
 ## Unreleased
 
+### Added
+
+- Enhance "sharing outputs" feature to support `any` input types.
+
 ## v0.10.4
 
 ### Added

--- a/cmd/terramate/cli/run.go
+++ b/cmd/terramate/cli/run.go
@@ -23,6 +23,7 @@ import (
 	"github.com/terramate-io/terramate/cloud/preview"
 	"github.com/terramate-io/terramate/config"
 	"github.com/terramate-io/terramate/errors"
+	"github.com/terramate-io/terramate/hcl/ast"
 	"github.com/terramate-io/terramate/printer"
 	prj "github.com/terramate-io/terramate/project"
 	runutil "github.com/terramate-io/terramate/run"
@@ -554,18 +555,7 @@ func (c *cli) runAll(
 
 						inputVal = mockVal
 					}
-					if !inputVal.Type().Equals(cty.String) {
-						err := errors.E("output type is not string but %s", inputVal.Type().FriendlyName())
-						errs.Append(err)
-						c.cloudSyncAfter(cloudRun, runResult{ExitCode: -1}, errors.E(ErrRunCommandNotExecuted, err))
-						releaseResource()
-						failedTaskIndex = taskIndex
-						if !continueOnError {
-							cancel()
-						}
-						break tasksLoop
-					}
-					environ = append(environ, stdfmt.Sprintf("TF_VAR_%s=%s", input.Name, inputVal.AsString()))
+					environ = append(environ, stdfmt.Sprintf("TF_VAR_%s=%s", input.Name, string(ast.TokensForValue(inputVal).Bytes())))
 				}
 			}
 

--- a/generate/generate_sharing_test.go
+++ b/generate/generate_sharing_test.go
@@ -86,7 +86,7 @@ func TestGenerateSharing(t *testing.T) {
 						"test.tf": Doc(
 							Block("variable",
 								Labels("var_name"),
-								Expr("type", "string"),
+								Expr("type", "any"),
 							),
 						),
 					},
@@ -149,11 +149,11 @@ func TestGenerateSharing(t *testing.T) {
 						"test.tf": Doc(
 							Block("variable",
 								Labels("var_name"),
-								Expr("type", "string"),
+								Expr("type", "any"),
 							),
 							Block("variable",
 								Labels("var_name2"),
-								Expr("type", "string"),
+								Expr("type", "any"),
 							),
 						),
 					},
@@ -369,19 +369,19 @@ func TestGenerateSharing(t *testing.T) {
 						"test.tf": Doc(
 							Block("variable",
 								Labels("var_input1"),
-								Expr("type", "string"),
+								Expr("type", "any"),
 							),
 							Block("variable",
 								Labels("var_input2"),
-								Expr("type", "string"),
+								Expr("type", "any"),
 							),
 							Block("variable",
 								Labels("var_input3"),
-								Expr("type", "string"),
+								Expr("type", "any"),
 							),
 							Block("variable",
 								Labels("var_input4"),
-								Expr("type", "string"),
+								Expr("type", "any"),
 							),
 							Block("output",
 								Labels("var_output1"),
@@ -454,7 +454,7 @@ func TestSharingOrphanedFilesAreDeleted(t *testing.T) {
 
 	expectedInput := genhcl.Header(genhcl.DefaultComment) + Block("variable",
 		Labels("name"),
-		Expr("type", "string"),
+		Expr("type", "any"),
 	).String() + "\n"
 	gotInput := s.RootEntry().ReadFile("s2/sharing.tf")
 	assert.EqualStrings(t, expectedInput, string(gotInput))

--- a/generate/sharing/sharing_backend.go
+++ b/generate/sharing/sharing_backend.go
@@ -39,7 +39,7 @@ func PrepareFile(root *config.Root, filename string, inputs config.Inputs, outpu
 		blockBody.SetAttributeRaw("type", hclwrite.Tokens{
 			{
 				Type:  hclsyntax.TokenIdent,
-				Bytes: []byte("string"),
+				Bytes: []byte("any"),
 			},
 		})
 		body.AppendBlock(varBlock)


### PR DESCRIPTION
## What this PR does / why we need it:

Change default sharing backend type to be `any` instead of `string`.

## Which issue(s) this PR fixes:
Closes #1861 

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
yes, add support for any input type.
```
