### PR TITLE
fix: change detection of Terragrunt module source.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 
 ## Unreleased
 
+### Fixed
+
+- Fix Terragrunt modules change detection.
+
 ## v0.11.2
 
 ### Added

--- a/test/git.go
+++ b/test/git.go
@@ -4,6 +4,7 @@
 package test
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/madlambda/spells/assert"
@@ -48,7 +49,10 @@ func EmptyRepo(t testing.TB, bare bool) string {
 	gw := NewGitWrapper(t, "", []string{})
 
 	repodir := TempDir(t)
-	err := gw.Init(repodir, DefBranch, bare)
+	// resolve symlinks
+	repodir, err := filepath.EvalSymlinks(repodir)
+	assert.NoError(t, err, "evaluating symlinks")
+	err = gw.Init(repodir, DefBranch, bare)
 	assert.NoError(t, err, "git init")
 
 	return repodir


### PR DESCRIPTION
## What this PR does / why we need it:

Fix the Terragrunt change detection for the case the `terraform.source` references a local directory.

## Which issue(s) this PR fixes:
Fixes #1959 

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
yes, fixes a bug.
```
