### PR TITLE
fix: tmc plan creation command not using `terramate.config.run.env`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
     To keep the old output format, we export the following variables when running `terramate run --terragrunt -- cmd`.
     - `TERRAGRUNT_FORWARD_TF_STDOUT=true`
     - `TERRAGRUNT_LOG_FORMAT=bare`
+- Fix Terramate Cloud plan creation command not using environ defined in `terramate.config.run.env`.
+  - This can lead to a version mismatch between the user-supplied run command and the one used for creating the plan details.
 
 ## v0.11.9
 


### PR DESCRIPTION
## What this PR does / why we need it:

Fix Terramate Cloud plan creation command not using environ defined in `terramate.config.run.env`. This can lead to a version mismatch between the user-supplied run command and the one used for creating the plan details.

## Which issue(s) this PR fixes:
none
## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
fix TMC plan creation.
```
