### PR TITLE
fix(tmc): github login should check "email_verified" from JWT.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 - Backward compatibility in versions `0.0.z` is **not guaranteed** when `z` is increased.
 - Backward compatibility in versions `0.y.z` is **not guaranteed** when `y` is increased.
 
+## Unreleased
+
+### Fixed
+
+- Fix `terramate cloud login --github` when the Github email is not verified but the associated Firebase account is verified.
+
 ## v0.12.0
 
 ### Added

--- a/cmd/terramate/cli/tmcloud/auth/cloud_credential_google.go
+++ b/cmd/terramate/cli/tmcloud/auth/cloud_credential_google.go
@@ -300,9 +300,16 @@ func signInWithIDP(reqPayload googleSignInPayload, idpKey string) (cred credenti
 	if creds.NeedConfirmation {
 		return credentialInfo{}, newIDPNeedConfirmationError(creds.VerifiedProviders)
 	}
-	if !creds.EmailVerified {
+
+	claims, err := tokenClaims(creds.IDToken)
+	if err != nil {
+		return credentialInfo{}, err
+	}
+
+	if emailVerified, ok := claims["email_verified"].(bool); ok && !emailVerified {
 		return credentialInfo{}, newEmailNotVerifiedError(creds.Email)
 	}
+
 	return creds, nil
 }
 


### PR DESCRIPTION
## What this PR does / why we need it:

When using `terramate cloud login --github` the CLI is giving an incorrect error telling the user that email is not verified. The problem is because it's checking the `email_verified` field from the response of the `signInWithIDP` Firebase endpoint and the field relates to the federated `email_verified` state but this is not important for Terramate Cloud. The JWT `email_verified` claim that should be used instead.

## Which issue(s) this PR fixes:
Fixes an issue reported by a customer.

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
yes
```
