### PR TITLE
chore: run e2e tests whenever a Go package changes.

### DIFF
--- a/.github/workflows/ci-sync-deployment.yml
+++ b/.github/workflows/ci-sync-deployment.yml
@@ -66,41 +66,61 @@ jobs:
 
       ### Check for changed stacks
 
-      - name: List changed stacks
-        id: list
+      - name: List changed Go packages
+        id: list_go_packages
         run: terramate list --tags golang --changed
+
+      - name: List changed e2e tests packages
+        id: list_e2e_packages
+        run: terramate list --tags e2etests --changed
 
       ### Linting
 
       - name: linting code
-        if: steps.list.outputs.stdout
+        if: ${{ steps.list_go_packages.outputs.stdout || steps.list_e2e_packages }}
         run: make lint
 
       - name: checking go mod tidyness
-        if: steps.list.outputs.stdout
+        if: ${{ steps.list_go_packages.outputs.stdout || steps.list_e2e_packages }}
         run: make mod/check
 
       - name: checking license on source code
-        if: steps.list.outputs.stdout
+        if: ${{ steps.list_go_packages.outputs.stdout || steps.list_e2e_packages }}
         run: make license/check
 
       - name: Check Terramate formatting
         run: terramate fmt --check
 
       - name: Check Terraform formatting
-        if: steps.list.outputs.stdout
+        if: ${{ steps.list_go_packages.outputs.stdout || steps.list_e2e_packages }}
         run: terraform fmt -recursive -check -diff
       
       ### Run the Terramate tests and create a Cloud deployment
 
-      - name: Run Terraform deployment on changed
-        if: steps.list.outputs.stdout
+      - name: Run Terraform deployment on changed packages
+        if: ${{ steps.list_go_packages.outputs.stdout || steps.list_e2e_packages }}
         timeout-minutes: 30
-        run: terramate script run --changed --tags golang --continue-on-error --target ${{ matrix.os.name }} --parallel 12 deploy
+        run: terramate script run --changed --tags golang --continue-on-error --target ${{ matrix.os.name }}-go-packages --parallel 12 deploy
         env:
           GITHUB_TOKEN: ${{ github.token }}
           TM_TEST_TERRAFORM_REQUIRED_VERSION: "1.7.5"
 
+      - name: Run all e2e tests Preview if any Go packages changed
+        if: ${{ steps.list_go_packages.outputs.stdout }}
+        timeout-minutes: 30
+        run: terramate script run --tags e2etests --target ${{ matrix.os.name }}-e2e --parallel 12 deploy
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          TM_TEST_TERRAFORM_REQUIRED_VERSION: "1.7.5"
+  
+      - name: Else only run the changed e2e packages
+        if: ${{ !steps.list_e2e_packages.outputs.stdout && steps.list_e2e_packages.outputs.stdout }}
+        timeout-minutes: 30
+        run: terramate script run --tags e2etests --changed --target "${{ matrix.os.name }}-e2e" --parallel 12 deploy
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          TM_TEST_TERRAFORM_REQUIRED_VERSION: "1.7.5"
+  
   release_dry_run:
     name: Release Dry Run
 

--- a/.github/workflows/ci-sync-preview.yml
+++ b/.github/workflows/ci-sync-preview.yml
@@ -64,29 +64,33 @@ jobs:
 
       ### Check for changed stacks
 
-      - name: List changed stacks
-        id: list
+      - name: List changed Go packages
+        id: list_go_packages
         run: terramate list --tags golang --changed
+
+      - name: List changed e2e tests packages
+        id: list_e2e_packages
+        run: terramate list --tags e2etests --changed
 
       ### Linting
 
       - name: linting code
-        if: steps.list.outputs.stdout
+        if: ${{ steps.list_go_packages.outputs.stdout || steps.list_e2e_packages }}
         run: make lint
 
       - name: checking go mod tidyness
-        if: steps.list.outputs.stdout
+        if: ${{ steps.list_go_packages.outputs.stdout || steps.list_e2e_packages }}
         run: make mod/check
 
       - name: checking license on source code
-        if: steps.list.outputs.stdout
+        if: ${{ steps.list_go_packages.outputs.stdout || steps.list_e2e_packages }}
         run: make license/check
 
       - name: Check Terramate formatting
         run: terramate fmt --check
 
       - name: Check Terraform formatting
