### PR TITLE
test: increase cloud sdk test timeout.

### DIFF
--- a/.github/workflows/ci-sync-deployment.yml
+++ b/.github/workflows/ci-sync-deployment.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Run Terraform deployment on changed
         if: steps.list.outputs.stdout
         timeout-minutes: 30
-        run: terramate script run --changed --tags golang --target ${{ matrix.os.name }} --parallel 12 deploy
+        run: terramate script run --changed --tags golang --continue-on-error --target ${{ matrix.os.name }} --parallel 12 deploy
         env:
           GITHUB_TOKEN: ${{ github.token }}
           TM_TEST_TERRAFORM_REQUIRED_VERSION: "1.7.5"

--- a/.tmtriggers/cloud/changed-bf31787e-5490-4993-bbb0-6aa928df8d36.tm.hcl
+++ b/.tmtriggers/cloud/changed-bf31787e-5490-4993-bbb0-6aa928df8d36.tm.hcl
@@ -1,0 +1,6 @@
+trigger {
+  ctime   = 1726518806
+  reason  = "Created using Terramate CLI without setting specific reason."
+  type    = changed
+  context = stack
+}

--- a/.tmtriggers/cloud/deployment/changed-99711885-91ed-4c7b-89ef-0e0d78f758f6.tm.hcl
+++ b/.tmtriggers/cloud/deployment/changed-99711885-91ed-4c7b-89ef-0e0d78f758f6.tm.hcl
@@ -1,0 +1,6 @@
+trigger {
+  ctime   = 1726518806
+  reason  = "Created using Terramate CLI without setting specific reason."
+  type    = changed
+  context = stack
+}

--- a/.tmtriggers/cloud/drift/changed-4451a20c-840c-4c76-a99b-b3b7e0cf277c.tm.hcl
+++ b/.tmtriggers/cloud/drift/changed-4451a20c-840c-4c76-a99b-b3b7e0cf277c.tm.hcl
@@ -1,0 +1,6 @@
+trigger {
+  ctime   = 1726518806
+  reason  = "Created using Terramate CLI without setting specific reason."
+  type    = changed
+  context = stack
+}

--- a/.tmtriggers/cloud/preview/changed-d9f56c80-b385-4ca9-990c-726ee1c1a979.tm.hcl
+++ b/.tmtriggers/cloud/preview/changed-d9f56c80-b385-4ca9-990c-726ee1c1a979.tm.hcl
@@ -1,0 +1,6 @@
+trigger {
+  ctime   = 1726518806
+  reason  = "Created using Terramate CLI without setting specific reason."
+  type    = changed
+  context = stack
+}

--- a/.tmtriggers/cloud/stack/changed-8e6bf98e-ec51-49e3-9d54-48bc9b33a039.tm.hcl
+++ b/.tmtriggers/cloud/stack/changed-8e6bf98e-ec51-49e3-9d54-48bc9b33a039.tm.hcl
@@ -1,0 +1,6 @@
+trigger {
+  ctime   = 1726518806
+  reason  = "Created using Terramate CLI without setting specific reason."
+  type    = changed
+  context = stack
+}

--- a/.tmtriggers/cloud/testserver/changed-5ed1539f-ba05-4de8-af60-aa8d8c6a1331.tm.hcl
+++ b/.tmtriggers/cloud/testserver/changed-5ed1539f-ba05-4de8-af60-aa8d8c6a1331.tm.hcl
@@ -1,0 +1,6 @@
+trigger {
+  ctime   = 1726518807
+  reason  = "Created using Terramate CLI without setting specific reason."
+  type    = changed
+  context = stack
+}

--- a/.tmtriggers/cloud/testserver/cloudstore/changed-8aa49c83-c723-4af5-a7d9-700fff664f1b.tm.hcl
+++ b/.tmtriggers/cloud/testserver/cloudstore/changed-8aa49c83-c723-4af5-a7d9-700fff664f1b.tm.hcl
@@ -1,0 +1,6 @@
+trigger {
+  ctime   = 1726518807
+  reason  = "Created using Terramate CLI without setting specific reason."
+  type    = changed
+  context = stack
+}

