### PR TITLE
feat: allow dots in tags.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 - Add support for using `TM_ARG_*` environment variables to configure cli commands.
   Note: This is an incremental change. Only global flags and `terramate run` flags were added for now.
   - For example: Use `TM_ARG_CHDIR=stacks/prod TM_ARG_RUN_REVERSE=1 terramate run -- terraform apply` to run from inside `stacks/prod` and with reversed execution order (which is the same as `terramate --chdir stacks/prod run --reverse -- terraform apply`).
+- Add support for dot (`.`) in the tag syntax.
+  - Now you can add tags like `v1.0.0-abc_xyz`
 
 ### Changed
 
@@ -37,6 +39,8 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 - **(Breaking change)** Remove the deprecated `terramate experimental run-order`.
   - The `terramate list --run-order` was introduced in version `v0.4.5` and provides the same functionality as the removed command.
 - The **Outputs Sharing** feature now has no default value for the `sensitive` field of `input` and `output` blocks.
+
+## v0.10.8
 
 ### Fixed
 

--- a/config/tag/tag.go
+++ b/config/tag/tag.go
@@ -28,10 +28,10 @@ func Validate(tag string) error {
 					tag)
 			}
 		default:
-			if !isLowerAlnum(r) && r != '-' && r != '_' {
+			if !isLowerAlnum(r) && r != '-' && r != '_' && r != '.' {
 				return errors.E(
 					ErrInvalidTag,
-					"%q: [a-z_-] are the only permitted characters in tags",
+					"%q: [a-z._-] are the only permitted characters in tags",
 					tag)
 			}
 		}

--- a/e2etests/cloud/cloud_status_test.go
+++ b/e2etests/cloud/cloud_status_test.go
@@ -332,6 +332,31 @@ func TestCloudStatus(t *testing.T) {
 			},
 		},
 		{
+			name: "double check stack with dotted tags are not validated in the CLI",
+			layout: []string{
+				"s:s1:id=s1", // s1 has no tags locally
+				"s:s2:id=s2",
+			},
+			stacks: []cloudstore.Stack{
+				{
+					Stack: cloud.Stack{
+						MetaID:     "s1",
+						Repository: "github.com/terramate-io/terramate",
+						MetaTags:   []string{"something.with.dots"},
+					},
+					State: cloudstore.StackState{
+						Status:           stack.Drifted,
+						DeploymentStatus: deployment.Failed,
+						DriftStatus:      drift.Drifted,
+					},
+				},
+			},
+			flags: []string{`--status=unhealthy`},
+			want: RunExpected{
+				Stdout: nljoin("s1"),
+			},
+		},
+		{
 			name: "1 cloud stack ok, other absent, asking for deployment=failed: return nothing",
 			layout: []string{
 				"s:s1:id=s1",

--- a/e2etests/cloud/interop/testdata/interop-stacks/basic-drift/stack.tm.hcl
+++ b/e2etests/cloud/interop/testdata/interop-stacks/basic-drift/stack.tm.hcl
@@ -6,4 +6,5 @@ stack {
   description = "basic-drift"
   id          = "2530f1b3-2691-48dc-b418-e966f7e1441c"
   after       = ["../empty"] # only used for visualizing the graph.
+  tags        = ["interop", "tag.with.dots-and-dash_and_underscore"]
 }

--- a/e2etests/cloud/interop/testdata/interop-stacks/empty/stack.tm.hcl
+++ b/e2etests/cloud/interop/testdata/interop-stacks/empty/stack.tm.hcl
@@ -6,4 +6,5 @@ stack {
   description = "empty"
   id          = "04437b1f-27a9-4eab-8e63-1df968b76f6b"
   before      = ["/testdata/example-stack", "/testdata/testserver"]
+  tags        = ["interop", "tag.with.dots-and-dash_and_underscore"]
 }

--- a/e2etests/core/run_test.go
+++ b/e2etests/core/run_test.go
@@ -1546,6 +1546,19 @@ func TestRunWantedBy(t *testing.T) {
 				StderrRegex: string(tag.ErrInvalidTag),
 			},
 		},
+		{
+			name: "stack-b ordered and filtered with tag containing dots, dashes and underscores",
+			layout: []string{
+				`s:stack-a:tags=["v1.0.0-rc1_experiment"]`,
+				`s:stack-b:tags=["v1.0.1-rc1_experiment"];after=[":tag:v1.0.0-rc1_experiment"]`,
+			},
+			filterTags: []string{"v1.0.0-rc1_experiment"},
+			want: RunExpected{
+				Stdout: nljoin(
+					"/stack-a",
+				),
+			},
+		},
 	} {
 		testRunSelection(t, tc)
 	}

--- a/stack.tm.hcl
+++ b/stack.tm.hcl
@@ -4,6 +4,6 @@
 stack {
   name        = "package terramate // import \"github.com/terramate-io/terramate\""
   description = "package terramate // import \"github.com/terramate-io/terramate\"\n\nPackage terramate provides functions for managing terraform stacks. A stack is a\nunit of independent runnable terraform modules.\n\nfunc Version() string"
-  tags        = ["golang"]
+  tags        = ["golang", "tag.with.dots"]
   id          = "ff77cc8c-87da-4411-bdbe-ad2feec7ba23"
 }


### PR DESCRIPTION
## What this PR does / why we need it:

Apply #1925  to v0.11.

Relax the tag parser to allow dots.

A tag must:
- start with an alphabetical lowercase character: `a-z`
- contain any alphanumerical (`0-9a-z`), `-`, `.` or `_` in the middle. **<- CHANGED**
- and end with an alphanumerical: `0-9a-z`

## Which issue(s) this PR fixes:
none

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
yes, add a new feat
```
