### PR TITLE
chore: improve warning message to contain offended stack.

### DIFF
--- a/e2etests/core/run_test.go
+++ b/e2etests/core/run_test.go
@@ -79,7 +79,7 @@ func TestCLIRunOrder(t *testing.T) {
 				Stdout: nljoin(
 					`/stack`,
 				),
-				StderrRegex: "Warning: Stack references invalid path in 'after' attribute",
+				StderrRegex: `Warning: Stack /stack references an invalid path \(.*?\) in the 'after' attribute`,
 			},
 		},
 		{
@@ -91,7 +91,7 @@ func TestCLIRunOrder(t *testing.T) {
 				Stdout: nljoin(
 					`/stack`,
 				),
-				StderrRegex: "Warning: Stack references invalid path in 'after' attribute",
+				StderrRegex: `Warning: Stack /stack references an invalid path \(.*?\) in the 'after' attribute`,
 			},
 		},
 		{
@@ -1501,8 +1501,7 @@ func TestRunWantedBy(t *testing.T) {
 					"/stacks/stack-b",
 				),
 				StderrRegexes: []string{
-					"Stack references invalid path in 'wanted_by' attribute",
-					"no such file or directory",
+					"Stack /stacks/stack-a references an invalid path (.*?) in the 'wanted_by' attribute",
 				},
 			},
 		},

--- a/run/order.go
+++ b/run/order.go
@@ -179,7 +179,6 @@ func BuildDAG(
 ) error {
 	logger := log.With().
 		Str("action", "run.BuildDAG()").
-		Str("path", root.HostDir()).
 		Stringer("stack", s.Dir).
 		Logger()
 
@@ -217,14 +216,16 @@ func BuildDAG(
 			}
 			st, err := os.Stat(abspath)
 			if err != nil {
-				printer.Stderr.WarnWithDetails(
-					fmt.Sprintf("Stack references invalid path in '%s' attribute", fieldname),
-					err,
+				logger.Debug().Str("path", pathstr).Err(err).Msgf("Invalid stack.%s path", fieldname)
+				printer.Stderr.Warn(
+					fmt.Sprintf("Stack %s references an invalid path (%s) in the '%s' attribute", s.Dir, pathstr, fieldname),
 				)
 			} else if !st.IsDir() {
-				printer.Stderr.WarnWithDetails(
-					fmt.Sprintf("Stack references invalid path in '%s' attribute", fieldname),
-					errors.E("Path %s is not a directory", pathstr),
+				printer.Stderr.Warn(
+					fmt.Sprintf("Stack %s references a path (%s) that is not a directory in the '%s' attribute",
+						s.Dir,
+						pathstr, fieldname,
+					),
 				)
 			} else {
 				uniqPaths[pathstr] = struct{}{}


### PR DESCRIPTION
## What this PR does / why we need it:

In case a stack contains invalid paths in `after/before/wants/wanted_by` the offended stack should be in the warning output.


## Which issue(s) this PR fixes:
none

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
yes but just enhances the output.
```