--- a/.tmtriggers/cloud/testserver/cmd/testserver/changed-03aea4b7-c20c-42c5-abde-ce0c56912408.tm.hcl
+++ b/.tmtriggers/cloud/testserver/cmd/testserver/changed-03aea4b7-c20c-42c5-abde-ce0c56912408.tm.hcl
@@ -1,0 +1,6 @@
+trigger {
+  ctime   = 1726518807
+  reason  = "Created using Terramate CLI without setting specific reason."
+  type    = changed
+  context = stack
+}

--- a/.tmtriggers/cmd/terramate/cli/changed-748856e1-2a37-4d2d-8cdb-77ecc7aa0b7a.tm.hcl
+++ b/.tmtriggers/cmd/terramate/cli/changed-748856e1-2a37-4d2d-8cdb-77ecc7aa0b7a.tm.hcl
@@ -1,0 +1,6 @@
+trigger {
+  ctime   = 1726518807
+  reason  = "Created using Terramate CLI without setting specific reason."
+  type    = changed
+  context = stack
+}

--- a/.tmtriggers/cmd/terramate/cli/cliconfig/changed-3980e302-150d-44a4-9b90-f2d09b358ae4.tm.hcl
+++ b/.tmtriggers/cmd/terramate/cli/cliconfig/changed-3980e302-150d-44a4-9b90-f2d09b358ae4.tm.hcl
@@ -1,0 +1,6 @@
+trigger {
+  ctime   = 1726518807
+  reason  = "Created using Terramate CLI without setting specific reason."
+  type    = changed
+  context = stack
+}

--- a/.tmtriggers/cmd/terramate/cli/clitest/changed-c3a73530-7808-4d3a-86ba-46ba9a6b155d.tm.hcl
+++ b/.tmtriggers/cmd/terramate/cli/clitest/changed-c3a73530-7808-4d3a-86ba-46ba9a6b155d.tm.hcl
@@ -1,0 +1,6 @@
+trigger {
+  ctime   = 1726518807
+  reason  = "Created using Terramate CLI without setting specific reason."
+  type    = changed
+  context = stack
+}

--- a/.tmtriggers/cmd/terramate/cli/github/changed-8467de4d-b829-4f3a-aca2-7d2a6ccaa9da.tm.hcl
+++ b/.tmtriggers/cmd/terramate/cli/github/changed-8467de4d-b829-4f3a-aca2-7d2a6ccaa9da.tm.hcl
@@ -1,0 +1,6 @@
+trigger {
+  ctime   = 1726518807
+  reason  = "Created using Terramate CLI without setting specific reason."
+  type    = changed
+  context = stack
+}

--- a/.tmtriggers/cmd/terramate/cli/gitlab/changed-510cf593-60f9-4c45-aaa4-02ab2503614f.tm.hcl
+++ b/.tmtriggers/cmd/terramate/cli/gitlab/changed-510cf593-60f9-4c45-aaa4-02ab2503614f.tm.hcl
@@ -1,0 +1,6 @@
+trigger {
+  ctime   = 1726518807
+  reason  = "Created using Terramate CLI without setting specific reason."
+  type    = changed
+  context = stack
+}

--- a/.tmtriggers/cmd/terramate/cli/out/changed-048d674a-9cb9-4c62-af62-741d2a18710b.tm.hcl
+++ b/.tmtriggers/cmd/terramate/cli/out/changed-048d674a-9cb9-4c62-af62-741d2a18710b.tm.hcl
@@ -1,0 +1,6 @@
+trigger {
+  ctime   = 1726518807
+  reason  = "Created using Terramate CLI without setting specific reason."
+  type    = changed
+  context = stack
+}

--- a/.tmtriggers/config/tag/changed-39b89a93-7aa0-4e0b-bbd2-f25e5208c79a.tm.hcl
+++ b/.tmtriggers/config/tag/changed-39b89a93-7aa0-4e0b-bbd2-f25e5208c79a.tm.hcl
@@ -1,0 +1,6 @@
+trigger {
+  ctime   = 1726518807
+  reason  = "Created using Terramate CLI without setting specific reason."
+  type    = changed
+  context = stack
+}

