### PR TITLE
chore: hide deprecated experimental trigger in help

### DIFF
--- a/ui/tui/cli_spec.go
+++ b/ui/tui/cli_spec.go
@@ -109,7 +109,7 @@ type FlagSpec struct {
 		IgnoreChange bool   `default:"false" help:"Trigger stacks to be ignored by change detection"`
 		Reason       string `default:"" name:"reason" help:"Set a reason for triggering the stack."`
 		cloudFilterFlags
-	} `cmd:"" help:"Mark a stack as changed so it will be triggered in Change Detection."`
+	} `cmd:"" hidden:""  help:"Mark a stack as changed so it will be triggered in Change Detection. (DEPRECATED)"`
 
 	Experimental struct {
 		Clone struct {


### PR DESCRIPTION
## What this PR does / why we need it:

Trigger has been promoted to stable so the experimental version should be removed from the help listing.

## Does this PR introduce a user-facing change?
<!--
If no, just write "no" in the block below.
If yes, please explain the change and update documentation and the CHANGELOG.md file accordingly.
-->
```
No, just the help is affected.
```
