### PR TITLE
chore: improve tests not cleaning up test files.

### DIFF
--- a/e2etests/cloud/main_test.go
+++ b/e2etests/cloud/main_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/terramate-io/terramate/e2etests/internal/runner"
+	. "github.com/terramate-io/terramate/e2etests/internal/runner"
 )
 
 const testserverJSONFile = "testdata/cloud.data.json"
@@ -24,12 +24,15 @@ func TestMain(m *testing.M) {
 	// this file is inside cmd/terramate/e2etests/cloud
 	// change code below if it's not the case anymore.
 	projectRoot := filepath.Join(packageDir, "../..")
-	err = runner.Setup(projectRoot)
+	err = Setup(projectRoot)
 	if err != nil {
-		log.Fatal(err)
+		log.Printf("failed to setup e2e tests: %v", err)
+		Teardown()
+		os.Exit(1)
 	}
-	defer runner.Teardown()
-	os.Exit(m.Run())
+	code := m.Run()
+	Teardown()
+	os.Exit(code)
 }
 
 func nljoin(stacks ...string) string {

--- a/e2etests/core/main_test.go
+++ b/e2etests/core/main_test.go
@@ -23,8 +23,11 @@ func TestMain(m *testing.M) {
 	projectRoot := filepath.Join(packageDir, "../..")
 	err = Setup(projectRoot)
 	if err != nil {
-		log.Fatalf("failed to setup e2e tests: %v", err)
+		log.Printf("failed to setup e2e tests: %v", err)
+		Teardown()
+		os.Exit(1)
 	}
-	defer Teardown()
-	os.Exit(m.Run())
+	code := m.Run()
+	Teardown()
+	os.Exit(code)
 }

--- a/makefiles/unix.mk
+++ b/makefiles/unix.mk
@@ -38,8 +38,7 @@ test/helper:
 tempdir=$(shell ./bin/helper tempdir)
 test: test/helper build
 # 	Using `terramate` because it detects and fails if the generated files are outdated.
-	TM_TEST_ROOT_TEMPDIR=$(tempdir) ./bin/terramate run --no-recursive -- go test -race -count=1 -timeout 30m ./...
-	./bin/helper rm $(tempdir)
+	TM_TEST_ROOT_TEMPDIR=$(tempdir) ./bin/terramate run --no-recursive -- go test -race -count=1 -timeout 30m ./... || ./bin/helper rm $(tempdir)
 
 ## test/sync code
 .PHONY: test/sync
@@ -52,8 +51,7 @@ test/sync: test/helper build
 	GITHUB_TOKEN=$(shell cat ../my_github_token.txt) \
 	NO_COLOR=1 \
 	CI=1 \
-	./bin/terramate script run --tags golang --parallel=10 preview
-	./bin/helper rm $(tempdir)
+	./bin/terramate script run --tags golang --parallel=10 preview || ./bin/helper rm $(tempdir)
 
 ## test/interop
 .PHONY: test/interop


### PR DESCRIPTION
## What this PR does / why we need it:

Multiple invocations of `make test` that fails lead to filling the /tmp directory with generated test files.

## Which issue(s) this PR fixes:
none

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
no
```