-        if: steps.list.outputs.stdout
+        if: ${{ steps.list_go_packages.outputs.stdout || steps.list_e2e_packages }}
         run: terraform fmt -recursive -check -diff
       
       ### Run the Terramate tests and create a Cloud Preview
@@ -94,10 +98,26 @@ jobs:
       - name: Temporary PR Preview Link generation
         run: echo >preview_url.txt "https://cloud.terramate.io/o/terramate-tests/review-requests"
 
-      - name: Run Terraform preview on changed
-        if: steps.list.outputs.stdout
+      - name: Run Preview on changed Go packages
+        if: ${{ steps.list_go_packages.outputs.stdout }}
         timeout-minutes: 30
-        run: terramate script run --changed --tags golang --target ${{ matrix.os.name }} --parallel 12 preview
+        run: terramate script run --changed --tags golang --target "${{ matrix.os.name }}-go-packages" --parallel 12 preview
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          TM_TEST_TERRAFORM_REQUIRED_VERSION: "1.7.5"
+
+      - name: Run all e2e tests Preview if any Go packages changed
+        if: ${{ steps.list_go_packages.outputs.stdout }}
+        timeout-minutes: 30
+        run: terramate script run --tags e2etests --target "${{ matrix.os.name }}-e2e" --parallel 12 preview
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          TM_TEST_TERRAFORM_REQUIRED_VERSION: "1.7.5"
+
+      - name: Else only run the changed e2e packages
+        if: ${{ !steps.list_e2e_packages.outputs.stdout && steps.list_e2e_packages.outputs.stdout }}
+        timeout-minutes: 30
+        run: terramate script run --tags e2etests --changed --target "${{ matrix.os.name }}-e2e" --parallel 12 preview
         env:
           GITHUB_TOKEN: ${{ github.token }}
           TM_TEST_TERRAFORM_REQUIRED_VERSION: "1.7.5"
@@ -105,7 +125,7 @@ jobs:
       ### Update Pull Request comment
 
       - name: Generate Preview Comment
-        if: steps.list.outputs.stdout
+        if: ${{ steps.list_go_packages.outputs.stdout || steps.list_e2e_packages.outputs.stdout }}
         id: comment
         run: |
           echo >>pr-comment.txt "## Preview of ${{ matrix.os.name }}/go${{matrix.go}} tests in ${{ github.event.pull_request.head.sha }}"
@@ -115,12 +135,13 @@ jobs:
           echo >>pr-comment.txt "### "
           echo >>pr-comment.txt
           echo >>pr-comment.txt '```bash'
-          echo >>pr-comment.txt "${{ steps.list.outputs.stdout }}"
+          echo >>pr-comment.txt "${{ steps.list_go_packages.outputs.stdout }}"
+          echo >>pr-comment.txt "${{ steps.list_e2e_packages.outputs.stdout }}"
           echo >>pr-comment.txt '```'
           cat pr-comment.txt >>$GITHUB_STEP_SUMMARY
 
       - name: Inform about no Changed Stacks
-        if: success() && !steps.list.outputs.stdout
+        if: ${{ success() && !(steps.list_go_packages.outputs.stdout || steps.list_go_packages.outputs.stdout) }}
         run: |
           echo >>pr-comment.txt "## Preview of ${{ matrix.os.name }}/go${{matrix.go}} tests in ${{ github.event.pull_request.head.sha }}"
           echo >>pr-comment.txt
@@ -130,7 +151,7 @@ jobs:
           cat pr-comment.txt >>$GITHUB_STEP_SUMMARY
 
       - name: Inform about failure
-        if: failure()
+        if: ${{ failure() }}
         run: |
           echo >>pr-comment.txt "## Preview of ${{ matrix.os.name }}/go${{matrix.go}} tests in ${{ github.event.pull_request.head.sha }}"
           echo >>pr-comment.txt
@@ -139,7 +160,8 @@ jobs:
           echo >>pr-comment.txt "### Changed Stacks"
           echo >>pr-comment.txt
           echo >>pr-comment.txt '```bash'
