### PR TITLE
chore: avoid in-place modifications of AST nodes in the partial evaluation

### DIFF
--- a/generate/genhcl/genhcl.go
+++ b/generate/genhcl/genhcl.go
@@ -417,13 +417,7 @@ func loadGenHCLBlocks(root *config.Root, st *config.Stack, cfgdir project.Path) 
 func copyBody(dest *hclwrite.Body, src *hclsyntax.Body, eval hcl.Evaluator) error {
 	attrs := ast.SortRawAttributes(ast.AsHCLAttributes(src.Attributes))
 	for _, attr := range attrs {
-		// a generate_hcl.content block must be partially evaluated multiple
-		// times then the updates nodes should not be persisted.
-		expr := &ast.CloneExpression{
-			Expression: attr.Expr.(hclsyntax.Expression),
-		}
-
-		newexpr, _, err := eval.PartialEval(expr)
+		newexpr, _, err := eval.PartialEval(attr.Expr)
 		if err != nil {
 			return errors.E(err, attr.Expr.Range())
 		}
@@ -708,11 +702,6 @@ func getDynamicBlockAttrs(block *hclsyntax.Block) (dynBlockAttributes, error) {
 		switch name {
 		case "attributes":
 			dynAttrs.attributes = attr
-			if _, ok := attr.Expr.(*ast.CloneExpression); !ok {
-				dynAttrs.attributes.Expr = &ast.CloneExpression{
-					Expression: attr.Expr,
-				}
-			}
 
 		case "for_each":
 			dynAttrs.foreach = attr

--- a/hcl/ast/expr_clone.go
+++ b/hcl/ast/expr_clone.go
@@ -8,18 +8,7 @@ import (
 
 	"github.com/terramate-io/hcl/v2"
 	"github.com/terramate-io/hcl/v2/hclsyntax"
-	"github.com/zclconf/go-cty/cty"
 )
-
-// CloneExpression is an expression wrapper that
-type CloneExpression struct {
-	hclsyntax.Expression
-}
-
-// Value evaluates the wrapped expression.
-func (clone *CloneExpression) Value(ctx *hcl.EvalContext) (cty.Value, hcl.Diagnostics) {
-	return clone.Expression.Value(ctx)
-}
 
 // CloneExpr clones the given expression.
 func CloneExpr(expr hclsyntax.Expression) hclsyntax.Expression {

--- a/mapexpr/map.go
+++ b/mapexpr/map.go
@@ -78,12 +78,8 @@ func NewMapExpr(block *ast.MergedBlock) (*MapExpr, error) {
 		Origin:   block.RawOrigins[0].Range,
 		Children: children,
 		Attrs: Attributes{
-			ForEach: &ast.CloneExpression{
-				Expression: block.Attributes["for_each"].Expr.(hclsyntax.Expression),
-			},
-			Key: &ast.CloneExpression{
-				Expression: block.Attributes["key"].Expr.(hclsyntax.Expression),
-			},
+			ForEach:    block.Attributes["for_each"].Expr.(hclsyntax.Expression),
+			Key:        block.Attributes["key"].Expr.(hclsyntax.Expression),
 			ValueAttr:  valueExpr,
 			ValueBlock: valueBlock,
 			Iterator:   iterator,

--- a/stdlib/ternary.go
+++ b/stdlib/ternary.go
@@ -8,7 +8,6 @@ import (
 	"github.com/terramate-io/hcl/v2/ext/customdecode"
 	"github.com/terramate-io/hcl/v2/hclsyntax"
 	"github.com/terramate-io/terramate/errors"
-	"github.com/terramate-io/terramate/hcl/ast"
 	"github.com/terramate-io/terramate/hcl/eval"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/function"
@@ -51,9 +50,7 @@ func evalTernaryBranch(arg cty.Value) (cty.Value, error) {
 	closure := customdecode.ExpressionClosureFromVal(arg)
 
 	ctx := eval.NewContextFrom(closure.EvalContext)
-	newexpr, _, err := ctx.PartialEval(&ast.CloneExpression{
-		Expression: closure.Expression.(hclsyntax.Expression),
-	})
+	newexpr, _, err := ctx.PartialEval(closure.Expression.(hclsyntax.Expression))
 	if err != nil {
 		return cty.NilVal, errors.E(err, "evaluating tm_ternary branch")
 	}


### PR DESCRIPTION
## What this PR does / why we need it:

The in-place AST modifications were a nice optimization when generation was serial but with the introduction of #1937 it's racy.

## Which issue(s) this PR fixes:
none
## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
no
```
