### PR TITLE
refactor: improve configuration loading.

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/terramate-io/terramate/config"
 	"github.com/terramate-io/terramate/errors"
 	"github.com/terramate-io/terramate/project"
+	. "github.com/terramate-io/terramate/test/hclwrite/hclutils"
 	"github.com/terramate-io/terramate/test/sandbox"
 )
 
@@ -30,6 +31,80 @@ func TestIsStack(t *testing.T) {
 	assert.IsTrue(t, !isStack(cfg, "/dir"))
 	assert.IsTrue(t, isStack(cfg, "/stack"))
 	assert.IsTrue(t, !isStack(cfg, "/stack/subdir"))
+}
+
+func TestTryLoadConfig(t *testing.T) {
+	t.Parallel()
+	type want struct {
+		cfgpath string
+		found   bool
+	}
+	type testcase struct {
+		name    string
+		layout  []string
+		fromdir string
+		want    want
+	}
+
+	for _, tc := range []testcase{
+		{
+			name:    "no config",
+			layout:  []string{},
+			fromdir: "/",
+		},
+		{
+			name: "has config but no root config",
+			layout: []string{
+				"f:/config.tm:" + Block("generate_file",
+					Labels("test.txt"),
+					Str("content", "test"),
+				).String(),
+			},
+			fromdir: "/",
+		},
+		{
+			name: "has root config - find from root",
+			layout: []string{
+				"f:config.tm:" + Block("terramate",
+					Str("required_version", fmt.Sprintf("= %s", terramate.Version())),
+				).String(),
+			},
+			fromdir: "/",
+			want:    want{cfgpath: "/", found: true},
+		},
+		{
+			name: "has root config - find from nested subdir",
+			layout: []string{
+				"f:config.tm:" + Block("terramate",
+					Str("required_version", fmt.Sprintf("= %s", terramate.Version())),
+				).String(),
+				"d:/nested/subdir",
+			},
+			fromdir: "/nested/subdir",
+			want:    want{cfgpath: "/", found: true},
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			s := sandbox.NoGit(t, false)
+			s.BuildTree(tc.layout)
+			if tc.fromdir == "" {
+				tc.fromdir = "/"
+			}
+			fromdir := filepath.Join(s.RootDir(), tc.fromdir)
+			root, path, found, err := config.TryLoadConfig(fromdir)
+			assert.NoError(t, err)
+			if tc.want.found != found {
+				t.Fatalf("want %v, got %v", tc.want, found)
+			}
+			if tc.want.found {
+				assert.IsTrue(t, root != nil)
+				pdir := project.PrjAbsPath(s.RootDir(), path)
+				assert.EqualStrings(t, tc.want.cfgpath, pdir.String())
+			}
+		})
+	}
 }
 
 func TestValidStackIDs(t *testing.T) {

--- a/hcl/hcl_test.go
+++ b/hcl/hcl_test.go
@@ -1930,7 +1930,7 @@ func parse(tc testcase) (*hcl.Config, error) {
 	return parser.ParseConfig()
 }
 
-func TestHCLParseReParsingFails(t *testing.T) {
+func TestHCLParseReParsingWorks(t *testing.T) {
 	temp := test.TempDir(t)
 	p, err := hcl.NewTerramateParser(temp, temp)
 	assert.NoError(t, err)
@@ -1941,9 +1941,9 @@ func TestHCLParseReParsingFails(t *testing.T) {
 	assert.NoError(t, err)
 
 	_, err = p.ParseConfig()
-	assert.Error(t, err)
-	err = p.Parse()
-	assert.Error(t, err)
+	assert.NoError(t, err)
+	err = p.ParseHCL()
+	assert.NoError(t, err)
 }
 
 func TestHCLParseProvidesAllParsedBodies(t *testing.T) {

--- a/stack/clone.go
+++ b/stack/clone.go
@@ -158,7 +158,7 @@ func UpdateStackID(root *config.Root, stackdir string) (string, error) {
 		return "", err
 	}
 
-	if err := parser.Parse(); err != nil {
+	if err := parser.ParseHCL(); err != nil {
 		return "", err
 	}
 

--- a/test/stack.go
+++ b/test/stack.go
@@ -25,7 +25,7 @@ func AssertStackImports(t *testing.T, rootdir string, stackHostPath string, want
 	err = parser.AddDir(stackHostPath)
 	assert.NoError(t, err)
 
-	err = parser.Parse()
+	err = parser.ParseHCL()
 	assert.NoError(t, err)
 
 	imports, err := parser.Imports()

--- a/ui/tui/cli.go
+++ b/ui/tui/cli.go
@@ -264,7 +264,7 @@ func (c *CLI) Exec(args []string) {
 	}
 
 	if !foundRoot {
-		printer.Stderr.Fatal(`Error: Terramate was unable to detect a project root.
+		printer.Stderr.Fatal(`Terramate was unable to detect a project root.
 
 Please ensure you run Terramate inside a Git repository or create a new one here by calling 'git init'.
 


### PR DESCRIPTION
## What this PR does / why we need it:

This change is required for upcoming performance optimizations in the Terragrunt module detection.

## Which issue(s) this PR fixes:
none
## Special notes for your reviewer:

Main goal of this change is making the *Root available during the loadTree() tree walking for allowing a context and pool of workers for the Terragrunt async loading.

## Does this PR introduce a user-facing change?
```
no
```
