### PR TITLE
chore: reduce the fs syscalls by using file paths from tree.

### DIFF
--- a/fs/fs_bench_test.go
+++ b/fs/fs_bench_test.go
@@ -42,7 +42,7 @@ func BenchmarkListFiles(b *testing.B) {
 
 	b.StartTimer()
 	for n := 0; n < b.N; n++ {
-		files, err := fs.ListTerramateFiles(dir)
+		files, _, _, err := fs.ListTerramateFiles(dir)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/hcl/fmt/fmt.go
+++ b/hcl/fmt/fmt.go
@@ -65,7 +65,8 @@ func Format(src, filename string) (string, error) {
 // All files will be left untouched. To save the formatted result on disk you
 // can use FormatResult.Save for each FormatResult.
 func FormatTree(dir string) ([]FormatResult, error) {
-	files, err := fs.ListTerramateFiles(dir)
+	// TODO(i4k): use files from the config tree.
+	files, _, dirs, err := fs.ListTerramateFiles(dir)
 	if err != nil {
 		return nil, errors.E(errFormatTree, err)
 	}
@@ -76,14 +77,7 @@ func FormatTree(dir string) ([]FormatResult, error) {
 
 	errs.Append(err)
 
-	dirs, err := fs.ListTerramateDirs(dir)
-	if err != nil {
-		errs.Append(err)
-		return nil, errors.E(errFormatTree, errs)
-	}
-
 	sort.Strings(dirs)
-
 	for _, d := range dirs {
 		subres, err := FormatTree(filepath.Join(dir, d))
 		if err != nil {

--- a/hcl/hcl.go
+++ b/hcl/hcl.go
@@ -505,7 +505,7 @@ func (p *TerramateParser) addParsedFile(origin string, kind parsedKind, files ..
 // AddDir walks over all the files in the directory dir and add all .tm and
 // .tm.hcl files to the parser.
 func (p *TerramateParser) AddDir(dir string) error {
-	tmFiles, err := fs.ListTerramateFiles(dir)
+	tmFiles, _, _, err := fs.ListTerramateFiles(dir)
 	if err != nil {
 		return errors.E(err, "adding directory to terramate parser")
 	}


### PR DESCRIPTION
## What this PR does / why we need it:

Reuse the discovered file paths from the configuration loader.

## Which issue(s) this PR fixes:
none

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
no, just improves performance.
```
