### PR TITLE
chore: pin github actions.

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -18,13 +18,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
         with:
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
           fetch-depth: 0
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # pin@v5
         with:
           go-version: '1.21'
 
@@ -34,8 +34,8 @@ jobs:
           echo "result<<EOF" >> $GITHUB_OUTPUT
           echo "$(make bench/check new=${{ github.event.pull_request.head.sha }} old=${{ github.event.pull_request.base.ref }})" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
-      
-      - uses: marocchino/sticky-pull-request-comment@v2
+
+      - uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # pin@v2
         with:
           header: benchmark
           message: |

--- a/.github/workflows/ci-experimental.yml
+++ b/.github/workflows/ci-experimental.yml
@@ -5,6 +5,7 @@ name: ci-experimental
 on:
   pull_request:
 
+
 jobs:
   build_test:
     name: Build and Test
@@ -13,24 +14,24 @@ jobs:
 
     strategy:
       matrix:
-        os: ["windows-2022"]
-        go: ["1.21"]
+        os: [ "windows-2022" ]
+        go: [ "1.21" ]
 
     steps:
       - name: configure git
         run: git config --global core.autocrlf input
 
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
+      - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # pin@v5
         with:
           go-version: ${{ matrix.go }}
 
-      - uses: opentofu/setup-opentofu@v1
+      - uses: opentofu/setup-opentofu@12f4debbf681675350b6cd1f0ff8ecfbda62027b # pin@v1
         with:
           tofu_version: 1.6.2
           tofu_wrapper: false
           github_token: ${{ secrets.GITHUB_TOKEN }}
-    
+
       - name: make build
         run: make build
 

--- a/.github/workflows/ci-sync-deployment.yml
+++ b/.github/workflows/ci-sync-deployment.yml
@@ -28,31 +28,31 @@ jobs:
             value: "ubuntu-20.04"
           - name: macos-ventura
             value: "macos-13"
-        go: ["1.21"]
+        go: [ "1.21" ]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # pin@v5
         with:
           go-version: ${{ matrix.go }}
 
-      - uses: opentofu/setup-opentofu@v1
+      - uses: opentofu/setup-opentofu@12f4debbf681675350b6cd1f0ff8ecfbda62027b # pin@v1
         with:
           tofu_version: 1.6.2
           tofu_wrapper: false
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: hashicorp/setup-terraform@v3
+      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # pin@v3
         with:
           terraform_version: "1.7.5"
           terraform_wrapper: false
 
       - name: Install Terramate
-        uses: terramate-io/terramate-action@i4k-fix-macos
+        uses: terramate-io/terramate-action@b733b79e37eda5caba8703a75b522e9053d0846e # pin@i4k-fix-macos
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -92,7 +92,7 @@ jobs:
       - name: Check Terraform formatting
         if: ${{ steps.list_go_packages.outputs.stdout || steps.list_e2e_packages }}
         run: terraform fmt -recursive -check -diff
-      
+
       ### Run the Terramate tests and create a Cloud deployment
 
       - name: Run Terraform deployment on changed packages
@@ -110,7 +110,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           TM_TEST_TERRAFORM_REQUIRED_VERSION: "1.7.5"
-  
+
       - name: Else only run the changed e2e packages
         if: ${{ !steps.list_e2e_packages.outputs.stdout && steps.list_e2e_packages.outputs.stdout }}
         timeout-minutes: 30
@@ -118,33 +118,33 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           TM_TEST_TERRAFORM_REQUIRED_VERSION: "1.7.5"
-  
+
   release_dry_run:
     name: Release Dry Run
 
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
         with:
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
           fetch-depth: 0
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # pin@v5
         with:
           go-version: '1.21'
 
-      - name: install cosign 
+      - name: install cosign
         run: go install github.com/sigstore/cosign/v2/cmd/cosign@v2.2.4
       - name: install goreleaser
         run: |
           curl -sL https://github.com/goreleaser/goreleaser-pro/releases/download/v1.14.0-pro/goreleaser-pro_Linux_x86_64.tar.gz -o /tmp/goreleaser.tar.gz
           cd /tmp && tar -xzf goreleaser.tar.gz && chmod +x goreleaser
           sudo mv /tmp/goreleaser /usr/local/bin/
-      
+
       - name: Create cosign.pub file
-        run: echo "${{ secrets.COSIGN_PUBLIC_KEY }}" > cosign.pub      
-        
+        run: echo "${{ secrets.COSIGN_PUBLIC_KEY }}" > cosign.pub
+
       - name: release dry run
         run: make release/dry-run
         env:

--- a/.github/workflows/ci-sync-preview.yml
+++ b/.github/workflows/ci-sync-preview.yml
@@ -6,6 +6,7 @@ name: ci
 on:
   pull_request:
 
+
 jobs:
   build_test:
     name: Build and Test
@@ -13,7 +14,7 @@ jobs:
 
     permissions:
       id-token: write # This is required for requesting the JWT
-      contents: read  # This is required for actions/checkout
+      contents: read # This is required for actions/checkout
       pull-requests: write
       checks: read
 
@@ -25,34 +26,34 @@ jobs:
             value: "ubuntu-20.04"
           - name: macos-ventura
             value: "macos-13"
