### PR TITLE
fix: root stack has terramate.stack.path.basename=\ on Windows.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 ### Fixed
 
 - Fix the cleaning up of orphaned files in the `terramate generate` to respect the `-C <dir>` flag.
+- Fix the value of `terramate.stack.path.basename` and `terramate.root.path.basename` which were given the value of `"\\"` in the case the stack was defined at the project root directory.
 
 ## v0.10.6
 

--- a/config/config.go
+++ b/config/config.go
@@ -270,7 +270,7 @@ func (root *Root) Runtime() project.Runtime {
 func (root *Root) initRuntime() {
 	rootfs := cty.ObjectVal(map[string]cty.Value{
 		"absolute": cty.StringVal(root.HostDir()),
-		"basename": cty.StringVal(filepath.Base(root.HostDir())),
+		"basename": cty.StringVal(filepath.ToSlash(filepath.Base(root.HostDir()))),
 	})
 	rootpath := cty.ObjectVal(map[string]cty.Value{
 		"fs": rootfs,

--- a/config/stack.go
+++ b/config/stack.go
@@ -202,7 +202,7 @@ func (s *Stack) AppendBefore(path string) {
 func (s *Stack) String() string { return s.Dir.String() }
 
 // PathBase returns the base name of the stack path.
-func (s *Stack) PathBase() string { return filepath.Base(s.Dir.String()) }
+func (s *Stack) PathBase() string { return filepath.ToSlash(filepath.Base(s.Dir.String())) }
 
 // RelPath returns the project's relative path of stack.
 func (s *Stack) RelPath() string { return s.Dir.String()[1:] }

--- a/e2etests/core/debug_show_metadata_test.go
+++ b/e2etests/core/debug_show_metadata_test.go
@@ -26,6 +26,28 @@ func TestCliMetadata(t *testing.T) {
 			name: "no stacks",
 		},
 		{
+			name: "stack at /, wd = root",
+			layout: []string{
+				"s:/",
+			},
+			want: RunExpected{
+				Stdout: `Available metadata:
+
+project metadata:
+	terramate.stacks.list=[/]
+
+stack "/":
+	terramate.stack.name="sandbox"
+	terramate.stack.description=""
+	terramate.stack.tags=[]
+	terramate.stack.path.absolute="/"
+	terramate.stack.path.basename="/"
+	terramate.stack.path.relative=""
+	terramate.stack.path.to_root="."
+`,
+			},
+		},
+		{
 			name: "one stack, wd = root",
 			layout: []string{
 				"s:stack",


### PR DESCRIPTION
## What this PR does / why we need it:

The runtime variable `terramate.stack.path.basename` gives the value `\` for a stack at repository root on Windows. Terramate shall never return a Windows based path.

## Which issue(s) this PR fixes:
none

## Special notes for your reviewer:

Note: Windows CI is broken for quite some time 😞 

## Does this PR introduce a user-facing change?
```
yes, fixes an issue.
```
