### PR TITLE
fix: panic if Terraform module references path outside repository.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
   - The API Key configuration has precedence over all other authentication methods.
 - Add support for unprefixed Bitbucket URLs in Terraform `module.source`.
 
+### Fixed
+
+- Fix `terramate list --changed` panic when a Terraform module references a path outside the project root.
+
 ## v0.11.4
 
 ### Added


### PR DESCRIPTION
## What this PR does / why we need it:

Fix a panic in the case a Terraform module has module calls with source outside of the project root directory.

## Which issue(s) this PR fixes:
Fixes #2012 

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
yes, fixes a panic.
```
