### PR TITLE
chore: restore verbosity printing of token refresh.

### DIFF
--- a/engine/cloud.go
+++ b/engine/cloud.go
@@ -102,7 +102,7 @@ func (e *Engine) LoadCredential(preferences ...string) error {
 		return errors.E(err, clitest.ErrCloudCompat)
 	}
 
-	probes := cliauth.ProbingPrecedence(printer.DefaultPrinters, e.state.cloud.client, e.usercfg)
+	probes := cliauth.ProbingPrecedence(e.printers, e.verbosity, e.state.cloud.client, e.usercfg)
 	var found bool
 	for _, probe := range probes {
 		var err error

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -73,7 +73,8 @@ type (
 		HTTPClient http.Client
 		state      state
 
-		printers printer.Printers
+		printers  printer.Printers
+		verbosity int
 
 		uimode UIMode
 	}
@@ -106,7 +107,7 @@ func NoGitFilter() GitFilter { return GitFilter{} }
 
 // Load loads the engine with the given working directory and CLI configuration.
 // If the project is not found, it returns false.
-func Load(wd string, clicfg cliconfig.Config, uimode UIMode, printers printer.Printers, hclOpts ...hcl.Option) (e *Engine, found bool, err error) {
+func Load(wd string, clicfg cliconfig.Config, uimode UIMode, printers printer.Printers, verbosity int, hclOpts ...hcl.Option) (e *Engine, found bool, err error) {
 	prj, found, err := NewProject(wd, hclOpts...)
 	if err != nil {
 		return nil, false, err
@@ -119,11 +120,12 @@ func Load(wd string, clicfg cliconfig.Config, uimode UIMode, printers printer.Pr
 		return nil, true, errors.E(err, "setting configuration")
 	}
 	return &Engine{
-		project:  prj,
-		printers: printers,
-		uimode:   uimode,
-		usercfg:  clicfg,
-		hclOpts:  hclOpts,
+		project:   prj,
+		printers:  printers,
+		verbosity: verbosity,
+		uimode:    uimode,
+		usercfg:   clicfg,
+		hclOpts:   hclOpts,
 	}, true, nil
 }
 

--- a/ui/tui/cli.go
+++ b/ui/tui/cli.go
@@ -258,7 +258,7 @@ func (c *CLI) Exec(args []string) {
 		return
 	}
 
-	engine, foundRoot, err := engine.Load(c.state.wd, c.clicfg, c.state.uimode, c.printers, c.hclOptions...)
+	engine, foundRoot, err := engine.Load(c.state.wd, c.clicfg, c.state.uimode, c.printers, c.state.verbose, c.hclOptions...)
 	if err != nil {
 		printer.Stderr.FatalWithDetails("unable to parse configuration", err)
 	}

--- a/ui/tui/cliauth/cloud_credential_apikey.go
+++ b/ui/tui/cliauth/cloud_credential_apikey.go
@@ -24,11 +24,16 @@ type APIKey struct {
 
 	orgs   resources.MemberOrganizations
 	client *cloud.Client
+
+	printers  printer.Printers
+	verbosity int
 }
 
-func newAPIKey(client *cloud.Client) *APIKey {
+func newAPIKey(printers printer.Printers, verbosity int, client *cloud.Client) *APIKey {
 	return &APIKey{
-		client: client,
+		client:    client,
+		printers:  printers,
+		verbosity: verbosity,
 	}
 }
 
@@ -51,6 +56,9 @@ func (a *APIKey) Load() (bool, error) {
 	orgs, err := a.client.MemberOrganizations(ctx)
 	if err != nil {
 		return true, err
+	}
+	if a.verbosity > 0 {
+		a.printers.Stdout.Println(fmt.Sprintf("API key loaded from %s environment variable", apiKeyEnvName))
 	}
 	a.orgs = orgs
 	return true, nil

--- a/ui/tui/cliauth/cloud_credential_github_oidc.go
+++ b/ui/tui/cliauth/cloud_credential_github_oidc.go
@@ -39,14 +39,16 @@ type githubOIDC struct {
 	reqToken string
 	orgs     resources.MemberOrganizations
 
-	printers printer.Printers
-	client   *cloud.Client
+	printers  printer.Printers
+	verbosity int
+	client    *cloud.Client
 }
 
-func newGithubOIDC(printers printer.Printers, client *cloud.Client) *githubOIDC {
+func newGithubOIDC(printers printer.Printers, verbosity int, client *cloud.Client) *githubOIDC {
 	return &githubOIDC{
-		client:   client,
-		printers: printers,
+		client:    client,
+		printers:  printers,
+		verbosity: verbosity,
 	}
 }
 
@@ -104,12 +106,16 @@ func (g *githubOIDC) ExpireAt() time.Time {
 
 func (g *githubOIDC) Refresh() (err error) {
 	if g.token != "" {
-		g.printers.Stdout.Println("refreshing token...")
+		if g.verbosity > 0 {
+			g.printers.Stdout.Println("refreshing token...")
+		}
 
 		defer func() {
 			if err == nil {
-				g.printers.Stdout.Println("token successfully refreshed.")
-				g.printers.Stdout.Println(fmt.Sprintf("next token refresh in: %s", time.Until(g.ExpireAt())))
+				if g.verbosity > 0 {
+					g.printers.Stdout.Println("token successfully refreshed.")
+					g.printers.Stdout.Println(fmt.Sprintf("next token refresh in: %s", time.Until(g.ExpireAt())))
+				}
 			}
 		}()
 	}

--- a/ui/tui/cliauth/cloud_credential_gitlab_oidc.go
+++ b/ui/tui/cliauth/cloud_credential_gitlab_oidc.go
@@ -31,19 +31,23 @@ type gitlabOIDC struct {
 
 	orgs resources.MemberOrganizations
 
-	client *cloud.Client
+	printers  printer.Printers
+	verbosity int
+	client    *cloud.Client
 }
 
-func newGitlabOIDC(client *cloud.Client) *gitlabOIDC {
+func newGitlabOIDC(printers printer.Printers, verbosity int, client *cloud.Client) *gitlabOIDC {
 	return &gitlabOIDC{
-		client: client,
+		client:    client,
+		printers:  printers,
+		verbosity: verbosity,
 	}
 }
 
 func (g *gitlabOIDC) Load() (bool, error) {
-	const envToken = "TM_GITLAB_ID_TOKEN"
+	const envName = "TM_GITLAB_ID_TOKEN"
 
-	g.token = os.Getenv(envToken)
+	g.token = os.Getenv(envName)
 	if g.token == "" {
 		return false, nil
 	}
@@ -67,6 +71,10 @@ func (g *gitlabOIDC) Load() (bool, error) {
 	g.repoName = repoName
 
 	g.client.SetCredential(g)
+
+	if g.verbosity > 0 {
+		g.printers.Stdout.Println(fmt.Sprintf("GitLab OIDC token loaded from %s environment variable", envName))
+	}
 	return true, g.fetchDetails()
 }
 

--- a/ui/tui/cliauth/credential.go
+++ b/ui/tui/cliauth/credential.go
@@ -45,12 +45,12 @@ type Credential interface {
 }
 
 // ProbingPrecedence returns the probing precedence for the loading of credentials.
-func ProbingPrecedence(printers printer.Printers, client *cloud.Client, clicfg cliconfig.Config) []Credential {
+func ProbingPrecedence(printers printer.Printers, verbosity int, client *cloud.Client, clicfg cliconfig.Config) []Credential {
 	return []Credential{
-		newAPIKey(client),
-		newGithubOIDC(printers, client),
-		newGitlabOIDC(client),
-		newGoogleCredential(printers, clicfg, client),
+		newAPIKey(printers, verbosity, client),
+		newGithubOIDC(printers, verbosity, client),
+		newGitlabOIDC(printers, verbosity, client),
+		newGoogleCredential(printers, verbosity, clicfg, client),
 	}
 }
 


### PR DESCRIPTION
## What this PR does / why we need it:

The CLI refactor did not kept the conditional verbosity printing of token refresh.

## Which issue(s) this PR fixes:
none

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
no
```
