### PR TITLE
fix: module change detection for common name prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 - Fix crash in the `terramate install-completions` command.
 - Fix error on duplicate Terragrunt dependencies in `create --all-terragrunt`.
   - Duplicates are now removed and the command will no longer fail.
+- Fix mistakenly detecting stacks as changed on changes in referenced Terraform modules.
+  - A change in a module that is referenced by `stack-a` would also mark `stack-aa` as changed (and other stacks with a common name prefix).
 
 ## v0.14.0
 

--- a/stack/manager.go
+++ b/stack/manager.go
@@ -601,7 +601,7 @@ func (m *Manager) tfModuleChanged(
 		return false, "", err
 	}
 	for _, changedFile := range changedFiles {
-		if changedFile.HasPrefix(modPath.String()) {
+		if changedFile.HasDirPrefix(modPath.String()) {
 			return true, fmt.Sprintf("module %q has unmerged changes", mod.Source), nil
 		}
 	}
@@ -709,7 +709,7 @@ func (m *Manager) tgModuleChanged(
 		}
 
 		for _, file := range changedFiles {
-			if file.HasPrefix(dep.String()) {
+			if file.HasDirPrefix(dep.String()) {
 				return true, fmt.Sprintf("module %q changed because %q changed", tgMod.Path, dep), nil
 			}
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/terramate-io/terramate/blob/main/CONTRIBUTING.md
2. If the PR is unfinished, mark it as draft: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request
3. Please update the PR title using the Conventional Commits convention: https://www.conventionalcommits.org/en/v1.0.0/
    Example: feat: add support for XYZ.
-->

## What this PR does / why we need it:

This PR fixes a bug in the change detection that would mistakenly list a stack as changed in some circumstances.

The scenario is that if a stack named `foobar` references a Terraform module, then changes in that module will also flag a stack with a common name prefix as changed, i.e. a stack named `foo`.

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
<!--
If no, just write "no" in the block below.
If yes, please explain the change and update documentation and the CHANGELOG.md file accordingly.
-->
```
No, it is a change in behaviour but does not break compatibility.
```
