### PR TITLE
refactor: export DefaultRootFlagHandlers() to be reused.

### DIFF
--- a/ui/tui/cli.go
+++ b/ui/tui/cli.go
@@ -54,7 +54,7 @@ type CLI struct {
 	// The CLI engine works with any spec.
 	input            any
 	parser           *kong.Kong
-	rootFlagCheckers []rootFlagHandlers
+	rootFlagCheckers []RootFlagHandlers
 	hclOptions       []hcl.Option
 
 	checkpointResponse chan *checkpoint.CheckResponse
@@ -133,7 +133,7 @@ func NewCLI(opts ...Option) (*CLI, error) {
 			&FlagSpec{},
 			DefaultBeforeConfigHandler,
 			DefaultAfterConfigHandler,
-			defaultRootFlagHandlers()...)(c)
+			DefaultRootFlagHandlers()...)(c)
 
 		if err != nil {
 			return nil, err

--- a/ui/tui/cli_handler.go
+++ b/ui/tui/cli_handler.go
@@ -58,6 +58,26 @@ type handlerState struct {
 	tags filter.TagClause
 }
 
+func handleRootVersionFlagAlone(parsedSpec any, _ *CLI) (name string, val any, run func(c *CLI, value any) error, isset bool) {
+	p := parsedSpec.(*FlagSpec)
+	if p.VersionFlag {
+		return "--version", p.VersionFlag, func(c *CLI, _ any) error {
+			fmt.Println(c.version)
+			return nil
+		}, true
+	}
+	return "", nil, nil, false
+}
+
+// DefaultRootFlagHandlers returns the CLI default flag handlers for global flags
+// that can be used alone (without a command).
+// For example: terramate --version
+func DefaultRootFlagHandlers() []RootFlagHandlers {
+	return []RootFlagHandlers{
+		handleRootVersionFlagAlone, // handles: terramate --version
+	}
+}
+
 // DefaultBeforeConfigHandler implements the default flags handling for when
 // the config is not yet parsed.
 // Use [WithSpecHandler] if you need a different behavior.

--- a/ui/tui/cli_options.go
+++ b/ui/tui/cli_options.go
@@ -86,10 +86,11 @@ func WithHelpPrinter(p kong.HelpPrinter) Option {
 	}
 }
 
-type rootFlagHandlers func(parsed any, cli *CLI) (name string, val any, run func(c *CLI, value any) error, isset bool)
+// RootFlagHandlers is a function signature for root flag handlers.
+type RootFlagHandlers func(parsed any, cli *CLI) (name string, val any, run func(c *CLI, value any) error, isset bool)
 
 // WithSpecHandler is an option to set the flag spec and handler for the CLI.
-func WithSpecHandler(a any, beforeHandler, afterHandler Handler, checkers ...rootFlagHandlers) Option {
+func WithSpecHandler(a any, beforeHandler, afterHandler Handler, checkers ...RootFlagHandlers) Option {
 	return func(c *CLI) error {
 		kongOptions := []kong.Option{
 			kong.Name(c.kongOpts.name),

--- a/ui/tui/cli_spec.go
+++ b/ui/tui/cli_spec.go
@@ -4,8 +4,6 @@
 package tui
 
 import (
-	"fmt"
-
 	"github.com/terramate-io/terramate/cloud/api/preview"
 	"github.com/terramate-io/terramate/safeguard"
 	"github.com/willabides/kongplete"
@@ -313,22 +311,5 @@ func migrateStringFlag(flag *string, alias string) {
 func migrateBoolFlag(flag *bool, alias bool) {
 	if alias && !*flag {
 		*flag = alias
-	}
-}
-
-func handleRootVersionFlagAlone(parsedSpec any, _ *CLI) (name string, val any, run func(c *CLI, value any) error, isset bool) {
-	p := parsedSpec.(*FlagSpec)
-	if p.VersionFlag {
-		return "--version", p.VersionFlag, func(c *CLI, _ any) error {
-			fmt.Println(c.version)
-			return nil
-		}, true
-	}
-	return "", nil, nil, false
-}
-
-func defaultRootFlagHandlers() []rootFlagHandlers {
-	return []rootFlagHandlers{
-		handleRootVersionFlagAlone, // handles: terramate --version
 	}
 }


### PR DESCRIPTION
## What this PR does / why we need it:

This is needed for creating alternative CLI flag handlers.

## Which issue(s) this PR fixes:
none

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
no
```
