### PR TITLE
feat: consider untracked/uncommitted in the change detector.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,16 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 
 ## Unreleased
 
+### Added
+
+- Add `--enable-change-detection=<options>` and `--disable-change-detection=<options>` to the commands: `terramate list`, `terramate run` and `terramate script run`. 
+  - These flags overrides both the default change detection strategy and the configuration in `terramate.config.change_detection.git` block.
+
+### Changed
+
+- **(Breaking change)** The `terramate list --changed` now considers *untracked* and * uncommitted*  files for detecting changed stacks.
+  - This behavior can be turned off by `terramate.config.change_detection.git.untracked = "off"` and `terramate.config.change_detection.git.uncommitted = "off"`.
+
 ## v0.10.7
 
 ### Added

--- a/benchmarks/changed/changed_bench_test.go
+++ b/benchmarks/changed/changed_bench_test.go
@@ -42,7 +42,7 @@ func BenchmarkChangeDetection(b *testing.B) {
 
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
-		report, err := manager.ListChanged("origin/main")
+		report, err := manager.ListChanged(stack.ChangeConfig{BaseRef: "origin/main"})
 		assert.NoError(b, err)
 		assert.EqualInts(b, 1, len(report.Stacks))
 		assert.EqualStrings(b, fmt.Sprintf("/stack-%d", nstacks-1), report.Stacks[0].Stack.Dir.String())
@@ -91,7 +91,7 @@ func BenchmarkChangeDetectionTFAndTG(b *testing.B) {
 
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
-		report, err := manager.ListChanged("origin/main")
+		report, err := manager.ListChanged(stack.ChangeConfig{BaseRef: "origin/main"})
 		assert.NoError(b, err)
 		assert.EqualInts(b, 2, len(report.Stacks))
 		assert.EqualStrings(b, fmt.Sprintf("/stack-%d", nTfStacks-1), report.Stacks[0].Stack.Dir.String())

--- a/cmd/terramate/cli/run.go
+++ b/cmd/terramate/cli/run.go
@@ -890,7 +890,11 @@ func (c *cli) getAffectedStacks() []stack.Entry {
 	var report *stack.Report
 	var err error
 	if c.parsedArgs.Changed {
-		report, err = mgr.ListChanged(c.baseRef())
+		report, err = mgr.ListChanged(stack.ChangeConfig{
+			BaseRef:            c.baseRef(),
+			UntrackedChanges:   c.changeDetection.untracked,
+			UncommittedChanges: c.changeDetection.uncommitted,
+		})
 		if err != nil {
 			fatalWithDetailf(err, "listing changed stacks")
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -663,6 +663,17 @@ func (root *Root) TerragruntEnabledOption() hcl.TerragruntChangeDetectionEnabled
 	return hcl.TerragruntAutoOption // "auto" is the default.
 }
 
+// ChangeDetectionGitConfig returns the `terramate.config.change_detection.git` object config.
+func (root *Root) ChangeDetectionGitConfig() (*hcl.GitChangeDetectionConfig, bool) {
+	if root.tree.Node.Terramate != nil &&
+		root.tree.Node.Terramate.Config != nil &&
+		root.tree.Node.Terramate.Config.ChangeDetection != nil &&
+		root.tree.Node.Terramate.Config.ChangeDetection.Git != nil {
+		return root.tree.Node.Terramate.Config.ChangeDetection.Git, true
+	}
+	return nil, false
+}
+
 // HasTerragruntStacks returns true if the stack loading has detected Terragrunt files.
 func (root *Root) HasTerragruntStacks() bool {
 	b := root.hasTerragruntStacks

--- a/e2etests/core/change_detection_test.go
+++ b/e2etests/core/change_detection_test.go
@@ -1,0 +1,479 @@
+// Copyright 2024 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+package core_test
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/madlambda/spells/assert"
+	. "github.com/terramate-io/terramate/e2etests/internal/runner"
+	"github.com/terramate-io/terramate/stack"
+	"github.com/terramate-io/terramate/test"
+	. "github.com/terramate-io/terramate/test/hclwrite/hclutils"
+	"github.com/terramate-io/terramate/test/sandbox"
+)
+
+func TestChangeDetection(t *testing.T) {
+	t.Parallel()
+	// TODO(i4k): migrate all tests in manager_test.go to use the sandbox.
+	prepareBranch := func(t *testing.T) *sandbox.S {
+		s := sandbox.New(t)
+		s.BuildTree([]string{
+			"s:stacks/s1",
+			"f:stacks/s1/main.tf:# main",
+			"s:stacks/s2",
+			"f:stacks/s2/main.tf:# main",
+			"s:stacks/s3",
+			"f:stacks/s3/main.tf:# main",
+			"f:script.tm:" + Doc(
+				Terramate(
+					Config(
+						Expr("experiments", `["scripts"]`),
+					),
+				),
+				Script(
+					Labels("test"),
+					Block("job",
+						Expr("command", fmt.Sprintf(`["%s", "stack-abs-path", "${tm_chomp(<<-EOF
+		%s
+	EOF
+	)}"]`, HelperPathAsHCL, s.RootDir())),
+					),
+				),
+			).String(),
+		})
+		s.Git().CommitAll("create stacks")
+		s.Git().Push("main")
+		s.Git().CheckoutNew("test-branch")
+		return &s
+	}
+
+	t.Run("no config, no changes", func(t *testing.T) {
+		t.Parallel()
+		s := prepareBranch(t)
+		mgr := stack.NewGitAwareManager(s.Config(), s.Git().Unwrap())
+		report, err := mgr.ListChanged(stack.ChangeConfig{
+			BaseRef: "origin/main",
+		})
+		assert.NoError(t, err)
+		assert.EqualInts(t, len(report.Stacks), 0)
+		assert.EqualInts(t, len(report.Checks.UntrackedFiles), 0)
+		assert.EqualInts(t, len(report.Checks.UncommittedFiles), 0)
+
+		tmcli := NewCLI(t, s.RootDir())
+		AssertRun(t, tmcli.Run("list", "--changed"))
+		AssertRun(t, tmcli.Run("list", "--changed", "--disable-change-detection=git-untracked"))
+		AssertRun(t, tmcli.Run("list", "--changed", "--disable-change-detection=git-uncommitted"))
+		AssertRun(t, tmcli.Run("list", "--changed", "--disable-change-detection=git-untracked,git-uncommitted"))
+
+		AssertRun(t, tmcli.Run("run", "--changed", "--", HelperPath, "stack-abs-path", s.RootDir()))
+		AssertRun(t, tmcli.Run("run", "--changed", "--enable-change-detection=git-untracked", "--", HelperPath, "stack-abs-path", s.RootDir()))
+		AssertRun(t, tmcli.Run("run", "--changed", "--enable-change-detection=git-uncommitted", "--", HelperPath, "stack-abs-path", s.RootDir()))
+	})
+
+	t.Run("no config/single stack changed", func(t *testing.T) {
+		t.Parallel()
+		s := prepareBranch(t)
+		test.WriteFile(t, filepath.Join(s.RootDir(), "stacks/s1"), "main.tf", "# changed")
+		s.Git().CommitAll("s1 changed")
+		mgr := stack.NewGitAwareManager(s.Config(), s.Git().Unwrap())
+		report, err := mgr.ListChanged(stack.ChangeConfig{
+			BaseRef: "origin/main",
+		})
+		assert.NoError(t, err)
+		assert.EqualInts(t, len(report.Stacks), 1)
+		assert.EqualInts(t, len(report.Checks.UntrackedFiles), 0)
+		assert.EqualInts(t, len(report.Checks.UncommittedFiles), 0)
+		assert.EqualStrings(t, report.Stacks[0].Stack.Dir.String(), "/stacks/s1")
+
+		tmcli := NewCLI(t, s.RootDir())
+		AssertRunResult(t,
+			tmcli.Run("list", "--changed"),
+			RunExpected{Stdout: nljoin("stacks/s1")},
+		)
+
+		AssertRunResult(t,
+			tmcli.Run("list", "--changed", "--disable-change-detection=git-untracked"),
+			RunExpected{Stdout: nljoin("stacks/s1")},
+		)
+
+		AssertRunResult(t,
+			tmcli.Run("list", "--changed", "--disable-change-detection=git-uncommitted"),
+			RunExpected{Stdout: nljoin("stacks/s1")},
+		)
+
+		AssertRunResult(t,
+			tmcli.Run("list", "--changed", "--disable-change-detection=git-untracked,git-uncommitted"),
+			RunExpected{Stdout: nljoin("stacks/s1")},
+		)
+
+		AssertRunResult(t,
+			tmcli.Run("run", "--quiet", "--changed", "--", HelperPath, "stack-abs-path", s.RootDir()),
+			RunExpected{Stdout: nljoin("/stacks/s1")},
+		)
+		AssertRunResult(t,
+			tmcli.Run("run", "--quiet", "--changed", "--enable-change-detection=git-untracked", "--", HelperPath, "stack-abs-path", s.RootDir()),
+			RunExpected{Stdout: nljoin("/stacks/s1")},
+		)
+		AssertRunResult(t,
+			tmcli.Run("run", "--quiet", "--changed", "--enable-change-detection=git-uncommitted", "--", HelperPath, "stack-abs-path", s.RootDir()),
+			RunExpected{Stdout: nljoin("/stacks/s1")},
+		)
+
+		AssertRunResult(t,
+			tmcli.Run("script", "run", "--quiet", "--changed", "test"),
+			RunExpected{Stdout: nljoin("/stacks/s1")},
+		)
+
+		AssertRunResult(t,
+			tmcli.Run("script", "run", "--quiet", "--changed", "--enable-change-detection=git-untracked", "test"),
+			RunExpected{Stdout: nljoin("/stacks/s1")},
+		)
+
+		AssertRunResult(t,
+			tmcli.Run("script", "run", "--quiet", "--changed", "--enable-change-detection=git-uncommitted", "test"),
+			RunExpected{Stdout: nljoin("/stacks/s1")},
+		)
+	})
+
+	t.Run("with config disabling all", func(t *testing.T) {
+		t.Parallel()
+		s := prepareBranch(t)
+		s.BuildTree([]string{
+			`f:change_detection.tm:` + Terramate(
+				Config(
+					Block("change_detection",
+						Block("git",
+							Str("untracked", "off"),
+							Str("uncommitted", "off"),
+						),
+					),
+				),
+			).String(),
+		})
+		test.WriteFile(t, filepath.Join(s.RootDir(), "stacks/s1"), "main.tf", "# changed")
+		s.Git().CommitAll("s1 changed")
+		test.WriteFile(t, filepath.Join(s.RootDir(), "stacks/s2"), "main.tf", "# uncommitted")
+		test.WriteFile(t, filepath.Join(s.RootDir(), "stacks/s3"), "untracked.tf", "# something")
+		mgr := stack.NewGitAwareManager(s.Config(), s.Git().Unwrap())
+		report, err := mgr.ListChanged(stack.ChangeConfig{
+			BaseRef: "origin/main",
+		})
+		assert.NoError(t, err)
+		assert.EqualInts(t, 1, len(report.Stacks))
+		assert.EqualInts(t, 1, len(report.Checks.UntrackedFiles))
+		assert.EqualInts(t, 1, len(report.Checks.UncommittedFiles))
+		assert.EqualStrings(t, report.Stacks[0].Stack.Dir.String(), "/stacks/s1")
+
+		tmcli := NewCLI(t, s.RootDir())
+		AssertRunResult(t,
+			tmcli.Run("list", "--changed"),
+			RunExpected{Stdout: nljoin("stacks/s1")},
+		)
+
+		AssertRunResult(t,
+			tmcli.Run("list", "--changed", "--disable-change-detection=git-untracked"),
+			RunExpected{Stdout: nljoin("stacks/s1")},
+		)
+
+		AssertRunResult(t,
+			tmcli.Run("list", "--changed", "--enable-change-detection=git-untracked"),
+			RunExpected{Stdout: nljoin("stacks/s1", "stacks/s3")},
+		)
+
+		AssertRunResult(t,
+			tmcli.Run("list", "--changed", "--disable-change-detection=git-uncommitted"),
+			RunExpected{Stdout: nljoin("stacks/s1")},
+		)
+
+		AssertRunResult(t,
+			tmcli.Run("list", "--changed", "--enable-change-detection=git-uncommitted"),
+			RunExpected{Stdout: nljoin("stacks/s1", "stacks/s2")},
+		)
+
+		AssertRunResult(t,
+			tmcli.Run("list", "--changed", "--disable-change-detection=git-untracked,git-uncommitted"),
+			RunExpected{Stdout: nljoin("stacks/s1")},
+		)
+
+		AssertRunResult(t,
+			tmcli.Run("list", "--changed", "--enable-change-detection=git-uncommitted,git-untracked"),
+			RunExpected{Stdout: nljoin("stacks/s1", "stacks/s2", "stacks/s3")},
+		)
+
+		AssertRunResult(t,
+			tmcli.Run("run", "--quiet", "--changed", "--", HelperPath, "stack-abs-path", s.RootDir()),
+			RunExpected{
+				Status:      1,
+				StderrRegex: "Error: repository has untracked files",
+			},
+		)
+
+		AssertRunResult(t,
+			tmcli.Run("run", "--quiet", "--changed", "--disable-safeguards=git-untracked", "--", HelperPath, "stack-abs-path", s.RootDir()),
+			RunExpected{
+				Status:      1,
+				StderrRegex: "Error: repository has uncommitted files",
+			},
+		)
+
+		AssertRunResult(t,
+			tmcli.Run("run", "--quiet", "--changed", "--disable-safeguards=git", "--", HelperPath, "stack-abs-path", s.RootDir()),
+			RunExpected{
+				Stdout: nljoin("/stacks/s1"),
+			},
+		)
+
+		AssertRunResult(t,
+			tmcli.Run("run", "--quiet", "--changed", "--disable-change-detection=git-untracked", "--disable-safeguards=git", "--", HelperPath, "stack-abs-path", s.RootDir()),
+			RunExpected{
+				Stdout: nljoin("/stacks/s1"),
+			},
+		)
+
+		AssertRunResult(t,
+			tmcli.Run("run", "--quiet", "--changed", "--disable-change-detection=git-uncommitted", "--disable-safeguards=git", "--", HelperPath, "stack-abs-path", s.RootDir()),
+			RunExpected{
+				Stdout: nljoin("/stacks/s1"),
+			},
+		)
+
+		AssertRunResult(t,
+			tmcli.Run("run", "--quiet", "--changed", "--enable-change-detection=git-untracked", "--disable-safeguards=git", "--", HelperPath, "stack-abs-path", s.RootDir()),
+			RunExpected{
+				Stdout: nljoin("/stacks/s1", "/stacks/s3"),
+			},
+		)
+
+		AssertRunResult(t,
+			tmcli.Run("run", "--quiet", "--changed", "--enable-change-detection=git-uncommitted", "--disable-safeguards=git", "--", HelperPath, "stack-abs-path", s.RootDir()),
+			RunExpected{
+				Stdout: nljoin("/stacks/s1", "/stacks/s2"),
+			},
+		)
+
+		AssertRunResult(t,
+			tmcli.Run("run", "--quiet", "--changed", "--enable-change-detection=git-uncommitted,git-untracked", "--disable-safeguards=git", "--", HelperPath, "stack-abs-path", s.RootDir()),
+			RunExpected{
+				Stdout: nljoin("/stacks/s1", "/stacks/s2", "/stacks/s3"),
+			},
+		)
+
+		AssertRunResult(t,
+			tmcli.Run("script", "run", "--quiet", "--changed", "test"),
+			RunExpected{
+				Status:      1,
+				StderrRegex: "Error: repository has untracked files",
+			},
+		)
+
+		AssertRunResult(t,
+			tmcli.Run("script", "run", "--quiet", "--changed", "--disable-safeguards=git-untracked", "test"),
+			RunExpected{
+				Status:      1,
+				StderrRegex: "Error: repository has uncommitted files",
+			},
+		)
+
+		AssertRunResult(t,
+			tmcli.Run("script", "run", "--quiet", "--changed", "--disable-safeguards=git-uncommitted,git-untracked", "test"),
+			RunExpected{Stdout: nljoin("/stacks/s1")},
+		)
+	})
+
+	t.Run("with config enabling all", func(t *testing.T) {
+		t.Parallel()
+		s := prepareBranch(t)
+		s.BuildTree([]string{
+			`f:change_detection.tm:` + Terramate(
+				Config(
+					Block("change_detection",
+						Block("git",
+							Str("untracked", "on"),
+							Str("uncommitted", "on"),
+						),
+					),
+				),
+			).String(),
+		})
+		test.WriteFile(t, filepath.Join(s.RootDir(), "stacks/s1"), "main.tf", "# changed")
+		s.Git().CommitAll("s1 changed")
+		test.WriteFile(t, filepath.Join(s.RootDir(), "stacks/s2"), "main.tf", "# uncommitted")
+		test.WriteFile(t, filepath.Join(s.RootDir(), "stacks/s3"), "untracked.tf", "# something")
+		mgr := stack.NewGitAwareManager(s.Config(), s.Git().Unwrap())
+		report, err := mgr.ListChanged(stack.ChangeConfig{
+			BaseRef: "origin/main",
+		})
+		assert.NoError(t, err)
+		assert.EqualInts(t, 3, len(report.Stacks))
+		assert.EqualInts(t, 1, len(report.Checks.UntrackedFiles))
+		assert.EqualInts(t, 1, len(report.Checks.UncommittedFiles))
+		assert.EqualStrings(t, "stacks/s3/untracked.tf", report.Checks.UntrackedFiles[0])
+		assert.EqualStrings(t, "stacks/s2/main.tf", report.Checks.UncommittedFiles[0])
+		assert.EqualStrings(t, report.Stacks[0].Stack.Dir.String(), "/stacks/s1")
+		assert.EqualStrings(t, report.Stacks[1].Stack.Dir.String(), "/stacks/s2")
+		assert.EqualStrings(t, report.Stacks[2].Stack.Dir.String(), "/stacks/s3")
+
+		tmcli := NewCLI(t, s.RootDir())
+		AssertRunResult(t,
+			tmcli.Run("list", "--changed"),
+			RunExpected{Stdout: nljoin("stacks/s1", "stacks/s2", "stacks/s3")},
+		)
+
+		// enabling in the CLI is a no-op because config has them enabled already.
+		AssertRunResult(t,
+			tmcli.Run("list", "--changed", "--enable-change-detection=git-untracked,git-uncommitted"),
+			RunExpected{Stdout: nljoin("stacks/s1", "stacks/s2", "stacks/s3")},
+		)
+
+		AssertRunResult(t,
+			tmcli.Run("list", "--changed", "--disable-change-detection=git-untracked"),
+			RunExpected{Stdout: nljoin("stacks/s1", "stacks/s2")},
+		)
+
+		AssertRunResult(t,
+			tmcli.Run("list", "--changed", "--disable-change-detection=git-uncommitted"),
+			RunExpected{Stdout: nljoin("stacks/s1", "stacks/s3")},
+		)
+
+		AssertRunResult(t,
+			tmcli.Run("list", "--changed", "--disable-change-detection=git-untracked,git-uncommitted"),
+			RunExpected{Stdout: nljoin("stacks/s1")},
+		)
+
+		AssertRunResult(t,
+			tmcli.Run("run", "--quiet", "--changed", "--", HelperPath, "stack-abs-path", s.RootDir()),
+			RunExpected{
+				Status:      1,
+				StderrRegex: "Error: repository has untracked files",
+			},
+		)
+
+		AssertRunResult(t,
+			tmcli.Run("run", "--quiet", "--changed", "--disable-safeguards=git-untracked", "--", HelperPath, "stack-abs-path", s.RootDir()),
+			RunExpected{
+				Status:      1,
+				StderrRegex: "Error: repository has uncommitted files",
+			},
+		)
+
+		AssertRunResult(t,
+			tmcli.Run("run", "--quiet", "--changed", "--disable-safeguards=git", "--", HelperPath, "stack-abs-path", s.RootDir()),
+			RunExpected{
+				Stdout: nljoin("/stacks/s1", "/stacks/s2", "/stacks/s3"),
+			},
+		)
+
+		// enabling in the CLI is a no-op because the config has them enabled already.
+		AssertRunResult(t,
+			tmcli.Run("run", "--quiet", "--changed", "--enable-change-detection=git-untracked,git-uncommitted", "--disable-safeguards=git", "--", HelperPath, "stack-abs-path", s.RootDir()),
+			RunExpected{
+				Stdout: nljoin("/stacks/s1", "/stacks/s2", "/stacks/s3"),
+			},
+		)
+
+		AssertRunResult(t,
+			tmcli.Run("run", "--quiet", "--changed", "--disable-change-detection=git-uncommitted", "--disable-safeguards=git", "--", HelperPath, "stack-abs-path", s.RootDir()),
+			RunExpected{
+				Stdout: nljoin("/stacks/s1", "/stacks/s3"),
+			},
+		)
+
+		AssertRunResult(t,
+			tmcli.Run("run", "--quiet", "--changed", "--disable-change-detection=git-untracked", "--disable-safeguards=git", "--", HelperPath, "stack-abs-path", s.RootDir()),
+			RunExpected{
+				Stdout: nljoin("/stacks/s1", "/stacks/s2"),
+			},
+		)
+
+		AssertRunResult(t,
+			tmcli.Run("run", "--quiet", "--changed", "--disable-change-detection=git-untracked,git-uncommitted", "--disable-safeguards=git", "--", HelperPath, "stack-abs-path", s.RootDir()),
+			RunExpected{
+				Stdout: nljoin("/stacks/s1"),
+			},
+		)
+
+		AssertRunResult(t,
+			tmcli.Run("script", "run", "--quiet", "--changed", "test"),
+			RunExpected{
+				Status:      1,
+				StderrRegex: "Error: repository has untracked files",
+			},
+		)
+
+		AssertRunResult(t,
+			tmcli.Run("script", "run", "--quiet", "--changed", "--disable-safeguards=git-untracked", "test"),
+			RunExpected{
+				Status:      1,
+				StderrRegex: "Error: repository has uncommitted files",
+			},
+		)
+
+		AssertRunResult(t,
+			tmcli.Run("script", "run", "--quiet", "--changed", "--disable-safeguards=git-uncommitted,git-untracked", "test"),
+			RunExpected{Stdout: nljoin("/stacks/s1", "/stacks/s2", "/stacks/s3")},
+		)
+	})
+
+	t.Run("trigger --ignore-change ignores stacks marked by dirty files", func(t *testing.T) {
+		t.Parallel()
+		s := prepareBranch(t)
+		s.BuildTree([]string{
+			`f:change_detection.tm:` + Terramate(
+				Config(
+					Block("change_detection",
+						Block("git",
+							Str("untracked", "on"),
+							Str("uncommitted", "on"),
+						),
+					),
+				),
+			).String(),
+		})
+		test.WriteFile(t, filepath.Join(s.RootDir(), "stacks/s1"), "main.tf", "# changed")
+		s.Git().CommitAll("s1 changed")
+		test.WriteFile(t, filepath.Join(s.RootDir(), "stacks/s2"), "main.tf", "# uncommitted")
+		test.WriteFile(t, filepath.Join(s.RootDir(), "stacks/s3"), "untracked.tf", "# something")
+
+		tmcli := NewCLI(t, s.RootDir())
+		AssertRunResult(t,
+			tmcli.Run("experimental", "trigger", "--ignore-change", "--recursive", "./stacks"),
+			RunExpected{
+				Stdout: nljoin(
+					`Created ignore trigger for stack "/stacks/s1"`,
+					`Created ignore trigger for stack "/stacks/s2"`,
+					`Created ignore trigger for stack "/stacks/s3"`,
+				),
+			},
+		)
+
+		mgr := stack.NewGitAwareManager(s.Config(), s.Git().Unwrap())
+		report, err := mgr.ListChanged(stack.ChangeConfig{
+			BaseRef: "origin/main",
+		})
+		assert.NoError(t, err)
+		assert.EqualInts(t, 0, len(report.Stacks))
+		assert.EqualInts(t, 4, len(report.Checks.UntrackedFiles))
+		assert.EqualInts(t, 1, len(report.Checks.UncommittedFiles))
+		assert.EqualStrings(t, "stacks/s3/untracked.tf", report.Checks.UntrackedFiles[0])
+		if !strings.HasPrefix(report.Checks.UntrackedFiles[1], ".tmtriggers/stacks/s1/ignore-change-") {
+			t.Errorf("unexpected untracked file: %s", report.Checks.UntrackedFiles[1])
+		}
+		if !strings.HasPrefix(report.Checks.UntrackedFiles[2], ".tmtriggers/stacks/s2/ignore-change-") {
+			t.Errorf("unexpected untracked file: %s", report.Checks.UntrackedFiles[2])
+		}
+		if !strings.HasPrefix(report.Checks.UntrackedFiles[3], ".tmtriggers/stacks/s3/ignore-change-") {
+			t.Errorf("unexpected untracked file: %s", report.Checks.UntrackedFiles[3])
+		}
+		assert.EqualStrings(t, "stacks/s2/main.tf", report.Checks.UncommittedFiles[0])
+
+		AssertRunResult(t,
+			tmcli.Run("run", "--quiet", "--changed", "--disable-safeguards=git", "--", HelperPath, "stack-abs-path", s.RootDir()),
+			RunExpected{},
+		)
+	})
+}

--- a/e2etests/core/run_test.go
+++ b/e2etests/core/run_test.go
@@ -1882,11 +1882,13 @@ func TestRunFailIfGitSafeguardUntracked(t *testing.T) {
 		})
 	})
 
-	t.Run("ensure list is not affected by untracked check", func(t *testing.T) {
+	t.Run("ensure list **is** affected by untracked check (by default)", func(t *testing.T) {
 		tmcli := NewCLI(t, s.RootDir())
 
-		AssertRun(t, tmcli.Run("list", "--changed"))
 		AssertRunResult(t, tmcli.Run("list"), RunExpected{
+			Stdout: nljoin("stack"),
+		})
+		AssertRunResult(t, tmcli.Run("list", "--changed"), RunExpected{
 			Stdout: nljoin("stack"),
 		})
 	})
@@ -1895,14 +1897,17 @@ func TestRunFailIfGitSafeguardUntracked(t *testing.T) {
 
 	t.Run("disable check using deprecated cmd args", func(t *testing.T) {
 		tmcli := NewCLI(t, s.RootDir(), testEnviron(t)...)
-		AssertRun(t, tmcli.Run(
+		AssertRunResult(t, tmcli.Run(
 			"run",
+			"--quiet",
 			"--changed",
 			"--disable-check-git-untracked",
 			HelperPath,
 			"cat",
 			mainTfFileName,
-		))
+		), RunExpected{
+			Stdout: mainTfContents,
+		})
 
 		AssertRunResult(t, tmcli.Run(
 			"run",
@@ -1918,14 +1923,17 @@ func TestRunFailIfGitSafeguardUntracked(t *testing.T) {
 
 	t.Run("disable check using --disable-safeguards=git-untracked cmd args", func(t *testing.T) {
 		tmcli := NewCLI(t, s.RootDir(), testEnviron(t)...)
-		AssertRun(t, tmcli.Run(
+		AssertRunResult(t, tmcli.Run(
 			"run",
+			"--quiet",
 			"--disable-safeguards=git-untracked",
 			"--changed",
 			HelperPath,
 			"cat",
 			mainTfFileName,
-		))
+		), RunExpected{
+			Stdout: mainTfContents,
+		})
 
 		AssertRunResult(t, tmcli.Run(
 			"--quiet",
@@ -1941,14 +1949,17 @@ func TestRunFailIfGitSafeguardUntracked(t *testing.T) {
 
 	t.Run("disable check using --disable-safeguards=all cmd args", func(t *testing.T) {
 		tmcli := NewCLI(t, s.RootDir(), testEnviron(t)...)
-		AssertRun(t, tmcli.Run(
+		AssertRunResult(t, tmcli.Run(
 			"run",
+			"--quiet",
 			"--disable-safeguards=all",
 			"--changed",
 			HelperPath,
 			"cat",
 			mainTfFileName,
-		))
+		), RunExpected{
+			Stdout: mainTfContents,
+		})
 
 		AssertRunResult(t, tmcli.Run(
 			"--quiet",
@@ -1964,14 +1975,17 @@ func TestRunFailIfGitSafeguardUntracked(t *testing.T) {
 
 	t.Run("disable check using -X", func(t *testing.T) {
 		tmcli := NewCLI(t, s.RootDir(), testEnviron(t)...)
-		AssertRun(t, tmcli.Run(
+		AssertRunResult(t, tmcli.Run(
 			"run",
+			"--quiet",
 			"-X",
 			"--changed",
 			HelperPath,
 			"cat",
 			mainTfFileName,
-		))
+		), RunExpected{
+			Stdout: mainTfContents,
+		})
 
 		AssertRunResult(t, tmcli.Run(
 			"--quiet",
@@ -1989,13 +2003,16 @@ func TestRunFailIfGitSafeguardUntracked(t *testing.T) {
 		tmcli := NewCLI(t, s.RootDir(), testEnviron(t)...)
 		tmcli.AppendEnv = append(tmcli.AppendEnv, "TM_DISABLE_CHECK_GIT_UNTRACKED=true")
 
-		AssertRun(t, tmcli.Run(
+		AssertRunResult(t, tmcli.Run(
 			"run",
+			"--quiet",
 			"--changed",
 			HelperPath,
 			"cat",
 			mainTfFileName,
-		))
+		), RunExpected{
+			Stdout: mainTfContents,
+		})
 
 		AssertRunResult(t, tmcli.Run(
 			"run",
@@ -2012,13 +2029,16 @@ func TestRunFailIfGitSafeguardUntracked(t *testing.T) {
 		tmcli := NewCLI(t, s.RootDir(), testEnviron(t)...)
 		tmcli.AppendEnv = append(tmcli.AppendEnv, "TM_DISABLE_CHECK_GIT_UNTRACKED=1")
 
-		AssertRun(t, tmcli.Run(
+		AssertRunResult(t, tmcli.Run(
 			"run",
+			"--quiet",
 			"--changed",
 			HelperPath,
 			"cat",
 			mainTfFileName,
-		))
+		), RunExpected{
+			Stdout: mainTfContents,
+		})
 
 		AssertRunResult(t, tmcli.Run(
 			"run",
@@ -2046,13 +2066,16 @@ func TestRunFailIfGitSafeguardUntracked(t *testing.T) {
 		defer s.RootEntry().RemoveFile(rootConfig)
 
 		tmcli := NewCLI(t, s.RootDir(), testEnviron(t)...)
-		AssertRun(t, tmcli.Run(
+		AssertRunResult(t, tmcli.Run(
 			"run",
+			"--quiet",
 			"--changed",
 			HelperPath,
 			"cat",
 			mainTfFileName,
-		))
+		), RunExpected{
+			Stdout: mainTfContents,
+		})
 
 		AssertRunResult(t, tmcli.Run(
 			"run",
@@ -2078,13 +2101,16 @@ func TestRunFailIfGitSafeguardUntracked(t *testing.T) {
 		defer s.RootEntry().RemoveFile(rootConfig)
 
 		tmcli := NewCLI(t, s.RootDir(), testEnviron(t)...)
-		AssertRun(t, tmcli.Run(
+		AssertRunResult(t, tmcli.Run(
 			"run",
+			"--quiet",
 			"--changed",
 			HelperPath,
 			"cat",
 			mainTfFileName,
-		))
+		), RunExpected{
+			Stdout: mainTfContents,
+		})
 
 		AssertRunResult(t, tmcli.Run(
 			"run",
@@ -2110,13 +2136,16 @@ func TestRunFailIfGitSafeguardUntracked(t *testing.T) {
 		defer s.RootEntry().RemoveFile(rootConfig)
 
 		tmcli := NewCLI(t, s.RootDir(), testEnviron(t)...)
-		AssertRun(t, tmcli.Run(
+		AssertRunResult(t, tmcli.Run(
 			"run",
+			"--quiet",
 			"--changed",
 			HelperPath,
 			"cat",
 			mainTfFileName,
-		))
+		), RunExpected{
+			Stdout: mainTfContents,
+		})
 
 		AssertRunResult(t, tmcli.Run(
 			"run",
@@ -2144,14 +2173,17 @@ func TestRunFailIfGitSafeguardUntracked(t *testing.T) {
 		defer s.RootEntry().RemoveFile(rootConfig)
 
 		tmcli := NewCLI(t, s.RootDir(), testEnviron(t)...)
-		AssertRun(t, tmcli.Run(
+		AssertRunResult(t, tmcli.Run(
 			"run",
+			"--quiet",
 			"--disable-safeguards=git-untracked",
 			"--changed",
 			HelperPath,
 			"cat",
 			mainTfFileName,
-		))
+		), RunExpected{
+			Stdout: mainTfContents,
+		})
 
 		AssertRunResult(t, tmcli.Run(
 			"run",
@@ -2178,19 +2210,23 @@ func TestRunFailIfGitSafeguardUntracked(t *testing.T) {
 		defer s.RootEntry().RemoveFile(rootConfig)
 
 		tmcli := NewCLI(t, s.RootDir(), testEnviron(t)...)
-		AssertRun(t, tmcli.Run(
+		AssertRunResult(t, tmcli.Run(
 			"run",
+			"--quiet",
 			"--disable-safeguards=git-untracked",
 			"--changed",
 			HelperPath,
 			"cat",
 			mainTfFileName,
-		))
+		), RunExpected{
+			Stdout: mainTfContents,
+		})
 
 		AssertRunResult(t, tmcli.Run(
 			"run",
 			"--disable-safeguards=git-untracked",
 			"--quiet",
+			"--",
 			HelperPath,
 			"cat",
 			mainTfFileName,
@@ -2216,7 +2252,10 @@ func TestRunFailIfGitSafeguardUntracked(t *testing.T) {
 		tmcli := NewCLI(t, s.RootDir(), testEnviron(t)...)
 		AssertRunResult(t, tmcli.Run(
 			"run",
+			"--quiet",
 			"--disable-safeguards=none",
+			"--changed",
+			"--",
 			HelperPath,
 			"cat",
 			mainTfFileName,
@@ -2227,6 +2266,7 @@ func TestRunFailIfGitSafeguardUntracked(t *testing.T) {
 
 		AssertRunResult(t, tmcli.Run(
 			"run",
+			"--quiet",
 			"--disable-safeguards=none",
 			HelperPath,
 			"cat",
@@ -2255,6 +2295,9 @@ func TestRunFailIfGitSafeguardUntracked(t *testing.T) {
 		tmcli.AppendEnv = append(tmcli.AppendEnv, "TM_DISABLE_SAFEGUARDS=none")
 		AssertRunResult(t, tmcli.Run(
 			"run",
+			"--quiet",
+			"--changed",
+			"--",
 			HelperPath,
 			"cat",
 			mainTfFileName,
@@ -2265,6 +2308,8 @@ func TestRunFailIfGitSafeguardUntracked(t *testing.T) {
 
 		AssertRunResult(t, tmcli.Run(
 			"run",
+			"--quiet",
+			"--",
 			HelperPath,
 			"cat",
 			mainTfFileName,

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -493,16 +493,16 @@ func TestListDirtyFiles(t *testing.T) {
 	assert.NoError(t, err)
 	assert.EqualInts(t, 2, len(untracked))
 	assert.EqualInts(t, 0, len(uncommitted))
-	assert.EqualStrings(t, "deep", untracked[0])
-	assert.EqualStrings(t, "test.txt", untracked[1])
+	assert.EqualStrings(t, "test.txt", untracked[0])
+	assert.EqualStrings(t, "deep/nested/path/test.txt", untracked[1])
 
 	test.WriteFile(t, repodir, "README.md", "# changed")
 	untracked, uncommitted, err = g.ListDirtyFiles()
 	assert.NoError(t, err)
 	assert.EqualInts(t, 2, len(untracked))
 	assert.EqualInts(t, 1, len(uncommitted))
-	assert.EqualStrings(t, "deep", untracked[0])
-	assert.EqualStrings(t, "test.txt", untracked[1])
+	assert.EqualStrings(t, "test.txt", untracked[0])
+	assert.EqualStrings(t, "deep/nested/path/test.txt", untracked[1])
 	assert.EqualStrings(t, "README.md", uncommitted[0])
 
 }

--- a/hcl/hcl_test.go
+++ b/hcl/hcl_test.go
@@ -601,6 +601,8 @@ func TestHCLParserTerramateBlock(t *testing.T) {
 
 func TestHCLParserRootConfig(t *testing.T) {
 	ptr := func(s string) *string { return &s }
+	on := true
+	off := false
 	for _, tc := range []testcase{
 		{
 			name: "no config returns empty config",
@@ -985,7 +987,7 @@ func TestHCLParserRootConfig(t *testing.T) {
 					Terramate: &hcl.Terramate{
 						Config: &hcl.RootConfig{
 							ChangeDetection: &hcl.ChangeDetectionConfig{
-								Terragrunt: &hcl.TerragruntConfig{
+								Terragrunt: &hcl.TerragruntChangeDetectionConfig{
 									Enabled: hcl.TerragruntAutoOption,
 								},
 							},
@@ -1017,7 +1019,7 @@ func TestHCLParserRootConfig(t *testing.T) {
 					Terramate: &hcl.Terramate{
 						Config: &hcl.RootConfig{
 							ChangeDetection: &hcl.ChangeDetectionConfig{
-								Terragrunt: &hcl.TerragruntConfig{
+								Terragrunt: &hcl.TerragruntChangeDetectionConfig{
 									Enabled: hcl.TerragruntOffOption,
 								},
 							},
@@ -1049,8 +1051,76 @@ func TestHCLParserRootConfig(t *testing.T) {
 					Terramate: &hcl.Terramate{
 						Config: &hcl.RootConfig{
 							ChangeDetection: &hcl.ChangeDetectionConfig{
-								Terragrunt: &hcl.TerragruntConfig{
+								Terragrunt: &hcl.TerragruntChangeDetectionConfig{
 									Enabled: hcl.TerragruntForceOption,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "disabling terramate.config.change_detection.git",
+			input: []cfgfile{
+				{
+					filename: "cfg.tm",
+					body: `
+						terramate {
+						  config {
+						    change_detection {
+							  git {
+							    untracked = "off"
+								uncommitted = false
+							  }
+							}
+						  }
+						}
+					`,
+				},
+			},
+			want: want{
+				config: hcl.Config{
+					Terramate: &hcl.Terramate{
+						Config: &hcl.RootConfig{
+							ChangeDetection: &hcl.ChangeDetectionConfig{
+								Git: &hcl.GitChangeDetectionConfig{
+									Untracked:   &off,
+									Uncommitted: &off,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "enabling terramate.config.change_detection.git",
+			input: []cfgfile{
+				{
+					filename: "cfg.tm",
+					body: `
+						terramate {
+						  config {
+						    change_detection {
+							  git {
+							    untracked = "on"
+								uncommitted = true
+							  }
+							}
+						  }
+						}
+					`,
+				},
+			},
+			want: want{
+				config: hcl.Config{
+					Terramate: &hcl.Terramate{
+						Config: &hcl.RootConfig{
+							ChangeDetection: &hcl.ChangeDetectionConfig{
+								Git: &hcl.GitChangeDetectionConfig{
+									Untracked:   &on,
+									Uncommitted: &on,
 								},
 							},
 						},
@@ -1232,7 +1302,7 @@ func TestHCLParserMultipleErrors(t *testing.T) {
 			},
 		},
 		{
-			name: "terramate.config.generate..hcl_magic_header_comment_style is not string -- fail",
+			name: "terramate.config.generate.hcl_magic_header_comment_style is not string -- fail",
 			input: []cfgfile{
 				{
 					filename: "tm.tm",

--- a/stack/manager_test.go
+++ b/stack/manager_test.go
@@ -247,7 +247,9 @@ func TestListChangedStacks(t *testing.T) {
 			g := test.NewGitWrapper(t, repo.Dir, []string{})
 			m := stack.NewGitAwareManager(root, g)
 
-			report, err := m.ListChanged(tc.baseRef)
+			report, err := m.ListChanged(stack.ChangeConfig{
+				BaseRef: tc.baseRef,
+			})
 			assert.EqualErrs(t, tc.want.err, err, "ListChanged() error")
 
 			changedStacks := report.Stacks
@@ -267,7 +269,7 @@ func TestListChangedStackReason(t *testing.T) {
 	repo := singleNotMergedCommitBranch(t)
 
 	m := newManager(t, repo.Dir)
-	report, err := m.ListChanged(defaultBranch)
+	report, err := m.ListChanged(stack.ChangeConfig{BaseRef: defaultBranch})
 	assert.NoError(t, err, "unexpected error")
 
 	changed := report.Stacks
@@ -278,7 +280,7 @@ func TestListChangedStackReason(t *testing.T) {
 	repo = singleStackDependentModuleChangedRepo(t)
 
 	m = newManager(t, repo.Dir)
-	report, err = m.ListChanged(defaultBranch)
+	report, err = m.ListChanged(stack.ChangeConfig{BaseRef: defaultBranch})
 	assert.NoError(t, err, "unexpected error")
 
 	changed = report.Stacks


### PR DESCRIPTION
## What this PR does / why we need it:

**This is a breaking change**

This change considers untracked and uncommitted files in the change detection.
It means `terramate list --changed` will show stacks changed by uncommitted or untracked files in the index. The `terramate run` safeguards will continue to kick in but the user can disable the `git` safeguards and in this case commands can run in dirty stacks.

## Which issue(s) this PR fixes:
Closes #1398 

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
yes, it's a breaking change that needs documentation!
```
