### PR TITLE
chore: refactor project paths in change detection.

### DIFF
--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -1221,10 +1221,10 @@ func (c *cli) checkGitUncommited() bool {
 	return !cfg.Terramate.Config.HasSafeguardDisabled(safeguard.GitUncommitted)
 }
 
-func debugFiles(files []string, msg string) {
+func debugFiles(files prj.Paths, msg string) {
 	for _, file := range files {
 		log.Debug().
-			Str("file", file).
+			Stringer("file", file).
 			Msg(msg)
 	}
 }
@@ -2335,7 +2335,7 @@ func (c *cli) setupEvalContext(st *config.Stack, overrideGlobals map[string]stri
 			globalPath,
 			expr,
 			info.NewRange(c.rootdir(), hhcl.Range{
-				Filename: "<eval argument>",
+				Filename: filepath.Join(c.rootdir(), "<cmdline>"),
 				Start:    hhcl.InitialPos,
 				End:      hhcl.InitialPos,
 			}),

--- a/e2etests/core/change_detection_test.go
+++ b/e2etests/core/change_detection_test.go
@@ -315,8 +315,8 @@ func TestChangeDetection(t *testing.T) {
 		assert.EqualInts(t, 3, len(report.Stacks))
 		assert.EqualInts(t, 1, len(report.Checks.UntrackedFiles))
 		assert.EqualInts(t, 1, len(report.Checks.UncommittedFiles))
-		assert.EqualStrings(t, "stacks/s3/untracked.tf", report.Checks.UntrackedFiles[0])
-		assert.EqualStrings(t, "stacks/s2/main.tf", report.Checks.UncommittedFiles[0])
+		assert.EqualStrings(t, "/stacks/s3/untracked.tf", report.Checks.UntrackedFiles[0].String())
+		assert.EqualStrings(t, "/stacks/s2/main.tf", report.Checks.UncommittedFiles[0].String())
 		assert.EqualStrings(t, report.Stacks[0].Stack.Dir.String(), "/stacks/s1")
 		assert.EqualStrings(t, report.Stacks[1].Stack.Dir.String(), "/stacks/s2")
 		assert.EqualStrings(t, report.Stacks[2].Stack.Dir.String(), "/stacks/s3")
@@ -462,17 +462,17 @@ func TestChangeDetection(t *testing.T) {
 		assert.EqualInts(t, 0, len(report.Stacks))
 		assert.EqualInts(t, 4, len(report.Checks.UntrackedFiles))
 		assert.EqualInts(t, 1, len(report.Checks.UncommittedFiles))
-		assert.EqualStrings(t, "stacks/s3/untracked.tf", report.Checks.UntrackedFiles[0])
-		if !strings.HasPrefix(report.Checks.UntrackedFiles[1], ".tmtriggers/stacks/s1/ignore-change-") {
+		assert.EqualStrings(t, "/stacks/s3/untracked.tf", report.Checks.UntrackedFiles[0].String())
+		if !strings.HasPrefix(report.Checks.UntrackedFiles[1].String(), "/.tmtriggers/stacks/s1/ignore-change-") {
 			t.Errorf("unexpected untracked file: %s", report.Checks.UntrackedFiles[1])
 		}
-		if !strings.HasPrefix(report.Checks.UntrackedFiles[2], ".tmtriggers/stacks/s2/ignore-change-") {
+		if !strings.HasPrefix(report.Checks.UntrackedFiles[2].String(), "/.tmtriggers/stacks/s2/ignore-change-") {
 			t.Errorf("unexpected untracked file: %s", report.Checks.UntrackedFiles[2])
 		}
-		if !strings.HasPrefix(report.Checks.UntrackedFiles[3], ".tmtriggers/stacks/s3/ignore-change-") {
+		if !strings.HasPrefix(report.Checks.UntrackedFiles[3].String(), "/.tmtriggers/stacks/s3/ignore-change-") {
 			t.Errorf("unexpected untracked file: %s", report.Checks.UntrackedFiles[3])
 		}
-		assert.EqualStrings(t, "stacks/s2/main.tf", report.Checks.UncommittedFiles[0])
+		assert.EqualStrings(t, "/stacks/s2/main.tf", report.Checks.UncommittedFiles[0].String())
 
 		AssertRunResult(t,
 			tmcli.Run("run", "--quiet", "--changed", "--disable-safeguards=git", "--", HelperPath, "stack-abs-path", s.RootDir()),

--- a/project/project.go
+++ b/project/project.go
@@ -119,6 +119,12 @@ func (paths Paths) Sort() {
 // PrjAbsPath converts the file system absolute path absdir into an absolute
 // project path on the form /path/on/project relative to the given root.
 func PrjAbsPath(root, abspath string) Path {
+	if !filepath.IsAbs(abspath) {
+		panic(fmt.Errorf("path %q is not absolute", abspath))
+	}
+	if !strings.HasPrefix(abspath, root) {
+		panic(fmt.Errorf("abspath %q does not start with root %q", abspath, root))
+	}
 	d := filepath.ToSlash(strings.TrimPrefix(abspath, root))
 	if d == "" {
 		d = "/"

--- a/test/sandbox/sandbox.go
+++ b/test/sandbox/sandbox.go
@@ -791,7 +791,7 @@ func assertTree(t testing.TB, root *config.Root, layout []string, opts *assertTr
 
 		case "s", "stack":
 			stackdir, _ := popArg(spec)
-			prjStackdir := project.PrjAbsPath(rootdir, stackdir)
+			prjStackdir := project.PrjAbsPath(rootdir, filepath.Join(rootdir, stackdir))
 
 			if opts.withStrictStacks {
 				wantStrictStacks = append(wantStrictStacks, prjStackdir.String())


### PR DESCRIPTION
## What this PR does / why we need it:

While fixing #1971 another problem was identified that prevented the fix.
The `project.PrjAbsPath()` function had many misuses that worked by luck in many cases but the other fix depends on this one.

## Which issue(s) this PR fixes:
none

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
no
```
