### PR TITLE
fix(terragrunt,tmc): only export TG envs during changeset creation.

### DIFF
--- a/cmd/terramate/cli/cloud_sync_terraform_plan.go
+++ b/cmd/terramate/cli/cloud_sync_terraform_plan.go
@@ -17,6 +17,7 @@ import (
 	"github.com/terramate-io/terramate/cloud"
 	"github.com/terramate-io/terramate/cmd/terramate/cli/clitest"
 	"github.com/terramate-io/terramate/errors"
+	runpkg "github.com/terramate-io/terramate/run"
 	"github.com/terramate-io/tfjson"
 	"github.com/terramate-io/tfjson/sanitize"
 )
@@ -126,21 +127,34 @@ func (c *cli) runTerraformShow(run stackCloudRun, flags ...string) (string, erro
 		cmdName = "terraform"
 	}
 
+	cmdPath, err := runpkg.LookPath(cmdName, run.Env)
+	if err != nil {
+		return "", errors.E(clitest.ErrCloudTerraformPlanFile, "looking up executable for %s: %w", cmdName, err)
+	}
+
+	env := run.Env
+
 	args := []string{"show"}
 	args = append(args, flags...)
 	if run.Task.UseTerragrunt {
 		args = append(args, "--terragrunt-non-interactive")
+
+		env = make([]string, len(run.Env))
+		copy(env, run.Env)
+
+		env = append(env, "TERRAGRUNT_FORWARD_TF_STDOUT=true")
+		env = append(env, "TERRAGRUNT_LOG_FORMAT=bare")
 	}
 	args = append(args, planfile)
 
 	ctx, cancel := context.WithTimeout(context.Background(), terraformShowTimeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, cmdName, args...)
+	cmd := exec.CommandContext(ctx, cmdPath, args...)
 	cmd.Dir = run.Stack.Dir.HostPath(c.rootdir())
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
-	cmd.Env = run.Env
+	cmd.Env = env
 
 	logger := log.With().
 		Str("action", "runTerraformShow").
@@ -149,7 +163,7 @@ func (c *cli) runTerraformShow(run stackCloudRun, flags ...string) (string, erro
 		Str("command", cmd.String()).
 		Logger()
 
-	err := cmd.Run()
+	err = cmd.Run()
 	if err != nil {
 		if ctx.Err() == context.DeadlineExceeded {
 			return "", errors.E(clitest.ErrCloudTerraformPlanFile, "command timed out: %s", cmd.String())

--- a/cmd/terramate/cli/run.go
+++ b/cmd/terramate/cli/run.go
@@ -420,14 +420,6 @@ func (c *cli) runAll(
 
 			cfg, _ := c.cfg().Lookup(run.Stack.Dir)
 			environ := newEnvironFrom(stackEnvs[run.Stack.Dir])
-			if task.UseTerragrunt {
-				if _, found := runutil.Getenv("TERRAGRUNT_FORWARD_TF_STDOUT", environ); !found {
-					environ = append(environ, "TERRAGRUNT_FORWARD_TF_STDOUT=true")
-				}
-				if _, found := runutil.Getenv("TERRAGRUNT_LOG_FORMAT", environ); !found {
-					environ = append(environ, "TERRAGRUNT_LOG_FORMAT=bare")
-				}
-			}
 
 			if task.EnableSharing {
 				for _, in := range cfg.Node.Inputs {

--- a/e2etests/cmd/helper/main.go
+++ b/e2etests/cmd/helper/main.go
@@ -28,6 +28,13 @@ func main() {
 		log.Fatalf("%s requires at least one subcommand argument", os.Args[0])
 	}
 
+	execName := filepath.Base(os.Args[0])
+	switch execName {
+	case "terragrunt", "terragrunt.exe":
+		terragrunt(os.Args[1:]...)
+		return
+	}
+
 	// note: unrecovered panic() aborts the program with exit code 2 and this
 	// could be confused with a *detected drift* (see: run --sync-drift-status)
 	// then avoid panics here and do proper os.Exit(1) in case of errors.
@@ -72,6 +79,8 @@ func main() {
 		fibonacci()
 	case "git-normalization":
 		gitnorm(os.Args[2])
+	case "terragrunt":
+		terragrunt(os.Args[2:]...)
 	default:
 		log.Fatalf("unknown command %s", os.Args[1])
 	}

--- a/e2etests/cmd/helper/terragrunt.go
+++ b/e2etests/cmd/helper/terragrunt.go
@@ -1,0 +1,37 @@
+// Copyright 2025 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+)
+
+func terragrunt(args ...string) {
+	switch args[0] {
+	case "show":
+		forwardTfStdout := os.Getenv("TERRAGRUNT_FORWARD_TF_STDOUT")
+		if forwardTfStdout == "" {
+			log.Printf("error: TERRAGRUNT_FORWARD_TF_STDOUT is not set")
+			os.Exit(1)
+		}
+		if forwardTfStdout != "true" {
+			log.Printf("error: TERRAGRUNT_FORWARD_TF_STDOUT is not true; got %q", forwardTfStdout)
+			os.Exit(1)
+		}
+
+		logFormat := os.Getenv("TERRAGRUNT_LOG_FORMAT")
+		if logFormat == "" {
+			log.Printf("error: TERRAGRUNT_LOG_FORMAT is not set")
+			os.Exit(1)
+		}
+		if logFormat != "bare" {
+			log.Printf("error: TERRAGRUNT_LOG_FORMAT is not bare; got %q", logFormat)
+			os.Exit(1)
+		}
+
+		fmt.Println(`TERRAGRUNT SHOW TEST OUTPUT`)
+	}
+}

--- a/e2etests/core/run_env_test.go
+++ b/e2etests/core/run_env_test.go
@@ -385,17 +385,6 @@ func TestRunEnv(t *testing.T) {
 				),
 			},
 		},
-		{
-			name: "--terragrunt export TERRAGRUNT_FORWARD_TF_STDOUT and TERRAGRUNT_LOG_FORMAT",
-			layout: []string{
-				"s:stack",
-			},
-			runArgs: []string{"--terragrunt"},
-			args:    []string{"TERRAGRUNT_FORWARD_TF_STDOUT", "TERRAGRUNT_LOG_FORMAT"},
-			want: RunExpected{
-				Stdout: nljoin("/stack: true", "/stack: bare"),
-			},
-		},
 	} {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {

--- a/fs/copy.go
+++ b/fs/copy.go
@@ -64,7 +64,7 @@ func CopyDir(destdir, srcdir string, filter CopyFilterFunc) error {
 			return err
 		}
 
-		if err := copyFile(destpath, srcpath); err != nil {
+		if err := CopyFile(destpath, srcpath); err != nil {
 			return errors.E(err, "copying src to dest file")
 		}
 	}
@@ -79,7 +79,8 @@ func CopyAll(dstdir, srcdir string) error {
 	})
 }
 
-func copyFile(destfile, srcfile string) error {
+// CopyFile copies a file from srcfile to destfile.
+func CopyFile(destfile, srcfile string) error {
 	src, err := os.Open(srcfile)
 	if err != nil {
 		return errors.E(err, "opening source file")


### PR DESCRIPTION
## What this PR does / why we need it:

As discussed, it's better if we export the `TERRAGRUNT_FORWARD_TF_STDOUT` and `TERRAGRUNT_LOG_FORMAT` only during the changeset details.

## Which issue(s) this PR fixes:
no
## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
not released yet
```