-          echo >>pr-comment.txt "${{ steps.list.outputs.stdout }}"
+          echo >>pr-comment.txt "${{ steps.list_go_packages.outputs.stdout }}"
+          echo >>pr-comment.txt "${{ steps.list_e2e_packages.outputs.stdout }}"
           echo >>pr-comment.txt '```'
           echo >>pr-comment.txt ":boom: Generating preview failed. [Please see details on Terramate Cloud]($(cat preview_url.txt))"
           cat pr-comment.txt >>$GITHUB_STEP_SUMMARY

--- a/e2etests/cloud/stack.tm.hcl
+++ b/e2etests/cloud/stack.tm.hcl
@@ -4,6 +4,6 @@
 stack {
   name        = "cloud"
   description = "cloud"
-  tags        = ["cloud", "e2etests", "golang"]
+  tags        = ["cloud", "e2etests"]
   id          = "88f4382b-a453-4228-bf80-788306af8c47"
 }

--- a/e2etests/cmd/helper/stack.tm.hcl
+++ b/e2etests/cmd/helper/stack.tm.hcl
@@ -4,6 +4,6 @@
 stack {
   name        = "helper is a utility command that implements behaviors that are useful when"
   description = "helper is a utility command that implements behaviors that are useful when\ntesting terramate run features in a way that reduces dependencies on the\nenvironment to run the tests."
-  tags        = ["cmd", "e2etests", "golang", "helper"]
+  tags        = ["cmd", "golang", "helper"]
   id          = "b2c8a842-b230-4afd-9d99-47b72d423d54"
 }

--- a/e2etests/core/stack.tm.hcl
+++ b/e2etests/core/stack.tm.hcl
@@ -4,6 +4,6 @@
 stack {
   name        = "core"
   description = "core"
-  tags        = ["core", "e2etests", "golang"]
+  tags        = ["core", "e2etests"]
   id          = "b36bb769-6f65-467a-9195-f043cd495e16"
 }

--- a/e2etests/internal/runner/stack.tm.hcl
+++ b/e2etests/internal/runner/stack.tm.hcl
@@ -4,6 +4,6 @@
 stack {
   name        = "package runner // import \"github.com/terramate-io/terramate/e2etests/internal/runner\""
   description = "package runner // import \"github.com/terramate-io/terramate/e2etests/internal/runner\"\n\nPackage runner provides helpers for compiling and running the Terramate binary\nwith the intent of doing e2e tests. Additionally, it also provides functions for\nbuilding and installing dependency binaries.\n\nvar HelperPath string\nvar HelperPathAsHCL string\nvar TerraformTestPath string\nvar TerraformVersion string\nfunc AssertRun(t *testing.T, got RunResult)\nfunc AssertRunResult(t *testing.T, got RunResult, want RunExpected)\nfunc BuildTerramate(projectRoot, binDir string) (string, error)\nfunc BuildTestHelper(projectRoot, binDir string) (string, error)\nfunc InstallTerraform(preferredVersion string) (string, string, func(), error)\nfunc RemoveEnv(environ []string, names ...string) []string\nfunc Setup(projectRoot string) (err error)\nfunc Teardown()\ntype CLI struct{ ... }\n    func NewCLI(t *testing.T, chdir string, env ...string) CLI\n    func NewInteropCLI(t *testing.T, chdir string, env ...string) CLI\ntype Cmd struct{ ... }\ntype RunExpected struct{ ... }\ntype RunResult struct{ ... }"
-  tags        = ["e2etests", "golang", "internal", "runner"]
+  tags        = ["golang", "internal", "runner"]
   id          = "6d40054a-a8cf-440c-a22b-5f186fd90af2"
 }

--- a/generate_preview.tm
+++ b/generate_preview.tm
@@ -4,7 +4,10 @@
 // This file is required by the "preview" script.
 
 generate_hcl "_test_mock.tf" {
-  condition = tm_contains(terramate.stack.tags, "golang")
+  condition = tm_anytrue([
+    tm_contains(terramate.stack.tags, "golang"),
+    tm_contains(terramate.stack.tags, "e2etests"),
+  ])
   lets {
     name = tm_ternary(terramate.stack.path.basename == "/", "terramate", terramate.stack.path.basename)
   }


### PR DESCRIPTION
## What this PR does / why we need it:

This change ensures e2e tests run whenever a Go package changes.

## Which issue(s) this PR fixes:
none

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
no
```
