### PR TITLE
fix(terragrunt): make Terragrunt keep command output as is.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,14 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 
 ## Unreleased
 
+### Fixed
+
+- Fix Terragrunt stdout/stderr log in Terramate Cloud.
+  - Terragrunt changed the output format in newer versions, which causes issues with output formatting in Terramate Cloud.
+    To keep the old output format, we export the following variables when running `terramate run --terragrunt -- cmd`.
+    - `TERRAGRUNT_FORWARD_TF_STDOUT=true`
+    - `TERRAGRUNT_LOG_FORMAT=bare`
+
 ## v0.11.9
 
 ### Changed

--- a/run/env.go
+++ b/run/env.go
@@ -114,7 +114,10 @@ func LoadEnv(root *config.Root, st *config.Stack) (EnvVars, error) {
 	return envVars, nil
 }
 
-func getEnv(key string, environ []string) (string, bool) {
+// Getenv returns the value of the environment variable named by the key,
+// which is assumed to be case-insensitive, from the given environment.
+// If the variable is not present in the environment, found is false.
+func Getenv(key string, environ []string) (val string, found bool) {
 	for i := len(environ) - 1; i >= 0; i-- {
 		env := environ[i]
 		for j := 0; j < len(env); j++ {

--- a/run/lookpath_unix.go
+++ b/run/lookpath_unix.go
@@ -42,7 +42,7 @@ func LookPath(file string, environ []string) (string, error) {
 		}
 		return "", errors.E(ErrNotFound, err, file)
 	}
-	path, _ := getEnv("PATH", environ)
+	path, _ := Getenv("PATH", environ)
 	for _, dir := range filepath.SplitList(path) {
 		if dir == "" {
 			// Unix shell semantics: path element "" means "."

--- a/run/lookpath_windows.go
+++ b/run/lookpath_windows.go
@@ -76,7 +76,7 @@ func findExecutable(file string, exts []string) (string, error) {
 // errors.Is(err, ErrDot). See the package documentation for more details.
 func LookPath(file string, environ []string) (string, error) {
 	var exts []string
-	x, _ := getEnv(`PATHEXT`, environ)
+	x, _ := Getenv(`PATHEXT`, environ)
 	if x != "" {
 		for _, e := range strings.Split(strings.ToLower(x), `;`) {
 			if e == "" {
@@ -112,13 +112,13 @@ func LookPath(file string, environ []string) (string, error) {
 		dotf   string
 		dotErr error
 	)
-	if _, found := getEnv("NoDefaultCurrentDirectoryInExePath", environ); !found {
+	if _, found := Getenv("NoDefaultCurrentDirectoryInExePath", environ); !found {
 		if f, err := findExecutable(filepath.Join(".", file), exts); err == nil {
 			dotf, dotErr = f, errors.E(ErrDot, file)
 		}
 	}
 
-	path, _ := getEnv("path", environ)
+	path, _ := Getenv("path", environ)
 	for _, dir := range filepath.SplitList(path) {
 		if f, err := findExecutable(filepath.Join(dir, file), exts); err == nil {
 			if dotErr != nil {


### PR DESCRIPTION
## What this PR does / why we need it:

Newer versions of Terragrunt transform the user-supplied command output and redirect stdout/stderr and this does not work well with Terramate, which always respects the user command stdout/stderr.

This change exports `TERRAGRUNT_FORWARD_TF_STDOUT=true` and `TERRAGRUNT_LOG_FORMAT=bare` in order to force Terragrunt to keep old behavior.

## Which issue(s) this PR fixes:
none

## Special notes for your reviewer:

- [x] Changelog

## Does this PR introduce a user-facing change?
```
yes fixes an issue found at a customer.
```
