### PR TITLE
fix: cloud info shows all orgs instead of active ones.

### DIFF
--- a/cmd/terramate/cli/tmcloud/auth/cloud_credential_google.go
+++ b/cmd/terramate/cli/tmcloud/auth/cloud_credential_google.go
@@ -690,7 +690,7 @@ func (g *googleCredential) Info(selectedOrgName string) {
 
 	activeOrgs := g.orgs.ActiveOrgs()
 	if len(activeOrgs) > 0 {
-		printer.Stdout.Println(fmt.Sprintf("active organizations: %s", g.orgs))
+		printer.Stdout.Println(fmt.Sprintf("active organizations: %s", activeOrgs))
 	}
 	if invitedOrgs := g.orgs.InvitedOrgs(); len(invitedOrgs) > 0 {
 		printer.Stdout.Println(fmt.Sprintf("pending invitations: %d", len(invitedOrgs)))


### PR DESCRIPTION
## What this PR does / why we need it:

`cloud info` shows all orgs instead of active.

## Which issue(s) this PR fixes:
none

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
no because this is not released yet
```
