### PR TITLE
chore: optimize DetectOutdated by avoiding re-sorting.

### DIFF
--- a/generate/generate.go
+++ b/generate/generate.go
@@ -599,10 +599,7 @@ func stackOutdated(root *config.Root, cfg *config.Tree, vendorDir project.Path) 
 	if err != nil {
 		return nil, errors.E(err, "handling detected files")
 	}
-
-	outdated := outdatedFiles.slice()
-	sort.Strings(outdated)
-	return outdated, nil
+	return outdatedFiles.slice(), nil
 }
 
 func updateOutdatedFiles(root *config.Root, cfgpath string, generated []GenFile, outdatedFiles *stringSet) error {


### PR DESCRIPTION
## What this PR does / why we need it:

Small optimization to avoid re-sorting of outdated files.

## Which issue(s) this PR fixes:
none

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
no
```
