### PR TITLE
fix: non-subcmd commands when used with root-flag-only-commands.

### DIFF
--- a/e2etests/core/cli_args_test.go
+++ b/e2etests/core/cli_args_test.go
@@ -1,0 +1,36 @@
+// Copyright 2025 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+package core_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/terramate-io/terramate"
+	. "github.com/terramate-io/terramate/e2etests/internal/runner"
+	"github.com/terramate-io/terramate/test"
+)
+
+func TestCLIArgs(t *testing.T) {
+	cli := NewCLI(t, test.TempDir(t))
+	AssertRunResult(t, cli.Run("--help"), RunExpected{
+		Status:      0,
+		StdoutRegex: regexp.QuoteMeta("Usage: terramate <command>"),
+	})
+
+	AssertRunResult(t, cli.Run("list", "--help"), RunExpected{
+		Status:      0,
+		StdoutRegex: regexp.QuoteMeta("Usage: terramate list"),
+	})
+
+	AssertRunResult(t, cli.Run("--version"), RunExpected{
+		Status: 0,
+		Stdout: terramate.Version() + "\n",
+	})
+
+	AssertRunResult(t, cli.Run("--version", "list"), RunExpected{
+		Status:      1,
+		StderrRegex: regexp.QuoteMeta(`command list cannot be used with flag --version`),
+	})
+}

--- a/ui/tui/cli_handler.go
+++ b/ui/tui/cli_handler.go
@@ -64,31 +64,7 @@ type handlerState struct {
 func DefaultBeforeConfigHandler(ctx context.Context, c *CLI) (cmd commands.Executor, found bool, cont bool, err error) {
 	kctx := ctx.Value(KongContext).(*kong.Context)
 
-	var kerr error
-	if v := ctx.Value(KongError); v != nil {
-		kerr = v.(error)
-	}
-
-	if c.kongExit && c.kongExitStatus == 0 {
-		return nil, false, false, nil
-	}
-
 	parsedArgs := c.input.(*FlagSpec)
-
-	// When we run terramate --version the kong parser just fails
-	// since no subcommand was provided (which is odd..but happens).
-	// So we check if the flag for version is present before checking the error.
-	if parsedArgs.VersionFlag {
-		return &version.Spec{
-			Version:  c.version,
-			InfoChan: c.checkpointResponse,
-		}, true, false, nil
-	}
-
-	if kerr != nil {
-		return nil, false, false, err
-	}
-
 	// profiler is only started if Terramate is built with -tags profiler
 	startProfiler(parsedArgs.CPUProfiling)
 

--- a/ui/tui/cli_spec.go
+++ b/ui/tui/cli_spec.go
@@ -316,15 +316,19 @@ func migrateBoolFlag(flag *bool, alias bool) {
 	}
 }
 
-func handleRootVersionFlagAlone(p *FlagSpec, c *CLI) bool {
+func handleRootVersionFlagAlone(parsedSpec any, _ *CLI) (name string, val any, run func(c *CLI, value any) error, isset bool) {
+	p := parsedSpec.(*FlagSpec)
 	if p.VersionFlag {
-		fmt.Println(c.version)
+		return "--version", p.VersionFlag, func(c *CLI, _ any) error {
+			fmt.Println(c.version)
+			return nil
+		}, true
 	}
-	return p.VersionFlag
+	return "", nil, nil, false
 }
 
-func defaultRootFlagCheckers() []rootFlagCheckers[*FlagSpec] {
-	return []rootFlagCheckers[*FlagSpec]{
+func defaultRootFlagHandlers() []rootFlagHandlers {
+	return []rootFlagHandlers{
 		handleRootVersionFlagAlone, // handles: terramate --version
 	}
 }


### PR DESCRIPTION
## What this PR does / why we need it:

This fix an edge case when a `root-only-flag` (eg.: --version) is used with
a subcommand (eg.: `list`).

The invocation below:
```
terramate --version list
```

must fail.

Additionally, it fixes the "terramate" name in the *Usage* line that was not lowercase.

## Which issue(s) this PR fixes:
none

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
no because affected code is not released
```
