### PR TITLE
fix: updated project setup docs link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 - Backward compatibility in versions `0.0.z` is **not guaranteed** when `z` is increased.
 - Backward compatibility in versions `0.y.z` is **not guaranteed** when `y` is increased.
 
+## [Unreleased]
+
+### Fixed
+
+- Fix link to project setup documentation when not finding a project root.
+
 ## v0.14.1
 
 ### Fixed

--- a/ui/tui/cli.go
+++ b/ui/tui/cli.go
@@ -274,7 +274,7 @@ Using Terramate together with Git is the recommended way.
 
 Alternatively you can create a Terramate config to make the current directory the project root.
 
-Please see https://terramate.io/docs/cli/configuration/project-setup for details.
+Please see https://terramate.io/docs/cli/projects/configuration for details.
 `)
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/terramate-io/terramate/blob/main/CONTRIBUTING.md
2. If the PR is unfinished, mark it as draft: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request
3. Please update the PR title using the Conventional Commits convention: https://www.conventionalcommits.org/en/v1.0.0/
    Example: feat: add support for XYZ.
-->

## What this PR does / why we need it:

The link shown when the terramate CLI was unable to detect the project root was 404.

```Please see https://terramate.io/docs/cli/configuration/project-setup for details.```

This PR updates the link to a working version:

```Please see https://terramate.io/docs/cli/projects/configuration for details.```

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Keep it empty if not applicable.
-->
Fixes #

## Special notes for your reviewer:

## Does this PR introduce a user-facing change?
<!--
If no, just write "no" in the block below.
If yes, please explain the change and update documentation and the CHANGELOG.md file accordingly.
-->
Yes, fixes the project setup link.