-        go: ["1.21"]
+        go: [ "1.21" ]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # pin@v5
         with:
           go-version: ${{ matrix.go }}
 
       - name: check all packages with tests are Terramate Stacks
         run: ./hack/check-stacks.sh
 
-      - uses: opentofu/setup-opentofu@v1
+      - uses: opentofu/setup-opentofu@12f4debbf681675350b6cd1f0ff8ecfbda62027b # pin@v1
         with:
           tofu_version: 1.6.2
           tofu_wrapper: false
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: hashicorp/setup-terraform@v3
+      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # pin@v3
         with:
           terraform_version: "1.7.5"
           terraform_wrapper: false
 
       - name: Install Terramate
-        uses: terramate-io/terramate-action@i4k-fix-macos
+        uses: terramate-io/terramate-action@b733b79e37eda5caba8703a75b522e9053d0846e # pin@i4k-fix-macos
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -95,7 +96,7 @@ jobs:
       - name: Check Terraform formatting
         if: ${{ steps.list_go_packages.outputs.stdout || steps.list_e2e_packages }}
         run: terraform fmt -recursive -check -diff
-      
+
       ### Run the Terramate tests and create a Cloud Preview
 
       - name: Temporary PR Preview Link generation
@@ -170,7 +171,7 @@ jobs:
           cat pr-comment.txt >>$GITHUB_STEP_SUMMARY
 
       - name: Publish Plans for Changed Stacks
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # pin@v2
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           header: preview-${{ matrix.os.name }}-go-${{matrix.go}}
@@ -182,26 +183,26 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
         with:
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
           fetch-depth: 0
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # pin@v5
         with:
           go-version: '1.21'
 
-      - name: install cosign 
+      - name: install cosign
         run: go install github.com/sigstore/cosign/v2/cmd/cosign@v2.2.4
       - name: install goreleaser
         run: |
           curl -sL https://github.com/goreleaser/goreleaser-pro/releases/download/v1.14.0-pro/goreleaser-pro_Linux_x86_64.tar.gz -o /tmp/goreleaser.tar.gz
           cd /tmp && tar -xzf goreleaser.tar.gz && chmod +x goreleaser
           sudo mv /tmp/goreleaser /usr/local/bin/
-      
+
       - name: Create cosign.pub file
-        run: echo "${{ secrets.COSIGN_PUBLIC_KEY }}" > cosign.pub      
-        
+        run: echo "${{ secrets.COSIGN_PUBLIC_KEY }}" > cosign.pub
+
       - name: release dry run
         run: make release/dry-run
         env:

--- a/.github/workflows/interop-tests.yml
+++ b/.github/workflows/interop-tests.yml
@@ -10,21 +10,21 @@ on:
 jobs:
   interop-tests:
     permissions:
-      id-token: write       # This is required for requesting the JWT
-      contents: read        # This is required for actions/checkout
-      pull-requests: write  # This is required for commenting on the PR.
-      checks: read          # This is required for fetching check runs.
+      id-token: write # This is required for requesting the JWT
+      contents: read # This is required for actions/checkout
+      pull-requests: write # This is required for commenting on the PR.
+      checks: read # This is required for fetching check runs.
 
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
         with:
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
           fetch-depth: 0
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # pin@v5
         with:
           go-version: '1.21'
 
@@ -38,8 +38,8 @@ jobs:
           TMC_API_HOST: api.stg.terramate.io
           TM_CLOUD_ORGANIZATION: test
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      
-      - uses: marocchino/sticky-pull-request-comment@v2
+
+      - uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # pin@v2
         with:
           header: interop
           message: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,10 +16,10 @@ jobs:
   goreleaser:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # pin@v4
         with:
           go-version: '1.21'
 
@@ -31,13 +31,12 @@ jobs:
           cd /tmp && tar -xzf goreleaser.tar.gz && chmod +x goreleaser
           sudo mv /tmp/goreleaser /usr/local/bin/
 
-      
-      - name: install cosign 
+      - name: install cosign
         run: go install github.com/sigstore/cosign/v2/cmd/cosign@v2.2.4
 
       - name: Create cosign.pub file
         run: echo "${{ secrets.COSIGN_PUBLIC_KEY }}" > cosign.pub
-      
+
       - name: Run GoReleaser
         run: make release
         env:
@@ -51,7 +50,7 @@ jobs:
           GORELEASER_KEY: ${{ secrets.GORELEASER_API_KEY }}
           FURY_TOKEN: ${{ secrets.FURY_TOKEN}}
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD}}
-          COSIGN_PRIVATE_KEY: ${{secrets.COSIGN_PRIVATE_KEY }}          
+          COSIGN_PRIVATE_KEY: ${{secrets.COSIGN_PRIVATE_KEY }}
       - name: Locate checksum file
         id: find_checksum
         run: |

--- a/makefiles/common.mk
+++ b/makefiles/common.mk
@@ -93,6 +93,11 @@ license:
 license/check:
 	$(RUN_ADD_LICENSE) --check .
 
+## pin github actions versions (install with: npm install -g pin-github-action)
+.PHONY: pin-gha
+pin-gha:
+	pin-github-action ./.github/workflows/*.yml
+
 ## generates coverage report
 .PHONY: coverage
 coverage:


### PR DESCRIPTION
## What this PR does / why we need it:

For security reasons we should pin the github action versions.

A `make pin-gha` command is added to automate this.

## Which issue(s) this PR fixes:
none

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
no
```
