### PR TITLE
fix: incorrect detected paths in Terragrunt modules.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 - Improve the error reporting of the Outputs Sharing feature.
 - Fix crash in the Terragrunt integration when the project had modules with dependency paths outside the current Terramate project.
   - A warning will be shown for such configurations.
+- Fix the Terragrunt scanner not supporting nested modules.
 
 ## v0.11.3
 


### PR DESCRIPTION
## What this PR does / why we need it:

Due to an incorrect assumption in the Terragrunt module detection, the dependency paths were wrong.

Thanks @LittleWat for the bug report and for providing a reproducible repository.

## Which issue(s) this PR fixes:
Fixes #1979 

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
yes, fixes a bug in the Terragrunt module detection.
```
