### PR TITLE
feat: track file() usage in Terragrunt change detection.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 
 ### Added
 
+- Add support for tracking `file()` usages in Terragrunt files for enhancing the change detection.
+  - Now if you have Terragrunt modules that directly read files from elsewhere in the project, Terramate will
+  mark the stack changed whenever the aforementioned file changes.
 - Add telemetry to collect anonymous usage metrics.
   - This helps us to improve user experience by measuring which Terramate features are used most actively.
     For further details, see [documentation](https://terramate.io/docs/cli/telemetry).

--- a/go.mod
+++ b/go.mod
@@ -194,7 +194,7 @@ require (
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-uuid v1.0.3
-	github.com/mitchellh/go-homedir v1.1.0 // indirect
+	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/rs/zerolog v1.28.0
 	github.com/zclconf/go-cty-yaml v1.0.3 // indirect

--- a/tg/tg_module.go
+++ b/tg/tg_module.go
@@ -100,9 +100,12 @@ func ScanModules(rootdir string, dir project.Path, trackDependencies bool) (Modu
 
 		// Override the predefined functions to intercept the function calls that process paths.
 		pctx.PredefinedFunctions = make(map[string]function.Function)
-		pctx.PredefinedFunctions[config.FuncNameFindInParentFolders] = findInParentFoldersFunc(pctx, rootdir, mod)
-		pctx.PredefinedFunctions[config.FuncNameReadTerragruntConfig] = readTerragruntConfigFunc(pctx, rootdir, mod)
-		pctx.PredefinedFunctions[config.FuncNameReadTfvarsFile] = wrapStringSliceToStringAsFuncImpl(pctx, rootdir, mod, readTFVarsFile)
+		pctx.PredefinedFunctions[config.FuncNameFindInParentFolders] = tgFindInParentFoldersFuncImpl(pctx, rootdir, mod)
+		pctx.PredefinedFunctions[config.FuncNameReadTerragruntConfig] = tgReadTerragruntConfigFuncImpl(pctx, rootdir, mod)
+		pctx.PredefinedFunctions[config.FuncNameReadTfvarsFile] = wrapStringSliceToStringAsFuncImpl(pctx, rootdir, mod, tgReadTFVarsFileFuncImpl)
+
+		// override Terraform function
+		pctx.PredefinedFunctions["file"] = tgFileFuncImpl(pctx, rootdir, mod)
 
 		// Here we parse the Terragrunt file which calls into our overrided functions.
 		// After this returns, the module's DependsOn will be populated.


### PR DESCRIPTION
## What this PR does / why we need it:

Track usage of `file()` in Terragrunt modules to enhance change detection and mark stacks as changed whenever dependent files change.

## Which issue(s) this PR fixes:
Fixes #1967

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
yes, add a new feature
```
