### PR TITLE
fix: trigger --ignore-change don't ignore stacks changed due to TF module changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 - **(Breaking change)** The `terramate list --changed` now considers *untracked* and * uncommitted*  files for detecting changed stacks.
   - This behavior can be turned off by `terramate.config.change_detection.git.untracked = "off"` and `terramate.config.change_detection.git.uncommitted = "off"`.
 
+### Fixed
+
+- Fix `trigger --ignore-change` not ignoring stacks changed due to Terraform or Terragrunt changes.
+
 ## v0.10.7
 
 ### Added

--- a/stack/manager.go
+++ b/stack/manager.go
@@ -272,10 +272,6 @@ func (m *Manager) ListChanged(cfg ChangeConfig) (*Report, error) {
 		}
 	}
 
-	for ignored := range ignoreSet {
-		delete(stackSet, ignored)
-	}
-
 	allstacks, err := m.allStacks()
 	if err != nil {
 		return nil, err
@@ -387,6 +383,10 @@ rangeStacks:
 			}
 			continue rangeStacks
 		}
+	}
+
+	for ignored := range ignoreSet {
+		delete(stackSet, ignored)
 	}
 
 	changedStacks := make([]Entry, 0, len(stackSet))


### PR DESCRIPTION
## What this PR does / why we need it:

The **ignore triggers** do not ignore stack changes if they were marked by Terraform or Terragrunt module changes.

## Which issue(s) this PR fixes:
none

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
<!--
If no, just write "no" in the block below.
If yes, please explain the change and update documentation and the CHANGELOG.md file accordingly.
-->
```
yes, fixes a trigger bug.
```
