### PR TITLE
fix: terragrunt loader printing misleading error.

### DIFF
--- a/tg/tg_module_test.go
+++ b/tg/tg_module_test.go
@@ -776,7 +776,9 @@ func TestTerragruntScanModules(t *testing.T) {
 			if err != nil {
 				return
 			}
-			if diff := cmp.Diff(modules, tc.want.modules, cmpopts.EquateComparable(project.Path{}), cmpopts.IgnoreUnexported(tg.Module{})); diff != "" {
+			if diff := cmp.Diff(modules, tc.want.modules,
+				cmpopts.IgnoreFields(tg.Module{}, "FilesProcessed"),
+				cmpopts.EquateComparable(project.Path{}), cmpopts.IgnoreUnexported(tg.Module{})); diff != "" {
 				t.Errorf("Diff (want [+], got [-]): %s", diff)
 			}
 		})


### PR DESCRIPTION
## What this PR does / why we need it:

When the project contains incomplete "terragrunt.hcl" files that are used by root modules, Terramate is issuing errors for the temporary parsers.

```
terramate run --changed -X -- echo ok
ERRO[0000] Error: Error in function call
      
ERRO[0000]   on /home/i4ki/src/terramate-terragrunt-infrastructure-live-example/terragrunt.hcl line 9, in locals: 
ERRO[0000]    9:   account_vars = read_terragrunt_config(find_in_parent_folders("account.hcl")) 
ERRO[0000]                                              
ERRO[0000] Call to function "find_in_parent_folders" failed: ParentFileNotFoundError: Could not find a account.hcl
in any of the parent folders of
/home/i4ki/src/terramate-terragrunt-infrastructure-live-example/terragrunt.hcl. Cause: Traversed all the way to the root..

terramate: Entering stack in /non-prod/us-east-1/qa/mysql
terramate: Executing command "echo ok"
ok
terramate: Entering stack in /non-prod/us-east-1/stage/mysql
terramate: Executing command "echo ok"
ok
terramate: Entering stack in /prod/us-east-1/prod/mysql
terramate: Executing command "echo ok"
ok
```

## Which issue(s) this PR fixes:
none

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
```
yes, but it was introduced in v0.13.1-rc4
```