--- a/.tmtriggers/generate/genfile/changed-cd22fd0a-dbe2-4c4c-b66f-fec2caefe2e1.tm.hcl
+++ b/.tmtriggers/generate/genfile/changed-cd22fd0a-dbe2-4c4c-b66f-fec2caefe2e1.tm.hcl
@@ -1,0 +1,6 @@
+trigger {
+  ctime   = 1726518807
+  reason  = "Created using Terramate CLI without setting specific reason."
+  type    = changed
+  context = stack
+}

--- a/.tmtriggers/generate/genhcl/changed-c1b11387-4d2f-4b9d-9f7a-4f0b6e620ff8.tm.hcl
+++ b/.tmtriggers/generate/genhcl/changed-c1b11387-4d2f-4b9d-9f7a-4f0b6e620ff8.tm.hcl
@@ -1,0 +1,6 @@
+trigger {
+  ctime   = 1726518807
+  reason  = "Created using Terramate CLI without setting specific reason."
+  type    = changed
+  context = stack
+}

--- a/.tmtriggers/generate/sharing/changed-64e7117e-98d4-4d68-b251-9f596d90e5a0.tm.hcl
+++ b/.tmtriggers/generate/sharing/changed-64e7117e-98d4-4d68-b251-9f596d90e5a0.tm.hcl
@@ -1,0 +1,6 @@
+trigger {
+  ctime   = 1726518807
+  reason  = "Created using Terramate CLI without setting specific reason."
+  type    = changed
+  context = stack
+}

--- a/.tmtriggers/hcl/ast/changed-d37a862d-b5c6-43f5-b8cd-feff02e79ae8.tm.hcl
+++ b/.tmtriggers/hcl/ast/changed-d37a862d-b5c6-43f5-b8cd-feff02e79ae8.tm.hcl
@@ -1,0 +1,6 @@
+trigger {
+  ctime   = 1726518807
+  reason  = "Created using Terramate CLI without setting specific reason."
+  type    = changed
+  context = stack
+}

--- a/.tmtriggers/hcl/eval/changed-0e7d4ff3-c98c-4823-ab5f-eb2773826c3d.tm.hcl
+++ b/.tmtriggers/hcl/eval/changed-0e7d4ff3-c98c-4823-ab5f-eb2773826c3d.tm.hcl
@@ -1,0 +1,6 @@
+trigger {
+  ctime   = 1726518807
+  reason  = "Created using Terramate CLI without setting specific reason."
+  type    = changed
+  context = stack
+}

--- a/.tmtriggers/hcl/fmt/changed-7d39b19a-c4df-432f-93c4-6ed0b7d5b443.tm.hcl
+++ b/.tmtriggers/hcl/fmt/changed-7d39b19a-c4df-432f-93c4-6ed0b7d5b443.tm.hcl
@@ -1,0 +1,6 @@
+trigger {
+  ctime   = 1726518808
+  reason  = "Created using Terramate CLI without setting specific reason."
+  type    = changed
+  context = stack
+}

--- a/.tmtriggers/hcl/info/changed-203ec6bd-544e-43a0-aa0e-6f2788f44d2d.tm.hcl
+++ b/.tmtriggers/hcl/info/changed-203ec6bd-544e-43a0-aa0e-6f2788f44d2d.tm.hcl
@@ -1,0 +1,6 @@
+trigger {
+  ctime   = 1726518808
+  reason  = "Created using Terramate CLI without setting specific reason."
+  type    = changed
+  context = stack
+}

--- a/.tmtriggers/scheduler/resource/changed-30822815-4f54-44bd-9e60-e06277ec5813.tm.hcl
+++ b/.tmtriggers/scheduler/resource/changed-30822815-4f54-44bd-9e60-e06277ec5813.tm.hcl
@@ -1,0 +1,6 @@
+trigger {
+  ctime   = 1726518808
+  reason  = "Created using Terramate CLI without setting specific reason."
+  type    = changed
+  context = stack
+}

--- a/.tmtriggers/stack/trigger/changed-3b601494-9ffa-4120-bb50-e6092e060749.tm.hcl
+++ b/.tmtriggers/stack/trigger/changed-3b601494-9ffa-4120-bb50-e6092e060749.tm.hcl
@@ -1,0 +1,6 @@
+trigger {
+  ctime   = 1726518808
+  reason  = "Created using Terramate CLI without setting specific reason."
+  type    = changed
+  context = stack
+}

