### PR TITLE
chore: sync bitbucket reviewer ID.

### DIFF
--- a/cmd/terramate/cli/cloud.go
+++ b/cmd/terramate/cli/cloud.go
@@ -1057,6 +1057,7 @@ func (c *cli) newBitbucketReviewRequest(pr *bitbucket.PR) *cloud.ReviewRequest {
 			uniqueReviewers[participant.User.DisplayName] = cloud.Reviewer{
 				Login:     participant.User.DisplayName,
 				AvatarURL: participant.User.Links.Avatar.Href,
+				ID:        participant.User.UUID,
 			}
 		}
 


### PR DESCRIPTION
## What this PR does / why we need it:

Sync the reviewer id in the `rr.reviewers[i].id`.

## Which issue(s) this PR fixes:
none

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
no, it's part of the unreleased bitbucket support.
```
