### PR TITLE
feat: add terramate.stack.parent.id.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 
 ## Unreleased
 
+### Added
+
+- Add `terramate.stack.parent.id` metadata to stacks that are part of a parent-child hierarchy.
+
 ## v0.11.1
 
 ### Added

--- a/config/stack.go
+++ b/config/stack.go
@@ -236,6 +236,21 @@ func (s *Stack) RuntimeValues(root *Root) map[string]cty.Value {
 	if s.ID != "" {
 		stackMapVals["id"] = cty.StringVal(s.ID)
 	}
+	cfg, _ := root.Lookup(s.Dir)
+	var parentStack *Tree
+
+	for cfg.Parent != nil {
+		cfg = cfg.Parent
+		if cfg.IsStack() {
+			parentStack = cfg
+			break
+		}
+	}
+	if parentStack != nil {
+		stackMapVals["parent"] = cty.ObjectVal(map[string]cty.Value{
+			"id": cty.StringVal(parentStack.Node.Stack.ID),
+		})
+	}
 	stack := cty.ObjectVal(stackMapVals)
 	return map[string]cty.Value{
 		"name":        cty.StringVal(s.Name),         // DEPRECATED

--- a/e2etests/core/debug_show_metadata_test.go
+++ b/e2etests/core/debug_show_metadata_test.go
@@ -249,6 +249,72 @@ stack "/stack":
 `,
 			},
 		},
+		{
+			name: "one stack with parent stack",
+			layout: []string{
+				`s:parent:id=parent-stack`,
+				`s:parent/child`,
+			},
+			want: RunExpected{
+				Stdout: `Available metadata:
+
+project metadata:
+	terramate.stacks.list=[/parent /parent/child]
+
+stack "/parent":
+	terramate.stack.id="parent-stack"
+	terramate.stack.name="parent"
+	terramate.stack.description=""
+	terramate.stack.tags=[]
+	terramate.stack.path.absolute="/parent"
+	terramate.stack.path.basename="parent"
+	terramate.stack.path.relative="parent"
+	terramate.stack.path.to_root=".."
+
+stack "/parent/child":
+	terramate.stack.name="child"
+	terramate.stack.description=""
+	terramate.stack.tags=[]
+	terramate.stack.path.absolute="/parent/child"
+	terramate.stack.path.basename="child"
+	terramate.stack.path.relative="parent/child"
+	terramate.stack.path.to_root="../.."
+`,
+			},
+		},
+		{
+			name: "one stack with parent stack separated by directories",
+			layout: []string{
+				`s:parent:id=parent-stack`,
+				`s:parent/some/child/stack`,
+			},
+			want: RunExpected{
+				Stdout: `Available metadata:
+
+project metadata:
+	terramate.stacks.list=[/parent /parent/some/child/stack]
+
+stack "/parent":
+	terramate.stack.id="parent-stack"
+	terramate.stack.name="parent"
+	terramate.stack.description=""
+	terramate.stack.tags=[]
+	terramate.stack.path.absolute="/parent"
+	terramate.stack.path.basename="parent"
+	terramate.stack.path.relative="parent"
+	terramate.stack.path.to_root=".."
+
+stack "/parent/some/child/stack":
+	terramate.stack.name="stack"
+	terramate.stack.description=""
+	terramate.stack.tags=[]
+	terramate.stack.path.absolute="/parent/some/child/stack"
+	terramate.stack.path.basename="stack"
+	terramate.stack.path.relative="parent/some/child/stack"
+	terramate.stack.path.to_root="../../../.."
+`,
+			},
+		},
 	} {
 		tc := tcase
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## What this PR does / why we need it:

Implements `terramate.stack.parent.id` metadata for stacks that has parent stacks.

## Which issue(s) this PR fixes:
none

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
yes, add a new feature
```
