### PR TITLE
fix: fmt not respecting .tmskip file.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 
 ## Unreleased
 
+### Fixed
+
+- Fix `terramate fmt` not respecting the `.tmskip` file.
+
 ## v0.11.1
 
 ### Added

--- a/config/config.go
+++ b/config/config.go
@@ -32,14 +32,6 @@ import (
 )
 
 const (
-	// DefaultFilename is the name of the default Terramate configuration file.
-	DefaultFilename = "terramate.tm.hcl"
-
-	// SkipFilename is the name of Terramate skip file.
-	SkipFilename = ".tmskip"
-)
-
-const (
 	// ErrSchema indicates that the configuration has an invalid schema.
 	ErrSchema errors.Kind = "config has an invalid schema"
 )
@@ -456,7 +448,7 @@ func loadTree(parentTree *Tree, cfgdir string, rootcfg *hcl.Config) (_ *Tree, er
 	}
 
 	for _, fname := range otherFiles {
-		if fname == SkipFilename {
+		if fname == terramate.SkipFilename {
 			logger.Debug().Msg("skip file found: skipping whole subtree")
 			return newSkippedTree(cfgdir), nil
 		}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/madlambda/spells/assert"
 	"github.com/rs/zerolog"
+	"github.com/terramate-io/terramate"
 	"github.com/terramate-io/terramate/config"
 	"github.com/terramate-io/terramate/errors"
 	"github.com/terramate-io/terramate/project"
@@ -306,7 +307,7 @@ func TestConfigSkipdir(t *testing.T) {
 	s.BuildTree([]string{
 		"s:/stack",
 		"s:/stack-2",
-		"f:/stack/" + config.SkipFilename,
+		"f:/stack/" + terramate.SkipFilename,
 		"f:/stack/ignored.tm:not valid hcl but wont be parsed",
 		"f:/stack/subdir/ignored.tm:not valid hcl but wont be parsed",
 	})

--- a/constants.go
+++ b/constants.go
@@ -1,0 +1,12 @@
+// Copyright 2024 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+package terramate
+
+const (
+	// DefaultFilename is the name of the default Terramate configuration file.
+	DefaultFilename = "terramate.tm.hcl"
+
+	// SkipFilename is the name of Terramate skip file.
+	SkipFilename = ".tmskip"
+)

--- a/e2etests/core/fmt_test.go
+++ b/e2etests/core/fmt_test.go
@@ -49,6 +49,10 @@ name = "name"
 			sprintf("f:stacks/globals.tm:%s", unformattedHCL),
 			sprintf("f:stacks/stack-1/globals.tm:%s", unformattedHCL),
 			sprintf("f:stacks/stack-2/globals.tm:%s", unformattedHCL),
+
+			// dir below must always be ignored
+			`f:skipped-dir/.tmskip:`,
+			sprintf("f:skipped-dir/globals.tm:%s", unformattedHCL),
 		})
 	}
 

--- a/e2etests/core/generate_test.go
+++ b/e2etests/core/generate_test.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/terramate-io/terramate/config"
+	"github.com/terramate-io/terramate"
 	"github.com/terramate-io/terramate/generate"
 	"github.com/terramate-io/terramate/modvendor"
 	"github.com/terramate-io/terramate/project"
@@ -568,7 +568,7 @@ func TestE2EGenerateRespectsWorkingDirectory(t *testing.T) {
 			})
 
 			s.RootEntry().CreateFile(
-				config.DefaultFilename,
+				terramate.DefaultFilename,
 				configStr,
 			)
 

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
+	"github.com/terramate-io/terramate"
 	"github.com/terramate-io/terramate/config"
 	"github.com/terramate-io/terramate/errors"
 	"github.com/terramate-io/terramate/event"
