### PR TITLE
fix: misleading error message when TMC onboarding is incomplete.

### DIFF
--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -1184,7 +1184,7 @@ func (c *cli) triggerStackByFilter() {
 	}
 	stacksReport, err := c.listStacks(false, cloudstack.AnyTarget, stackFilter, false)
 	if err != nil {
-		fatalWithDetailf(err, "unable to list stacks")
+		fatal(err)
 	}
 
 	for _, st := range c.filterStacksByWorkingDir(stacksReport.Stacks) {

--- a/cmd/terramate/cli/clitest/messages.go
+++ b/cmd/terramate/cli/clitest/messages.go
@@ -23,6 +23,9 @@ const (
 	// CloudLoginRequiredMessage is the message displayed when cloud login is required.
 	CloudLoginRequiredMessage = "This command uses Terramate Cloud features and requires you to be logged in"
 
+	// CloudOnboardingIncompleteMessage is the message displayed when the onboarding process is incomplete.
+	CloudOnboardingIncompleteMessage = "You need to complete the Terramate Cloud onboarding process before using this feature"
+
 	// CloudTargetsNotEnabledMessage is the message displayed when the targets feature is not enabled.
 	CloudTargetsNotEnabledMessage = `The \"targets\" feature is not enabled`
 

--- a/cmd/terramate/cli/run.go
+++ b/cmd/terramate/cli/run.go
@@ -151,7 +151,7 @@ func (c *cli) runOnStacks() {
 			DriftStatus:      driftFilter,
 		})
 		if err != nil {
-			fatalWithDetailf(err, "computing selected stacks")
+			fatal(err)
 		}
 	}
 

--- a/cmd/terramate/cli/tmcloud/auth/cloud_credential_google.go
+++ b/cmd/terramate/cli/tmcloud/auth/cloud_credential_google.go
@@ -638,7 +638,7 @@ func (g *googleCredential) fetchDetails() error {
 
 	if err != nil {
 		if errors.IsKind(err, cloud.ErrNotFound) {
-			return errors.E(clitest.ErrCloudOnboardingIncomplete, ErrLoginRequired)
+			return errors.E(clitest.ErrCloudOnboardingIncomplete)
 		}
 		return err
 	}

--- a/e2etests/cloud/run_cloud_uimode_test.go
+++ b/e2etests/cloud/run_cloud_uimode_test.go
@@ -318,7 +318,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 					want: RunExpected{
 						Status: 1,
 						StderrRegexes: []string{
-							string(clitest.CloudLoginRequiredMessage),
+							string(clitest.CloudOnboardingIncompleteMessage),
 						},
 					},
 				},
@@ -332,7 +332,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 					},
 					want: RunExpected{
 						StderrRegexes: []string{
-							string(clitest.CloudLoginRequiredMessage),
+							string(clitest.CloudOnboardingIncompleteMessage),
 							clitest.CloudDisablingMessage,
 						},
 					},
@@ -348,7 +348,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 					want: RunExpected{
 						Status: 1,
 						StderrRegexes: []string{
-							string(clitest.CloudLoginRequiredMessage),
+							string(clitest.CloudOnboardingIncompleteMessage),
 						},
 					},
 				},
@@ -362,7 +362,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 					},
 					want: RunExpected{
 						StderrRegexes: []string{
-							string(clitest.CloudLoginRequiredMessage),
+							string(clitest.CloudOnboardingIncompleteMessage),
 							string(clitest.CloudDisablingMessage),
 						},
 					},
@@ -376,7 +376,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 					want: RunExpected{
 						Status: 1,
 						StderrRegexes: []string{
-							`failed to load credentials`,
+							clitest.CloudOnboardingIncompleteMessage,
 						},
 					},
 				},
@@ -387,7 +387,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 					want: RunExpected{
 						Status: 1,
 						StderrRegexes: []string{
-							`failed to load credentials`,
+							clitest.CloudOnboardingIncompleteMessage,
 						},
 					},
 				},
@@ -481,7 +481,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 						Status: 1,
 						StderrRegexes: []string{
 							string(cloud.ErrUnexpectedResponseBody),
-							`failed to load credentials`,
+							`failed to load the cloud credentials`,
 						},
 					},
 				},
@@ -493,7 +493,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 						Status: 1,
 						StderrRegexes: []string{
 							string(cloud.ErrUnexpectedResponseBody),
-							`failed to load credentials`,
+							`failed to load the cloud credentials`,
 						},
 					},
 				},
@@ -566,7 +566,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 						Status: 1,
 						StderrRegexes: []string{
 							regexp.QuoteMeta(string(cloud.ErrNotFound)),
-							`failed to load credentials`,
+							`failed to load the cloud credentials`,
 						},
 					},
 				},
@@ -578,7 +578,7 @@ func TestCloudSyncUIMode(t *testing.T) {
 						Status: 1,
 						StderrRegexes: []string{
 							regexp.QuoteMeta(string(cloud.ErrNotFound)),
-							`failed to load credentials`,
+							`failed to load the cloud credentials`,
 						},
 					},
 				},


### PR DESCRIPTION
## What this PR does / why we need it:

When the user uses `terramate cloud login` but still haven't signup in Terramate, we were giving an error message saying he needs authenticate in the CLI when actually the correct message is that he needs to visit the cloud website and signup.

## Which issue(s) this PR fixes:
none

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
yes, fixes an issue
```
