### PR TITLE
feat: add`terramate.config.cloud.location` for setting the cloud location.

### DIFF
--- a/cmd/terramate/cli/cloud.go
+++ b/cmd/terramate/cli/cloud.go
@@ -1489,15 +1489,22 @@ func (c *cli) newGitlabReviewRequest(mr gitlab.MR) *cloud.ReviewRequest {
 }
 
 func (c *cli) loadCredential() error {
-	cloudURL := tmcloud.BaseURL()
+	region := c.cloudRegion()
+	cloudURL, envFound := tmcloud.EnvBaseURL()
+	if !envFound {
+		cloudURL = cloud.BaseURL(region)
+	}
 	clientLogger := log.With().
 		Str("tmc_url", cloudURL).
 		Logger()
 
 	c.cloud.client = &cloud.Client{
-		BaseURL:    cloudURL,
+		Region:     region, // always set so we can use it in error messages
 		HTTPClient: &c.httpClient,
 		Logger:     &clientLogger,
+	}
+	if envFound {
+		c.cloud.client.BaseURL = cloudURL
 	}
 	c.cloud.output = c.output
 

--- a/cmd/terramate/cli/run.go
+++ b/cmd/terramate/cli/run.go
@@ -878,7 +878,7 @@ func (c *cli) writePreviewURL() {
 		}
 	}
 
-	cloudURL := "https://cloud.terramate.io"
+	cloudURL := cloud.HTMLURL(c.cloud.client.Region)
 	if c.cloud.client.BaseURL == "https://api.stg.terramate.io" {
 		cloudURL = "https://cloud.stg.terramate.io"
 	}

--- a/cmd/terramate/cli/tmcloud/auth/cloud_credential_github_oidc.go
+++ b/cmd/terramate/cli/tmcloud/auth/cloud_credential_github_oidc.go
@@ -227,7 +227,7 @@ func (g *githubOIDC) Info(selectedOrgName string) {
 	}
 
 	if len(g.orgs) == 0 {
-		printer.Stderr.Warn("You are not part of an organization. Please visit cloud.terramate.io to create an organization.")
+		printer.Stderr.Warnf("You are not part of an organization. Please visit %s to create an organization.", cloud.HTMLURL(g.client.Region))
 	}
 }
 

--- a/cmd/terramate/cli/tmcloud/auth/cloud_credential_gitlab_oidc.go
+++ b/cmd/terramate/cli/tmcloud/auth/cloud_credential_gitlab_oidc.go
@@ -158,7 +158,7 @@ func (g *gitlabOIDC) Info(selectedOrgName string) {
 	}
 
 	if len(g.orgs) == 0 {
-		printer.Stderr.Warn("You are not part of an organization. Please visit cloud.terramate.io to create an organization.")
+		printer.Stderr.Warnf("You are not part of an organization. Please visit %s to create an organization.", cloud.HTMLURL(g.client.Region))
 	}
 }
 

--- a/cmd/terramate/cli/tmcloud/auth/cloud_credential_google.go
+++ b/cmd/terramate/cli/tmcloud/auth/cloud_credential_google.go
@@ -672,11 +672,11 @@ func (g *googleCredential) Info(selectedOrgName string) {
 	}
 
 	if g.user.DisplayName == "" {
-		printer.Stderr.Warn("On-boarding is incomplete. Please visit cloud.terramate.io to complete on-boarding.")
+		printer.Stderr.Warnf("On-boarding is incomplete. Please visit %s to complete on-boarding.", cloud.HTMLURL(g.client.Region))
 	}
 
 	if len(g.orgs) == 0 {
-		printer.Stderr.Warn("You are not part of an organization. Please visit cloud.terramate.io to create an organization.")
+		printer.Stderr.Warnf("You are not part of an organization. Please visit %s to create an organization.", cloud.HTMLURL(g.client.Region))
 	}
 }
 

--- a/cmd/terramate/cli/tmcloud/cloud.go
+++ b/cmd/terramate/cli/tmcloud/cloud.go
@@ -5,21 +5,15 @@ package tmcloud
 
 import (
 	"os"
-
-	"github.com/terramate-io/terramate/cloud"
 )
 
-// BaseURL returns the base URL for the TMC API.
-func BaseURL() string {
-	var baseURL string
-	cloudHost := os.Getenv("TMC_API_HOST")
-	cloudURL := os.Getenv("TMC_API_URL")
-	if cloudHost != "" {
-		baseURL = "https://" + cloudHost
-	} else if cloudURL != "" {
-		baseURL = cloudURL
-	} else {
-		baseURL = cloud.BaseURL(cloud.EU)
+// EnvBaseURL returns the base URL for the TMC API.
+func EnvBaseURL() (string, bool) {
+	if cloudHost := os.Getenv("TMC_API_HOST"); cloudHost != "" {
+		return "https://" + cloudHost, true
 	}
-	return baseURL
+	if cloudURL := os.Getenv("TMC_API_URL"); cloudURL != "" {
+		return cloudURL, true
+	}
+	return "", false
 }

--- a/hcl/hcl_test.go
+++ b/hcl/hcl_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/madlambda/spells/assert"
 	"github.com/rs/zerolog"
+	"github.com/terramate-io/terramate/cloud"
 	"github.com/terramate-io/terramate/errors"
 	"github.com/terramate-io/terramate/hcl"
 	"github.com/terramate-io/terramate/safeguard"
@@ -902,6 +903,34 @@ func TestHCLParserRootConfig(t *testing.T) {
 						Config: &hcl.RootConfig{
 							Cloud: &hcl.CloudConfig{
 								Organization: "my-org",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "terramate.config.cloud.location",
+			input: []cfgfile{
+				{
+					filename: "cfg.tm",
+					body: `
+						terramate {
+							config {
+								cloud {
+									location = "us"
+								}
+							}
+						}
+					`,
+				},
+			},
+			want: want{
+				config: hcl.Config{
+					Terramate: &hcl.Terramate{
+						Config: &hcl.RootConfig{
+							Cloud: &hcl.CloudConfig{
+								Location: cloud.US,
 							},
 						},
 					},

--- a/terramate.tm
+++ b/terramate.tm
@@ -17,6 +17,7 @@ terramate {
     }
 
     cloud {
+      location     = "eu"
       organization = "terramate-tests"
 
       targets {


### PR DESCRIPTION
## What this PR does / why we need it:

Terramate Cloud is now live in multiple regions and this configuration allows for users choosing which region best suits their needs.

Example:

```hcl
terramate {
  config {
    cloud {
      location = "us"
    }
  }
}
```

The available options are just `"eu"` and `"us"` at the moment.

## Which issue(s) this PR fixes:
none
## Special notes for your reviewer:

Note: tests are still WIP.

## Does this PR introduce a user-facing change?
```
yes, includes a new configuration option.
```
