### PR TITLE
chore(bitbucket): send rr.author.id with PR author UUID.

### DIFF
--- a/cloud/types.go
+++ b/cloud/types.go
@@ -339,6 +339,7 @@ type (
 	Author struct {
 		Login     string `json:"login"`
 		AvatarURL string `json:"avatar_url,omitempty"`
+		ID        string `json:"id,omitempty"`
 	}
 
 	// Reviewer is the user's reviewer of a Pull/Merge Request.

--- a/cmd/terramate/cli/bitbucket/bitbucket.go
+++ b/cmd/terramate/cli/bitbucket/bitbucket.go
@@ -157,7 +157,7 @@ func (c *Client) GetPullRequestsByCommit(ctx context.Context, commit string) (pr
 		"rendered",
 		"summary",
 		"state",
-		"author",
+		"author.*",
 		"source.branch.name",
 		"source.commit.hash",
 		"destination.branch.name",

--- a/cmd/terramate/cli/cloud.go
+++ b/cmd/terramate/cli/cloud.go
@@ -1079,7 +1079,7 @@ func (c *cli) newBitbucketReviewRequest(pr *bitbucket.PR) *cloud.ReviewRequest {
 	}
 
 	// TODO(i4k): Bitbucket does not provide a final review decision from the API but we
-	//  can infer it from the reviewers + participants fields.
+	// can infer it from the reviewers + participants fields.
 	reviewDecision := ""
 	if len(pr.Reviewers) > 0 {
 		reviewDecision = "review_required"
@@ -1105,6 +1105,7 @@ func (c *cli) newBitbucketReviewRequest(pr *bitbucket.PR) *cloud.ReviewRequest {
 		Status:      pr.State,
 		Author: cloud.Author{
 			Login:     pr.Author.DisplayName,
+			ID:        pr.Author.UUID,
 			AvatarURL: avatarURL,
 		},
 		Branch:                c.cloud.run.metadata.BitbucketPipelinesBranch,


### PR DESCRIPTION
## What this PR does / why we need it:

Additionally sync the PR author UUID in the TMC `review_request.author.id` field.

## Which issue(s) this PR fixes:
none

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
no
```
