### PR TITLE
feat: add create --wants and --wanted-by flags.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 
 ## Unreleased
 
+### Added
+
+- Add `terramate create --wants ... --wanted-by ...` flags for configuring the `stack.wants` and `stack.wanted_by` attributes, respectively.
+
 ## v0.10.6
 
 ### Fixed

--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -120,13 +120,16 @@ type cliSpec struct {
 	DisableCheckpointSignature bool `hidden:"true" optional:"true" default:"false" help:"Disable checkpoint signature."`
 
 	Create struct {
-		Path           string   `arg:"" optional:"" name:"path" predictor:"file" help:"Path of the new stack."`
-		ID             string   `help:"Set the ID of the stack, defaults to an UUIDv4 string."`
-		Name           string   `help:"Set the name of the stack, defaults to the basename of <path>"`
-		Description    string   `help:"Set the description of the stack, defaults to <name>"`
-		Import         []string `help:"Add 'import' block to the configuration of the new stack."`
-		After          []string `help:"Add 'after' attribute to the configuration of the new stack."`
-		Before         []string `help:"Add 'before' attribute to the configuration of the new stack."`
+		Path        string   `arg:"" optional:"" name:"path" predictor:"file" help:"Path of the new stack."`
+		ID          string   `help:"Set the ID of the stack, defaults to an UUIDv4 string."`
+		Name        string   `help:"Set the name of the stack, defaults to the basename of <path>"`
+		Description string   `help:"Set the description of the stack, defaults to <name>"`
+		Import      []string `help:"Add 'import' block to the configuration of the new stack."`
+		After       []string `help:"Add 'after' attribute to the configuration of the new stack."`
+		Before      []string `help:"Add 'before' attribute to the configuration of the new stack."`
+		Wants       []string `help:"Add 'wants' attribute to the configuration of the new stack."`
+		WantedBy    []string `help:"Add 'wanted_by' attribute to the configuration of the new stack."`
+
 		Watch          []string `help:"Add 'watch' attribute to the configuration of the new stack."`
 		IgnoreExisting bool     `help:"Skip creation without error when the stack already exist."`
 		AllTerraform   bool     `help:"Import existing Terraform Root Modules as stacks."`
@@ -1336,6 +1339,8 @@ func (c *cli) scanCreate() {
 		c.parsedArgs.Create.IgnoreExisting ||
 		len(c.parsedArgs.Create.After) != 0 ||
 		len(c.parsedArgs.Create.Before) != 0 ||
+		len(c.parsedArgs.Create.Wants) != 0 ||
+		len(c.parsedArgs.Create.WantedBy) != 0 ||
 		len(c.parsedArgs.Create.Watch) != 0 ||
 		len(c.parsedArgs.Create.Import) != 0 {
 
@@ -1555,6 +1560,8 @@ func (c *cli) createStack() {
 		Description: stackDescription,
 		After:       c.parsedArgs.Create.After,
 		Before:      c.parsedArgs.Create.Before,
+		Wants:       c.parsedArgs.Create.Wants,
+		WantedBy:    c.parsedArgs.Create.WantedBy,
 		Watch:       watch,
 		Tags:        tags,
 	}

--- a/e2etests/core/create_test.go
+++ b/e2etests/core/create_test.go
@@ -81,6 +81,8 @@ func TestCreateFailsWithIncompatibleFlags(t *testing.T) {
 		"--description=desc",
 		"--after=/test",
 		"--before=/test",
+		"--wants=/test",
+		"--wanted-by=/test",
 		"--import=/test",
 		"--ignore-existing",
 	}
@@ -106,6 +108,10 @@ func TestCreateStack(t *testing.T) {
 		stackAfter2      = "stack-after-2"
 		stackBefore1     = "stack-before-1"
 		stackBefore2     = "stack-before-2"
+		stackWants1      = "stack-wants-1"
+		stackWants2      = "stack-wants-2"
+		stackWanted1     = "stack-wanted-1"
+		stackWanted2     = "stack-wanted-2"
 		watch1           = "watched1.txt"
 		watch2           = "watched2.txt"
 		stackTag1        = "a"
@@ -132,7 +138,7 @@ func TestCreateStack(t *testing.T) {
 	`, genFilename, genFileContent)
 
 		stackPaths := []string{
-			"stack-1",
+			"/stack-1",
 			"/stack-2",
 			"/stacks/stack-a",
 			"stacks/stack-b",
@@ -168,6 +174,8 @@ func TestCreateStack(t *testing.T) {
 			assert.EqualStrings(t, stackDescription, got.Description, "checking stack description")
 			test.AssertDiff(t, got.After, []string{stackAfter1, stackAfter2}, "created stack has invalid after")
 			test.AssertDiff(t, got.Before, []string{stackBefore1, stackBefore2}, "created stack has invalid before")
+			test.AssertDiff(t, got.Wants, []string{stackWants1, stackWants2}, "created stack has invalid wants")
+			test.AssertDiff(t, got.WantedBy, []string{stackWanted1, stackWanted2}, "created stack has invalid wanted_by")
 			test.AssertDiff(t, got.Watch, wantWatch, "created stack has invalid watch")
 			test.AssertDiff(t, got.Tags, []string{stackTag1, stackTag2})
 
@@ -189,6 +197,10 @@ func TestCreateStack(t *testing.T) {
 		"--after", stackAfter2,
 		"--before", stackBefore1,
 		"--before", stackBefore2,
+		"--wants", stackWants1,
+		"--wants", stackWants2,
+		"--wanted-by", stackWanted1,
+		"--wanted-by", stackWanted2,
 		"--watch", watch1,
 		"--watch", watch2,
 		"--tags", stackTag1,
@@ -201,6 +213,8 @@ func TestCreateStack(t *testing.T) {
 		"--import", strings.Join([]string{stackImport1, stackImport2}, ","),
 		"--after", strings.Join([]string{stackAfter1, stackAfter2}, ","),
 		"--before", strings.Join([]string{stackBefore1, stackBefore2}, ","),
+		"--wants", strings.Join([]string{stackWants1, stackWants2}, ","),
+		"--wanted-by", strings.Join([]string{stackWanted1, stackWanted2}, ","),
 		"--watch", strings.Join([]string{watch1, watch2}, ","),
 		"--tags", strings.Join([]string{stackTag1, stackTag2}, ","),
 	)

--- a/stack/create.go
+++ b/stack/create.go
@@ -72,6 +72,8 @@ func Create(root *config.Root, stack config.Stack, imports ...string) (err error
 		Description: stack.Description,
 		After:       stack.After,
 		Before:      stack.Before,
+		Wants:       stack.Wants,
+		WantedBy:    stack.WantedBy,
 		Watch:       stack.Watch.Strings(),
 		Tags:        stack.Tags,
 	}


### PR DESCRIPTION
## What this PR does / why we need it:

Implements `terramate create --wants ...` and `terramate create --wanted-by ...`.
The flag works the same as `--after`, `--before`, etc, it creates the stack with the given values in the `stack.wants` and `stack.wanted_by` respectively.

## Which issue(s) this PR fixes:
none

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
yes, add new feature.
```
