### PR TITLE
fix: outdated safeguard descending into stack child dirs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 - Backward compatibility in versions `0.0.z` is **not guaranteed** when `z` is increased.
 - Backward compatibility in versions `0.y.z` is **not guaranteed** when `y` is increased.
 
+## Unreleased
+
+### Fixed
+
+- Fix "outdated-code" safeguard giving false positive results for files generated
+ in subdirectory of stacks.
+
 ## v0.10.5
 
 ### Fixed

--- a/config/config.go
+++ b/config/config.go
@@ -340,6 +340,17 @@ func (tree *Tree) IsStack() bool {
 	return tree.Node.Stack != nil
 }
 
+// IsInsideStack tells if current tree node is inside a parent stack.
+func (tree *Tree) IsInsideStack() bool {
+	if tree.Parent == nil {
+		return false
+	}
+	if tree.Parent.IsStack() {
+		return true
+	}
+	return tree.Parent.IsInsideStack()
+}
+
 // Stack returns the stack object.
 func (tree *Tree) Stack() (*Stack, error) {
 	if tree.stack == nil {

--- a/generate/generate_list_test.go
+++ b/generate/generate_list_test.go
@@ -232,7 +232,7 @@ func TestGeneratedFilesListing(t *testing.T) {
 				listdir = s.RootDir()
 			}
 
-			got, err := generate.ListGenFiles(s.Config(), listdir)
+			got, err := generate.ListStackGenFiles(s.Config(), listdir)
 			assert.NoError(t, err)
 			assertEqualStringList(t, got, tcase.want)
 		})

--- a/test/sandbox/sandbox.go
+++ b/test/sandbox/sandbox.go
@@ -437,7 +437,7 @@ func (de DirEntry) CreateFile(name, body string, args ...interface{}) FileEntry 
 func (de DirEntry) ListGenFiles(root *config.Root) []string {
 	de.t.Helper()
 
-	files, err := generate.ListGenFiles(root, de.abspath)
+	files, err := generate.ListStackGenFiles(root, de.abspath)
 	assert.NoError(de.t, err, "listing dir generated files")
 	return files
 }


### PR DESCRIPTION
## What this PR does / why we need it:

The outdated safeguard handling logic is descending into stack subdirs even when its parent stack was already handled.

## Which issue(s) this PR fixes:
Issue reported in Discord.

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
yes, fixes a bug.
```
