### PR TITLE
feat: make JWT audience respect the configured TMC location.

### DIFF
--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -31,7 +31,7 @@ import (
 )
 
 // BaseDomain is the Terramate Cloud base domain.
-const BaseDomain = "api.terramate.io"
+const apiBaseDomain = "api.terramate.io"
 
 const defaultPageSize = 50
 
@@ -133,12 +133,20 @@ func init() {
 	}
 }
 
-// BaseURL returns the API base URL for the given region.
+// BaseURL returns the API base URL for the Terramate Cloud.
 func BaseURL(region Region) string {
 	if region == EU {
-		return "https://" + BaseDomain
+		return "https://" + apiBaseDomain
 	}
-	return "https://" + region.String() + "." + BaseDomain
+	return "https://" + region.String() + "." + apiBaseDomain
+}
+
+// BaseDomain returns the API base domain for the Terramate Cloud.
+func BaseDomain(region Region) string {
+	if region == EU {
+		return apiBaseDomain
+	}
+	return region.String() + "." + apiBaseDomain
 }
 
 // CheckVersion checks if current Terramate version can be used to communicate

--- a/cmd/terramate/cli/tmcloud/auth/cloud_credential_github_oidc.go
+++ b/cmd/terramate/cli/tmcloud/auth/cloud_credential_github_oidc.go
@@ -61,7 +61,7 @@ func (g *githubOIDC) Load() (bool, error) {
 
 	g.reqToken = os.Getenv(envReqTok)
 
-	audience := oidcAudience()
+	audience := oidcAudience(g.client.Region)
 	if audience != "" {
 		u, err := url.Parse(g.reqURL)
 		if err != nil {

--- a/cmd/terramate/cli/tmcloud/auth/oidc_audience_default.go
+++ b/cmd/terramate/cli/tmcloud/auth/oidc_audience_default.go
@@ -5,6 +5,8 @@
 
 package auth
 
-func oidcAudience() string {
+import "github.com/terramate-io/terramate/cloud"
+
+func oidcAudience(_ cloud.Region) string {
 	return ""
 }

--- a/cmd/terramate/cli/tmcloud/auth/oidc_audience_terramate.go
+++ b/cmd/terramate/cli/tmcloud/auth/oidc_audience_terramate.go
@@ -7,6 +7,6 @@ package auth
 
 import "github.com/terramate-io/terramate/cloud"
 
-func oidcAudience() string {
-	return cloud.BaseDomain // do not include the region.
+func oidcAudience(region cloud.Region) string {
+	return cloud.BaseDomain(region)
 }


### PR DESCRIPTION
## What this PR does / why we need it:

This is the last missing PR for releasing the Terramate Cloud location configuration.
This ensures JWT tokens generated for one environment cannot be used with others.

## Which issue(s) this PR fixes:
none

## Special notes for your reviewer:

The `terramate.config.cloud.location` is not released, then no change in changelog is needed.

## Does this PR introduce a user-facing change?
```
no
```
