### PR TITLE
Fix crash in terramate cloud login with SSO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 - Backward compatibility in versions `0.0.z` is **not guaranteed** when `z` is increased.
 - Backward compatibility in versions `0.y.z` is **not guaranteed** when `y` is increased.
 
+## Unreleased
+
+### Fixed
+
+- Fix crash in the `terramate cloud login --sso` command.
+
 ## v0.14.1
 
 ### Fixed

--- a/engine/cloud.go
+++ b/engine/cloud.go
@@ -75,7 +75,7 @@ func (e *Engine) Credential() cliauth.Credential {
 
 // LoadCredential loads the cloud credential from the environment or configuration.
 func (e *Engine) LoadCredential(preferences ...string) error {
-	region := e.cloudRegion()
+	region := e.CloudRegion()
 	cloudURL, envFound := cliauth.EnvBaseURL()
 	if !envFound {
 		cloudURL = cloud.BaseURL(region)
@@ -227,7 +227,7 @@ func (e *Engine) SetupCloudConfig(requestedFeatures []string) error {
 					"Pending SSO invitation",
 					errors.E(
 						"If you trust the %s%s organization, go to %s to join it",
-						org.Name, domainStr, cloud.HTMLURL(e.cloudRegion()),
+						org.Name, domainStr, cloud.HTMLURL(e.CloudRegion()),
 					),
 				)
 			}

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -145,7 +145,8 @@ func (e *Engine) RepoChecks() stack.RepoChecks { return e.state.repoChecks }
 // RootNode returns the root node of the project.
 func (e *Engine) RootNode() hcl.Config { return e.project.root.Tree().Node }
 
-func (e *Engine) cloudRegion() cloud.Region {
+// CloudRegion returns the cloud region from configuration, defaulting to EU.
+func (e *Engine) CloudRegion() cloud.Region {
 	rootcfg := e.RootNode()
 	if rootcfg.Terramate != nil && rootcfg.Terramate.Config != nil && rootcfg.Terramate.Config.Cloud != nil {
 		return rootcfg.Terramate.Config.Cloud.Location

--- a/ui/tui/cli_handler.go
+++ b/ui/tui/cli_handler.go
@@ -482,6 +482,8 @@ func DefaultAfterConfigHandler(ctx context.Context, c *CLI) (commands.Executor, 
 			)
 		}
 		return &logincmd.SSOSpec{
+			Engine:    c.Engine(),
+			Region:    c.Engine().CloudRegion(),
 			Printers:  c.printers,
 			Verbosity: parsedArgs.Verbose,
 			OrgName:   orgName,


### PR DESCRIPTION
Fix a crash in `terramate cloud login --sso` which happened to the lack of mandatory field initialization in the engine