### PR TITLE
test: only run benchmarks on changed implementation Go files.

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     paths:
       - '**.go'
+      - '!**_test.go'
+      - '!cloud/testserver/**'
+      - '**_bench_test.go'
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
## What this PR does / why we need it:

Only run benchmarks if the modified files are Go files and benchmark test files.
In other words, do not run if just tests (not bench) were modified.
Reason: lots and lots of CI minutes being wasted.

## Which issue(s) this PR fixes:
none

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
no
```
