### PR TITLE
refactor(sharing_outputs): no default value for the sensitive fields.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 
 ## Unreleased
 
+### Changed
+
+- The **Outputs Sharing** feature now has no default value for the `sensitive` field of `input` and `output` blocks.
+
 ## v0.10.8
 
 ### Fixed

--- a/generate/sharing/sharing_backend.go
+++ b/generate/sharing/sharing_backend.go
@@ -43,7 +43,9 @@ func PrepareFile(root *config.Root, filename string, inputs config.Inputs, outpu
 				Bytes: []byte("any"),
 			},
 		})
-		blockBody.SetAttributeValue("sensitive", cty.BoolVal(in.Sensitive))
+		if in.Sensitive != nil {
+			blockBody.SetAttributeValue("sensitive", cty.BoolVal(*in.Sensitive))
+		}
 		body.AppendBlock(varBlock)
 	}
 	for _, out := range outputs {
@@ -53,7 +55,9 @@ func PrepareFile(root *config.Root, filename string, inputs config.Inputs, outpu
 		outBlock := hclwrite.NewBlock("output", []string{out.Name})
 		blockBody := outBlock.Body()
 		blockBody.SetAttributeRaw("value", ast.TokensForExpression(out.Value))
-		blockBody.SetAttributeValue("sensitive", cty.BoolVal(out.Sensitive))
+		if out.Sensitive != nil {
+			blockBody.SetAttributeValue("sensitive", cty.BoolVal(*out.Sensitive))
+		}
 		body.AppendBlock(outBlock)
 	}
 


### PR DESCRIPTION
## What this PR does / why we need it:

Backport of https://github.com/terramate-io/terramate/pull/1926 to `v0.10.x` branch.

## Which issue(s) this PR fixes:
none

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
yes, change the behavior.
```
