### PR TITLE
fix: warn if Terragrunt dependency is outside project.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 
 - Fix the command-line parsing of `run` and `script run` which were not failing from unknown flags.
 - Fix `create --all-terragrunt` creating Terragrunt stacks with cycles.
+- Panic in the Terragrunt integration when the project had modules with dependency paths outside the current Terramate project.
+  - Now Terramate throw a warning for such configurations.
 
 ## v0.11.3
 

--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -1609,7 +1609,7 @@ func (c *cli) initTerragrunt() {
 		for _, otherMod := range mod.After.Strings() {
 			// Parent stack modules must be excluded because of implicit filesystem ordering.
 			// Parent stacks are always executed before child stacks.
-			if mod.Path.HasPrefix(otherMod + "/") {
+			if otherMod == "/" || mod.Path.HasPrefix(otherMod+"/") {
 				continue
 			}
 			// after stacks must not be defined as child stacks

--- a/project/project.go
+++ b/project/project.go
@@ -122,8 +122,14 @@ func PrjAbsPath(root, abspath string) Path {
 	if !filepath.IsAbs(abspath) {
 		panic(fmt.Errorf("path %q is not absolute", abspath))
 	}
+	if root == abspath {
+		return NewPath("/")
+	}
+	if !strings.HasSuffix(root, string(filepath.Separator)) { // accounts for root=/
+		root = root + string(filepath.Separator)
+	}
 	if !strings.HasPrefix(abspath, root) {
-		panic(fmt.Errorf("abspath %q does not start with root %q", abspath, root))
+		panic(fmt.Errorf(`abspath %q does not start with root %q`, abspath, root))
 	}
 	d := filepath.ToSlash(strings.TrimPrefix(abspath, root))
 	if d == "" {


### PR DESCRIPTION
## What this PR does / why we need it:

Fix panic in the case of a Terragrunt module references a dependency outside of the Terramate project.
This changed adds a warning for such cases because this is not supported in Terramate at the moment.

## Which issue(s) this PR fixes:
Fixes #1979 

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
yes, fixes a panic in the Terragrunt integration.
```
