### PR TITLE
test: fix interop test to use Terraform from PATH env.

### DIFF
--- a/e2etests/cloud/interop/interoperability_test.go
+++ b/e2etests/cloud/interop/interoperability_test.go
@@ -46,12 +46,9 @@ func TestInteropCloudSyncPreview(t *testing.T) {
 			t.Logf("using GITHUB_EVENT_FILE=%s", eventFile)
 			env = append(env, "GITHUB_ACTIONS=1")
 			tmcli := NewInteropCLI(t, datapath(t, stackpath), env...)
+			tmcli.PrependToPath(filepath.Dir(TerraformTestPath))
 			AssertRunResult(t,
-				tmcli.Run("run", "--quiet",
-					"--",
-					TerraformTestPath,
-					"init",
-				),
+				tmcli.Run("run", "--quiet", "--", "terraform", "init"),
 				RunExpected{
 					IgnoreStdout: true,
 					IgnoreStderr: true,
@@ -63,7 +60,7 @@ func TestInteropCloudSyncPreview(t *testing.T) {
 					"--terraform-plan-file=out.plan",
 					"--target", defaultTarget,
 					"--",
-					TerraformTestPath,
+					"terraform",
 					"plan",
 					"-out=out.plan",
 					"--detailed-exitcode",
@@ -137,12 +134,13 @@ func TestInteropDrift(t *testing.T) {
 	} {
 		t.Run("drift: "+filepath.Base(stackpath), func(t *testing.T) {
 			tmcli := NewInteropCLI(t, datapath(t, stackpath))
+			tmcli.PrependToPath(filepath.Dir(TerraformTestPath))
 			AssertRunResult(t, tmcli.Run("list"), RunExpected{
 				Stdout: nljoin("."),
 			})
 			// initialize the providers
 			AssertRunResult(t,
-				tmcli.Run("run", "--quiet", "--", TerraformTestPath, "init"),
+				tmcli.Run("run", "--quiet", "--", "terraform", "init"),
 				RunExpected{
 					Status:       0,
 					IgnoreStdout: true,
@@ -152,7 +150,7 @@ func TestInteropDrift(t *testing.T) {
 
 			// basic drift, without details
 			AssertRunResult(t,
-				tmcli.Run("run", "--quiet", "--sync-drift-status", "--target", defaultTarget, "--", TerraformTestPath, "plan", "-detailed-exitcode"),
+				tmcli.Run("run", "--quiet", "--sync-drift-status", "--target", defaultTarget, "--", "terraform", "plan", "-detailed-exitcode"),
 				RunExpected{
 					Status:       0,
 					IgnoreStdout: true,
@@ -181,7 +179,7 @@ func TestInteropDrift(t *testing.T) {
 			AssertRunResult(t,
 				tmcli.Run(
 					"run", "--sync-drift-status", "--target", defaultTarget, "--terraform-plan-file=out.plan", "--",
-					TerraformTestPath, "plan", "-out=out.plan", "-detailed-exitcode",
+					"terraform", "plan", "-out=out.plan", "-detailed-exitcode",
 				),
 				RunExpected{
 					Status:       0,

--- a/e2etests/cloud/interop/interoperability_test.go
+++ b/e2etests/cloud/interop/interoperability_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -69,7 +70,7 @@ func TestInteropCloudSyncPreview(t *testing.T) {
 					StderrRegexes: []string{
 						"Preview created",
 					},
-					IgnoreStdout: true,
+					StdoutRegex: regexp.QuoteMeta(`Terraform will perform the following actions`),
 				},
 			)
 		})
@@ -152,9 +153,8 @@ func TestInteropDrift(t *testing.T) {
 			AssertRunResult(t,
 				tmcli.Run("run", "--quiet", "--sync-drift-status", "--target", defaultTarget, "--", "terraform", "plan", "-detailed-exitcode"),
 				RunExpected{
-					Status:       0,
-					IgnoreStdout: true,
-					IgnoreStderr: true,
+					Status:      0,
+					StdoutRegex: regexp.QuoteMeta(`Terraform will perform the following actions`),
 				},
 			)
 			AssertRunResult(t,
@@ -178,13 +178,12 @@ func TestInteropDrift(t *testing.T) {
 			// complete drift
 			AssertRunResult(t,
 				tmcli.Run(
-					"run", "--sync-drift-status", "--target", defaultTarget, "--terraform-plan-file=out.plan", "--",
+					"run", "--quiet", "--sync-drift-status", "--target", defaultTarget, "--terraform-plan-file=out.plan", "--",
 					"terraform", "plan", "-out=out.plan", "-detailed-exitcode",
 				),
 				RunExpected{
-					Status:       0,
-					IgnoreStdout: true,
-					IgnoreStderr: true,
+					Status:      0,
+					StdoutRegex: regexp.QuoteMeta(`Terraform will perform the following actions`),
 				},
 			)
 			AssertRunResult(t,


### PR DESCRIPTION
## What this PR does / why we need it:

The commands in interop tests were invoked like `-- /tmp/cmd-tmpdir-..../terraform plan`
but the internal changeset detail extraction command is invoked as "terraform show ...".
So the problem was that `PATH` did not contain the `terraform` binary anywhere and then the details were not synced. 

## Which issue(s) this PR fixes:
none

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
no
```
