### PR TITLE
fix(run,script-run): user-supplied relative cmdpath not built for sta…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 ### Fixed
 
 - Fix Terragrunt integration not skipping hidden directories and not honoring `.tmskip` file.
+- Fix `terramate [run, script run]` not computing the relative command path correctly relative
+  to the stack directory.
 
 ## v0.13.0
 

--- a/cloudsync/terraform_planfile.go
+++ b/cloudsync/terraform_planfile.go
@@ -122,7 +122,8 @@ func runTerraformShow(e *engine.Engine, run engine.StackCloudRun, flags ...strin
 		cmdName = "terraform"
 	}
 
-	cmdPath, err := runpkg.LookPath(cmdName, run.Env)
+	stackdir := run.Stack.Dir.HostPath(e.Config().HostDir())
+	cmdPath, err := runpkg.LookPath(cmdName, stackdir, run.Env)
 	if err != nil {
 		return "", errors.E(clitest.ErrCloudTerraformPlanFile, "looking up executable for %s: %w", cmdName, err)
 	}

--- a/engine/run.go
+++ b/engine/run.go
@@ -440,7 +440,8 @@ func (e *Engine) RunAll(
 				Str("cmd", cmdStr).
 				Logger()
 
-			cmdPath, err := runutil.LookPath(task.Cmd[0], environ)
+			stackdir := run.Stack.HostDir(e.Config())
+			cmdPath, err := runutil.LookPath(task.Cmd[0], stackdir, environ)
 			if err != nil {
 				opts.Hooks.After(e, cloudRun, RunResult{ExitCode: -1}, errors.E(ErrRunCommandNotExecuted, err))
 				errs.Append(errors.E(err, "running `%s` in stack %s", cmdStr, run.Stack.Dir))
@@ -453,7 +454,7 @@ func (e *Engine) RunAll(
 			}
 
 			cmd := exec.Command(cmdPath, task.Cmd[1:]...)
-			cmd.Dir = run.Stack.HostDir(e.Config())
+			cmd.Dir = stackdir
 			cmd.Env = environ
 
 			stdin := opts.Stdin

--- a/run/lookpath_unix.go
+++ b/run/lookpath_unix.go
@@ -30,12 +30,15 @@ const ErrNotFound errors.Kind = "executable file not found in $PATH"
 // In older versions of Go, LookPath could return a path relative to the current directory.
 // As of Go 1.19, LookPath will instead return that path along with an error satisfying
 // errors.Is(err, ErrDot). See the package documentation for more details.
-func LookPath(file string, environ []string) (string, error) {
+func LookPath(file string, cwd string, environ []string) (string, error) {
 	// NOTE(rsc): I wish we could use the Plan 9 behavior here
 	// (only bypass the path if file begins with / or ./ or ../)
 	// but that would not match all the Unix shells.
 
 	if strings.Contains(file, "/") {
+		if !filepath.IsAbs(file) {
+			file = filepath.Join(cwd, file)
+		}
 		err := findExecutable(file)
 		if err == nil {
 			return file, nil

--- a/run/lookpath_windows.go
+++ b/run/lookpath_windows.go
@@ -74,7 +74,7 @@ func findExecutable(file string, exts []string) (string, error) {
 // In older versions of Go, LookPath could return a path relative to the current directory.
 // As of Go 1.19, LookPath will instead return that path along with an error satisfying
 // errors.Is(err, ErrDot). See the package documentation for more details.
-func LookPath(file string, environ []string) (string, error) {
+func LookPath(file string, cwd string, environ []string) (string, error) {
 	var exts []string
 	x, _ := Getenv(`PATHEXT`, environ)
 	if x != "" {
@@ -92,6 +92,9 @@ func LookPath(file string, environ []string) (string, error) {
 	}
 
 	if strings.ContainsAny(file, `:\/`) {
+		if !filepath.IsAbs(file) {
+			file = filepath.Join(cwd, file)
+		}
 		f, err := findExecutable(file, exts)
 		if err == nil {
 			return f, nil

--- a/test/sandbox/sandbox.go
+++ b/test/sandbox/sandbox.go
@@ -739,7 +739,7 @@ func buildTree(t testing.TB, root *config.Root, environ []string, layout []strin
 			))
 		case "run:":
 			cmdParts := strings.Split(param2, " ")
-			path, err := run.LookPath(cmdParts[0], environ)
+			path, err := run.LookPath(cmdParts[0], rootdir, environ)
 			assert.NoError(t, err)
 			cmd := exec.Command(path, cmdParts[1:]...)
 			cmd.Dir = filepath.Join(rootdir, param1)


### PR DESCRIPTION
## What this PR does / why we need it:

If the user-supplied command to either `run` or `script run` is a relative path then the absolute path is not being built for the stack directory that it will run on.

Issue reported by *Atha Kouroussis* in Discord: https://discord.com/channels/1088753599951151154/1088769572305383484/1365061925309911190

## Which issue(s) this PR fixes:
none

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
yes, fixes a run/script-run issue.
```