--- a/.tmtriggers/test/hclutils/info/changed-9cfbbb36-a11f-49b0-83d1-5cbb592ad36c.tm.hcl
+++ b/.tmtriggers/test/hclutils/info/changed-9cfbbb36-a11f-49b0-83d1-5cbb592ad36c.tm.hcl
@@ -1,0 +1,6 @@
+trigger {
+  ctime   = 1726518808
+  reason  = "Created using Terramate CLI without setting specific reason."
+  type    = changed
+  context = stack
+}

--- a/.tmtriggers/test/hclwrite/hclutils/changed-7f75e980-f300-4eed-8811-998f15e3f7b4.tm.hcl
+++ b/.tmtriggers/test/hclwrite/hclutils/changed-7f75e980-f300-4eed-8811-998f15e3f7b4.tm.hcl
@@ -1,0 +1,6 @@
+trigger {
+  ctime   = 1726518808
+  reason  = "Created using Terramate CLI without setting specific reason."
+  type    = changed
+  context = stack
+}

--- a/cloud/cloud_test.go
+++ b/cloud/cloud_test.go
@@ -39,7 +39,7 @@ func TestCloudCustomHTTPClient(t *testing.T) {
 			Credential: credential(),
 		}
 
-		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 		defer cancel()
 		trace := &httptrace.ClientTrace{
 			GotConn: func(connInfo httptrace.GotConnInfo) {

--- a/hack/check-stacks.sh
+++ b/hack/check-stacks.sh
@@ -7,7 +7,7 @@ source "$(dirname "$0")/packages.sh"
 
 rootdir=$(git rev-parse --show-toplevel)
 
-for pkg in $(packages_with_tests); do
+for pkg in $(packages); do
     cd $pkg
     projdir=${pkg#"$rootdir"}
     if [ "x${projdir}" == "x" ]; then

--- a/hack/create-stacks.sh
+++ b/hack/create-stacks.sh
@@ -7,7 +7,7 @@ source "$(dirname "$0")/packages.sh"
 
 rootdir=$(git rev-parse --show-toplevel)
 
-for pkg in $(packages_with_tests); do
+for pkg in $(packages); do
     cd $pkg
     projdir=${pkg#"$rootdir"}
     if [ "x${projdir}" == "x" ]; then

--- a/hack/packages.sh
+++ b/hack/packages.sh
@@ -4,7 +4,3 @@
 packages() {
     go list -f '{{.Dir}}' ./... | sort
 }
-
-packages_with_tests() {
-    go list -f '{{.Dir}}' ./... | sort
-}

--- a/makefiles/common.mk
+++ b/makefiles/common.mk
@@ -1,7 +1,7 @@
 GO_RELEASER_VERSION=v1.14.0
 GOLANGCI_LINT_VERSION ?= v1.60.3
 COVERAGE_REPORT ?= coverage.txt
-RUN_ADD_LICENSE=go run github.com/google/addlicense@v1.0.0 -l mpl -s=only -ignore 'docs/**' -ignore '**/*.tf'
+RUN_ADD_LICENSE=go run github.com/google/addlicense@v1.0.0 -l mpl -s=only -ignore 'docs/**' -ignore '.tmtriggers/**' -ignore '**/*.tf'
 BENCH_CHECK=go run github.com/madlambda/benchcheck/cmd/benchcheck@743137fbfd827958b25ab6b13fa1180e0e933eb1
 
 ## Build terramate tools into bin directory


### PR DESCRIPTION
## What this PR does / why we need it:

Last CI check on `main` [failed](https://github.com/terramate-io/terramate/actions/runs/10891107259/job/30221306708) ([TMC deployment](https://cloud.terramate.io/o/terramate-tests/deployments/37776?page=1)) due to a test exceeding the configured timeout.

Additionally, the `deployment` workflow script lacked a `--continue-on-error` and then tests were skipped after the first error. Because of that, I triggered all `unhealthy` stacks in this PR to clear up the alerts and `--continue-on-error` was added to the deployment workflow.

## Which issue(s) this PR fixes:
none

## Special notes for your reviewer:

The `make license` and `make license/check` were fixed to ignore all files under `.tmtriggers` directory.

## Does this PR introduce a user-facing change?
```
no
```
