### PR TITLE
chore: avoid config package dependency in the cloud sdk package.

### DIFF
--- a/cloud/cloud_preview_test.go
+++ b/cloud/cloud_preview_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/madlambda/spells/assert"
 	"github.com/terramate-io/terramate/cloud"
 	"github.com/terramate-io/terramate/cloud/preview"
-	"github.com/terramate-io/terramate/config"
 	"github.com/terramate-io/terramate/errors"
 	"github.com/terramate-io/terramate/project"
 )
@@ -94,8 +93,6 @@ func TestCreatePreview(t *testing.T) {
 				CommitSHA:       "2fef3ab48c543322e911bc53baec6196231e95bc",
 				Technology:      "terraform",
 				TechnologyLayer: "default",
-				Repository:      "https://github.com/owner/repo",
-				DefaultBranch:   "main",
 				ReviewRequest: &cloud.ReviewRequest{
 					Platform:    "github",
 					Repository:  "https://github.com/owner/repo",
@@ -188,15 +185,17 @@ func TestUpdateStackPreview(t *testing.T) {
 	}
 }
 
-func makeAffectedStacks(num int) map[string]*config.Stack {
-	affectedStacks := map[string]*config.Stack{}
+func makeAffectedStacks(num int) map[string]cloud.Stack {
+	affectedStacks := map[string]cloud.Stack{}
 	for i := 0; i < num; i++ {
-		affectedStacks[strconv.Itoa(i)] = &config.Stack{
-			Dir:         project.NewPath("/somepath" + strconv.Itoa(i)),
-			ID:          uuid.NewString(),
-			Name:        "stack" + strconv.Itoa(i),
-			Description: "desc of stack" + strconv.Itoa(i),
-			Tags:        []string{"tag1", "tag2"},
+		affectedStacks[strconv.Itoa(i)] = cloud.Stack{
+			Path:            project.NewPath("/somepath" + strconv.Itoa(i)).String(),
+			MetaID:          uuid.NewString(),
+			MetaName:        "stack" + strconv.Itoa(i),
+			MetaDescription: "desc of stack" + strconv.Itoa(i),
+			MetaTags:        []string{"tag1", "tag2"},
+			Repository:      "https://github.com/owner/repo",
+			DefaultBranch:   "main",
 		}
 	}
 
@@ -207,14 +206,8 @@ func makeRunContexts(num int, cmd []string) []cloud.RunContext {
 	runs := make([]cloud.RunContext, num)
 	for i := 0; i < num; i++ {
 		runs[i] = cloud.RunContext{
-			Stack: &config.Stack{
-				Dir:         project.NewPath("/somepath" + strconv.Itoa(i)),
-				ID:          uuid.NewString(),
-				Name:        "stack" + strconv.Itoa(i),
-				Description: "desc of stack" + strconv.Itoa(i),
-				Tags:        []string{"tag1", "tag2"},
-			},
-			Cmd: cmd,
+			StackID: uuid.NewString(),
+			Cmd:     cmd,
 		}
 	}
 

--- a/cmd/terramate/cli/run.go
+++ b/cmd/terramate/cli/run.go
@@ -782,14 +782,24 @@ func (c *cli) createCloudPreview(runs []stackCloudRun, target, fromTarget string
 	previewRuns := make([]cloud.RunContext, len(runs))
 	for i, run := range runs {
 		previewRuns[i] = cloud.RunContext{
-			Stack: run.Stack,
-			Cmd:   run.Task.Cmd,
+			StackID: run.Stack.ID,
+			Cmd:     run.Task.Cmd,
 		}
 	}
 
-	affectedStacksMap := map[string]*config.Stack{}
+	affectedStacksMap := map[string]cloud.Stack{}
 	for _, st := range c.getAffectedStacks() {
-		affectedStacksMap[st.Stack.ID] = st.Stack
+		affectedStacksMap[st.Stack.ID] = cloud.Stack{
+			Path:            st.Stack.Dir.String(),
+			MetaID:          strings.ToLower(st.Stack.ID),
+			MetaName:        st.Stack.Name,
+			MetaDescription: st.Stack.Description,
+			MetaTags:        st.Stack.Tags,
+			Repository:      c.prj.prettyRepo(),
+			Target:          target,
+			FromTarget:      fromTarget,
+			DefaultBranch:   c.prj.gitcfg().DefaultBranch,
+		}
 	}
 
 	if c.cloud.run.reviewRequest == nil || c.cloud.run.rrEvent.pushedAt == nil {
@@ -831,10 +841,6 @@ func (c *cli) createCloudPreview(runs []stackCloudRun, target, fromTarget string
 			CommitSHA:       c.cloud.run.rrEvent.commitSHA,
 			Technology:      technology,
 			TechnologyLayer: technologyLayer,
-			Repository:      c.prj.prettyRepo(),
-			Target:          target,
-			FromTarget:      fromTarget,
-			DefaultBranch:   c.prj.gitcfg().DefaultBranch,
 			ReviewRequest:   c.cloud.run.reviewRequest,
 			Metadata:        c.cloud.run.metadata,
 		},


### PR DESCRIPTION
## What this PR does / why we need it:

The CLI configuration has attributes for configuring the Terramate Cloud client SDKs then it makes sense to reuse code by importing the cloud package in the config (to avoid duplicating the types).
At the moment, it's the other way around and `config.Stack` is used in the cloud package but this is wrong because the cloud types are owned by the Terramate Cloud backend team and we already have a `cloud.Stack` type that comply with the openapi spec.

## Which issue(s) this PR fixes:
none

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
no
```
