### PR TITLE
fix: add terramate create --all-terragrunt --tags a,b,c

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
     For further details, see [documentation](https://terramate.io/docs/cli/telemetry).
   - Can be turned off by setting `terramate.config.telemetry.enabled = false` in the project configuration,
     or by setting `disable_telemetry = true` in the user configuration.
+- Add `create --all-terragrunt --tags a,b,c` for creating stacks with the given tags.
 
 ### Fixed
 

--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -1605,6 +1605,7 @@ func (c *cli) initTerragrunt() {
 		if err != nil {
 			fatalWithDetailf(err, "creating stack UUID")
 		}
+
 		after := []string{}
 		for _, otherMod := range mod.After.Strings() {
 			// Parent stack modules must be excluded because of implicit filesystem ordering.
@@ -1622,11 +1623,18 @@ func (c *cli) initTerragrunt() {
 			}
 			after = append(after, otherMod)
 		}
+
+		var tags []string
+		for _, tag := range c.parsedArgs.Tags {
+			tags = append(tags, strings.Split(tag, ",")...)
+		}
+
 		stackSpec := config.Stack{
 			Dir:         mod.Path,
 			ID:          stackID.String(),
 			Name:        dirBasename,
 			Description: dirBasename,
+			Tags:        tags,
 			After:       after,
 		}
 


### PR DESCRIPTION
## What this PR does / why we need it:

Add `terramate create --all-terragrunt --tags a,b,c`.

## Which issue(s) this PR fixes:
Fixes #1966 

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
yes, add --tags to `create --all-terragrunt`.
```