@@ -540,7 +541,7 @@ processSubdirs:
 
 		// We need to skip all other files/dirs if we find a config.SkipFilename
 		for _, entry := range entries {
-			if entry.Name() == config.SkipFilename {
+			if entry.Name() == terramate.SkipFilename {
 				continue processSubdirs
 			}
 		}

--- a/generate/generate_hcl_test.go
+++ b/generate/generate_hcl_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/madlambda/spells/assert"
+	"github.com/terramate-io/terramate"
 	"github.com/terramate-io/terramate/config"
 	"github.com/terramate-io/terramate/errors"
 	"github.com/terramate-io/terramate/generate"
@@ -824,7 +825,7 @@ func TestGenerateHCL(t *testing.T) {
 					path: "/stacks/stack-1",
 					add: Doc(
 						Import(
-							Str("source", fmt.Sprintf("/common/%s", config.DefaultFilename)),
+							Str("source", fmt.Sprintf("/common/%s", terramate.DefaultFilename)),
 						),
 						Globals(
 							Str("local_a", "stack-1-local"),
@@ -842,7 +843,7 @@ func TestGenerateHCL(t *testing.T) {
 					path: "/stacks/stack-2",
 					add: Doc(
 						Import(
-							Str("source", fmt.Sprintf("/common/%s", config.DefaultFilename)),
+							Str("source", fmt.Sprintf("/common/%s", terramate.DefaultFilename)),
 						),
 						Globals(
 							Str("local_a", "stack-2-local"),
@@ -1122,7 +1123,7 @@ func TestGenerateHCL(t *testing.T) {
 				{
 					path: "/stacks/stack",
 					add: Import(
-						Str("source", fmt.Sprintf("/other/%s", config.DefaultFilename)),
+						Str("source", fmt.Sprintf("/other/%s", terramate.DefaultFilename)),
 					),
 				},
 			},
@@ -2102,7 +2103,7 @@ func TestWontOverwriteManuallyDefinedTerraform(t *testing.T) {
 
 	s := sandbox.NoGit(t, true)
 	s.BuildTree([]string{
-		fmt.Sprintf("f:%s:%s", config.DefaultFilename, generateHCLConfig.String()),
+		fmt.Sprintf("f:%s:%s", terramate.DefaultFilename, generateHCLConfig.String()),
 		"s:stack",
 		fmt.Sprintf("f:stack/%s:%s", genFilename, manualTfCode),
 	})

--- a/generate/generate_list_test.go
+++ b/generate/generate_list_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/madlambda/spells/assert"
-	"github.com/terramate-io/terramate/config"
+	"github.com/terramate-io/terramate"
 	"github.com/terramate-io/terramate/generate"
 	"github.com/terramate-io/terramate/generate/genhcl"
 	. "github.com/terramate-io/terramate/test/hclwrite/hclutils"
@@ -131,7 +131,7 @@ func TestGeneratedFilesListing(t *testing.T) {
 			layout: []string{
 				genfile("genfiles/1.tf"),
 				genfile("genfiles/2.tf"),
-				genfile("genfiles/" + config.SkipFilename),
+				genfile("genfiles/" + terramate.SkipFilename),
 				genfile("genfiles/subdir/1.tf"),
 				genfile("genfiles2/1.tf"),
 			},
@@ -145,7 +145,7 @@ func TestGeneratedFilesListing(t *testing.T) {
 			layout: []string{
 				"s:stack",
 				genfile("stack/1.tf"),
-				genfile("stack/dir/" + config.SkipFilename),
+				genfile("stack/dir/" + terramate.SkipFilename),
 				genfile("stack/dir/1.tf"),
 			},
 			want: []string{

--- a/generate/generate_test.go
+++ b/generate/generate_test.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/madlambda/spells/assert"
 	"github.com/rs/zerolog"
-	"github.com/terramate-io/terramate/config"
+	"github.com/terramate-io/terramate"
 	"github.com/terramate-io/terramate/errors"
 	"github.com/terramate-io/terramate/generate"
 	"github.com/terramate-io/terramate/generate/genhcl"
@@ -61,8 +61,8 @@ func TestGenerateIgnore(t *testing.T) {
 			layout: []string{
 				"s:stacks/stack",
 				"s:stacks/stack-2",
-				"f:stacks/stack-2/" + config.SkipFilename,
-				"f:not-a-stack/" + config.SkipFilename,
+				"f:stacks/stack-2/" + terramate.SkipFilename,
+				"f:not-a-stack/" + terramate.SkipFilename,
 			},
 			configs: []hclconfig{
 				{
@@ -1159,7 +1159,7 @@ func testCodeGeneration(t *testing.T, tcases []testcase) {
 				path := filepath.Join(s.RootDir(), cfg.path)
 				filename := cfg.filename
 				if filename == "" {
-					filename = config.DefaultFilename
+					filename = terramate.DefaultFilename
 				}
 				configurationFiles[filepath.Join(path, filename)] = struct{}{}
 				test.AppendFile(t, path, filename, cfg.add.String())
@@ -1255,7 +1255,7 @@ func testCodeGeneration(t *testing.T, tcases []testcase) {
 					return nil
 				}
 
-				if d.Name() == config.DefaultFilename ||
+				if d.Name() == terramate.DefaultFilename ||
 					d.Name() == stackpkg.DefaultFilename ||
 					d.Name() == "root.config.tm" {
 					return nil

--- a/generate/genhcl/genhcl_test.go
+++ b/generate/genhcl/genhcl_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/madlambda/spells/assert"
 	"github.com/rs/zerolog"
+	"github.com/terramate-io/terramate"
 	"github.com/terramate-io/terramate/config"
 	"github.com/terramate-io/terramate/errors"
 	"github.com/terramate-io/terramate/generate/genhcl"
@@ -1881,7 +1882,7 @@ func (tcase testcase) run(t *testing.T) {
 		for _, cfg := range tcase.configs {
 			filename := cfg.filename
 			if filename == "" {
-				filename = config.DefaultFilename
+				filename = terramate.DefaultFilename
 			}
 			path := filepath.Join(s.RootDir(), cfg.path)
 			test.AppendFile(t, path, filename, cfg.add.String())

--- a/generate/genhcl/partial_eval_test.go
+++ b/generate/genhcl/partial_eval_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/madlambda/spells/assert"
+	"github.com/terramate-io/terramate"
 	"github.com/terramate-io/terramate/config"
 	"github.com/terramate-io/terramate/errors"
 	"github.com/terramate-io/terramate/generate/genhcl"
@@ -1885,7 +1886,7 @@ EOT
 			)
 
 			t.Logf("input: %s", hclcfg.String())
-			test.AppendFile(t, path, config.DefaultFilename, hclcfg.String())
+			test.AppendFile(t, path, terramate.DefaultFilename, hclcfg.String())
 
 			root, err := config.LoadRoot(s.RootDir())
 			if errors.IsAnyKind(err, hcl.ErrHCLSyntax, hcl.ErrTerramateSchema) {

--- a/generate/outdated_detection_test.go
+++ b/generate/outdated_detection_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/madlambda/spells/assert"
-	"github.com/terramate-io/terramate/config"
+	"github.com/terramate-io/terramate"
 	"github.com/terramate-io/terramate/errors"
 	"github.com/terramate-io/terramate/generate"
 	"github.com/terramate-io/terramate/project"
@@ -1369,7 +1369,7 @@ func TestOutdatedDetection(t *testing.T) {
 					layout: []string{
 						"s:stack-1",
 						"s:stack-2",
-						"f:stack-2/" + config.SkipFilename,
+						"f:stack-2/" + terramate.SkipFilename,
 					},
 					files: []file{
 						{

--- a/globals/globals_test.go
+++ b/globals/globals_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/madlambda/spells/assert"
 	"github.com/rs/zerolog"
+	"github.com/terramate-io/terramate"
 	"github.com/terramate-io/terramate/config"
 	"github.com/terramate-io/terramate/errors"
 	"github.com/terramate-io/terramate/globals"
@@ -4063,7 +4064,7 @@ func TestLoadGlobalsErrors(t *testing.T) {
 
 			for _, c := range tcase.configs {
 				path := filepath.Join(s.RootDir(), c.path)
-				test.AppendFile(t, path, config.DefaultFilename, c.body)
+				test.AppendFile(t, path, terramate.DefaultFilename, c.body)
 			}
 
 			root, err := config.LoadRoot(s.RootDir())
@@ -4093,7 +4094,7 @@ func testGlobals(t *testing.T, tcase testcase) {
 		s.BuildTree(tcase.layout)
 		for _, globalBlock := range tcase.configs {
 			path := filepath.Join(s.RootDir(), globalBlock.path)
-			filename := config.DefaultFilename
+			filename := terramate.DefaultFilename
 			if globalBlock.filename != "" {
 				filename = globalBlock.filename
 			}

--- a/test/sandbox/sandbox.go
+++ b/test/sandbox/sandbox.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/madlambda/spells/assert"
+	"github.com/terramate-io/terramate"
 	"github.com/terramate-io/terramate/config"
 	"github.com/terramate-io/terramate/fs"
 	"github.com/terramate-io/terramate/generate"
@@ -456,7 +457,7 @@ func (de DirEntry) CreateConfig(body string) FileEntry {
 
 	fe := FileEntry{
 		t:        de.t,
-		hostpath: filepath.Join(de.abspath, config.DefaultFilename),
+		hostpath: filepath.Join(de.abspath, terramate.DefaultFilename),
 	}
 	fe.Write(body)
 	return fe
@@ -467,7 +468,7 @@ func (de DirEntry) DeleteConfig() {
 	de.t.Helper()
 
 	assert.NoError(de.t,
-		os.Remove(filepath.Join(de.abspath, config.DefaultFilename)),
+		os.Remove(filepath.Join(de.abspath, terramate.DefaultFilename)),
 		"removing default configuration file")
 }
 
@@ -563,7 +564,7 @@ func (se StackEntry) ModSource(mod DirEntry) string {
 func (se StackEntry) WriteConfig(cfg hcl.Config) {
 	var out bytes.Buffer
 	assert.NoError(se.t, hcl.PrintConfig(&out, cfg))
-	se.DirEntry.CreateFile(config.DefaultFilename, out.String())
+	se.DirEntry.CreateFile(terramate.DefaultFilename, out.String())
 }
 
 // DeleteStackConfig deletes the default stack definition file.
@@ -699,7 +700,7 @@ func buildTree(t testing.TB, root *config.Root, environ []string, layout []strin
 			}
 		}
 
-		assert.NoError(t, cfg.Save(config.DefaultFilename),
+		assert.NoError(t, cfg.Save(terramate.DefaultFilename),
 			"BuildTree() failed to generate config file.")
 	}
 


### PR DESCRIPTION
## What this PR does / why we need it:

Fixes the `terramate fmt` command not respecting the `.tmskip`.

## Which issue(s) this PR fixes:
Fixes #1952 

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
yes, fixes a bug.
```
