### PR TITLE
 feat: Add tm_joinlist() function for joining nested lists of strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,17 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 - Backward compatibility in versions `0.0.z` is **not guaranteed** when `z` is increased.
 - Backward compatibility in versions `0.y.z` is **not guaranteed** when `y` is increased.
 
+## Unreleased
+
+### Added
+
+- Add `tm_joinlist()` function for joining nested lists of strings with a separator.
+
+  ```hcl
+  tm_joinlist("/", [["root"], ["root", "child"], ["root", "child", "leaf"]])
+  # Returns: ["root", "root/child", "root/child/leaf"]
+  ```
+
 ## v0.14.4
 
 ### Fixed
@@ -60,54 +71,58 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 
   This affects and improves commands that use the stack order, i.e. `run`, `run script`, `list --run-order`.
   As a consequence, the evaluation order of _unrelated_ stacks may change.
-
   - Example 1:
     Nested stacks `a` must be executed after their parent stacks, but `/stack1` and `/stack2` are independent.
 
     Old run order:
-      ```
-      /stack1
-      /stack1/a
-      /stack2
-      /stack2/a
-      ```
+
+    ```
+    /stack1
+    /stack1/a
+    /stack2
+    /stack2/a
+    ```
 
     New run order:
-      ```
-      /stack1
-      /stack2
-      /stack1/a
-      /stack2/a
-      ```
+
+    ```
+    /stack1
+    /stack2
+    /stack1/a
+    /stack2/a
+    ```
 
   - Example 2:
     `stack2` must be executed after `stack1`, but `stack1` and `stack3` are independent in the follwing configuration:
-      ```
-      /stack1 
-      /stack2 (after=[stack1])
-      /stack3
-      ```
+
+    ```
+    /stack1
+    /stack2 (after=[stack1])
+    /stack3
+    ```
 
     Old run order:
-      ```
-      /stack1
-      /stack2
-      /stack3
-      ```
+
+    ```
+    /stack1
+    /stack2
+    /stack3
+    ```
 
     New run order:
-      ```
-      /stack1
-      /stack3
-      /stack2
-      ```
+
+    ```
+    /stack1
+    /stack3
+    /stack2
+    ```
 
   The new rule recursively aligns stacks that are independent into groups.
   - The first group contains all initially independent stacks.
   - The second group contains all stacks that just depended on stacks in the first group.
   - The third group contains all stacks that just depended on stacks in both previous groups.
   - The fourth group and following groups continue in the same way.
-  
+
   Stacks in each group are ordered lexicographically and returned as the order of execution when running sequentially.
 
   The run order when using the `--parallel` flag is not affected by this change.
@@ -230,7 +245,7 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 
 - Add support for tracking `file()` usages in Terragrunt files for enhancing the change detection.
   - Now if you have Terragrunt modules that directly read files from elsewhere in the project, Terramate will
-  mark the stack changed whenever the aforementioned file changes.
+    mark the stack changed whenever the aforementioned file changes.
 - Add telemetry to collect anonymous usage metrics.
   - This helps us to improve user experience by measuring which Terramate features are used most actively.
     For further details, see [documentation](https://terramate.io/docs/cli/telemetry).
@@ -273,11 +288,11 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 - Faster code generation through parallelization.
   - Enabled by default, use `terramate generate --parallel <n>` to control the amount of concurrent units (default = number of logical CPU cores).
 
-## v0.11.0 
+## v0.11.0
 
 ### Added
 
-- Add `--enable-change-detection=<options>` and `--disable-change-detection=<options>` to the commands: `terramate list`, `terramate run` and `terramate script run`. 
+- Add `--enable-change-detection=<options>` and `--disable-change-detection=<options>` to the commands: `terramate list`, `terramate run` and `terramate script run`.
   - These flags overrides both the default change detection strategy and the configuration in `terramate.config.change_detection.git` block.
 - Add support for using `TM_ARG_*` environment variables to configure cli commands.
   Note: This is an incremental change. Only global flags and `terramate run` flags were added for now.
@@ -285,7 +300,7 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 
 ### Changed
 
-- **(Breaking change)** The `terramate list --changed` now considers *untracked* and * uncommitted*  files for detecting changed stacks.
+- **(Breaking change)** The `terramate list --changed` now considers _untracked_ and _ uncommitted_ files for detecting changed stacks.
   - This behavior can be turned off by `terramate.config.change_detection.git.untracked = "off"` and `terramate.config.change_detection.git.uncommitted = "off"`.
 - **(Breaking change)** Remove the deprecated `terramate experimental run-order`.
   - The `terramate list --run-order` was introduced in version `v0.4.5` and provides the same functionality as the removed command.
@@ -324,13 +339,12 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 
 - Several performance improvements in the change detection.
 
-
 ## v0.10.6
 
 ### Fixed
 
 - Fix "outdated-code" safeguard giving false positive results for files generated
- in subdirectory of stacks.
+  in subdirectory of stacks.
 
 ## v0.10.5
 
@@ -462,7 +476,7 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 ### Fixed
 
 - Fix `terramate experimental trigger --status` to respect the `-C <dir>` flag.
-	- Now using `-C <dir>` (or `--chdir <dir>`) only triggers stacks inside the provided dir.
+  - Now using `-C <dir>` (or `--chdir <dir>`) only triggers stacks inside the provided dir.
 - Fix the update of stack status to respect the configured parallelism option and only set stack status to be `running` before the command starts.
 - Fix `terramate experimental trigger` gives a misleading error message when a stack is not found.
 
@@ -732,9 +746,7 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 - Add support for `stack_filter` blocks in `generate_file` blocks
 - Add `list --run-order` flag to list stacks in the order of execution
 - Add support for `terramate` in linting, pre-commit and test environments
-
   - Add `--detailed-exit-code` to `terramate fmt` and `terramate generate` commands:
-
     - An exit code of `0` represents successful execution and no changes made
     - An exit code of `1` represents the error state, something went wrong
     - An exit code of `2` represents successful execution but changes were made
@@ -742,7 +754,6 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 ### Changed
 
 - Refactor Safeguards
-
   - Add `disable_safeguards` configuration and `--disable-safeguards` CLI option with possible values
     - `all` Disable ALL safeguards (use with care)
     - `none` Enable ALL safeguards
@@ -753,19 +764,16 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
     - `outdated-code` Disable Safeguard that checks for outdated code
 
 - Promote cloud commands from `experimental`
-
   - `terramate cloud login`
   - `terramate cloud info`
   - `terramate cloud drift show`
 
 - Improve support for synchronization of deployments to Terramate Cloud
-
   - Add `cloud_sync_deployment` flag to Terramate Scripts Commands
   - Add `cloud_sync_terraform_plan_file` flag to Terramate Scripts Commands when synchronizing deployments.
   - Add `--cloud-sync-terraform-plan-file` support to `terramate run` when synchronizing deployments.
 
 - Promote `--experimental-status` flag to `--cloud-status` flag in
-
   - `terramate experimental trigger`
   - `terramate list`
 
@@ -786,7 +794,6 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 - Add `terramate.config.experiments` configuration to enable experimental features
 - Add support for statuses `ok`, `failed`, `drifted`, and `healthy` to the `--experimental-status` flag
 - Add experimental `script` configuration block
-
   - Add `terramate script list` to list scripts visible in current directory
   - Add `terramate script tree` to show a tree view of scripts visible in current directory
   - Add `terramate script info <scriptname>` to show details about a script
@@ -795,7 +802,6 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 - Add `stack_filter` block to `generate_hcl` for path-based conditional generation.
 
 - Promote experimental commands
-
   - `terramate debug show metadata`
   - `terramate debug show globals`
   - `terramate debug show generate-origins`

--- a/stdlib/funcs.go
+++ b/stdlib/funcs.go
@@ -101,6 +101,7 @@ func Functions(basedir string, experiments []string) map[string]function.Functio
 	tmfuncs["tm_hcldecode"] = HCLDecode()
 
 	tmfuncs["tm_slug"] = SlugFunc()
+	tmfuncs["tm_joinlist"] = JoinListFunc()
 
 	return tmfuncs
 }

--- a/stdlib/funcs_join_list.go
+++ b/stdlib/funcs_join_list.go
@@ -1,0 +1,97 @@
+// Copyright 2025 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+package stdlib
+
+import (
+	"strings"
+
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/function"
+)
+
+// JoinListFunc implements the `tm_joinlist()` function.
+// tm_joinlist(separator: string, list_of_lists: list(list(string))) -> list(string)
+// It joins each sublist in the list_of_lists using the separator.
+func JoinListFunc() function.Function {
+	return function.New(&function.Spec{
+		Params: []function.Parameter{
+			{
+				Name: "separator",
+				Type: cty.String,
+			},
+			{
+				Name: "list_of_lists",
+				Type: cty.DynamicPseudoType,
+			},
+		},
+		Type: function.StaticReturnType(cty.List(cty.String)),
+		Impl: func(args []cty.Value, _ cty.Type) (cty.Value, error) {
+			return joinList(args[0], args[1])
+		},
+	})
+}
+
+func joinList(separatorVal, listOfListsVal cty.Value) (cty.Value, error) {
+	separator := separatorVal.AsString()
+
+	// Validate that list_of_lists is actually a list or tuple (HCL represents [["a"]] as tuple)
+	if !listOfListsVal.Type().IsListType() && !listOfListsVal.Type().IsTupleType() {
+		return cty.NilVal, JoinListInvalidArgumentTypeError(listOfListsVal.Type().FriendlyName())
+	}
+
+	// Handle empty input list
+	if listOfListsVal.LengthInt() == 0 {
+		return cty.ListValEmpty(cty.String), nil
+	}
+
+	var results []cty.Value
+	listOfListsIt := listOfListsVal.ElementIterator()
+
+	for listOfListsIt.Next() {
+		idx, subListVal := listOfListsIt.Element()
+
+		// Type validation - ensure each element is list(string) or tuple(string...)
+		if !subListVal.Type().IsListType() && !subListVal.Type().IsTupleType() {
+			idxInt, _ := idx.AsBigFloat().Int64()
+			return cty.NilVal, JoinListInvalidElementTypeError(idxInt, subListVal.Type().FriendlyName())
+		}
+
+		// For lists, check element type
+		if subListVal.Type().IsListType() {
+			if !subListVal.Type().ElementType().Equals(cty.String) {
+				idxInt, _ := idx.AsBigFloat().Int64()
+				return cty.NilVal, JoinListInvalidListElementTypeError(idxInt, subListVal.Type().ElementType().FriendlyName())
+			}
+		}
+
+		// For tuples, check all element types are strings
+		if subListVal.Type().IsTupleType() {
+			for i, elemType := range subListVal.Type().TupleElementTypes() {
+				if !elemType.Equals(cty.String) {
+					idxInt, _ := idx.AsBigFloat().Int64()
+					return cty.NilVal, JoinListInvalidTupleElementTypeError(idxInt, i, elemType.FriendlyName())
+				}
+			}
+		}
+
+		// Handle empty sublist
+		if subListVal.LengthInt() == 0 {
+			results = append(results, cty.StringVal(""))
+			continue
+		}
+
+		// Join elements of the sublist
+		var subElements []string
+		subListIt := subListVal.ElementIterator()
+		for subListIt.Next() {
+			_, elementVal := subListIt.Element()
+			subElements = append(subElements, elementVal.AsString())
+		}
+
+		joinedString := strings.Join(subElements, separator)
+		results = append(results, cty.StringVal(joinedString))
+	}
+
+	return cty.ListVal(results), nil
+}

--- a/stdlib/funcs_join_list_errors.go
+++ b/stdlib/funcs_join_list_errors.go
@@ -1,0 +1,43 @@
+// Copyright 2025 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+package stdlib
+
+import "github.com/terramate-io/terramate/errors"
+
+// JoinListInvalidArgumentType is returned when the second argument to tm_joinlist is not a list or tuple.
+const JoinListInvalidArgumentType errors.Kind = "tm_joinlist: invalid argument type"
+
+// JoinListInvalidArgumentTypeError creates an error for invalid argument type.
+func JoinListInvalidArgumentTypeError(got string) error {
+	return errors.E(JoinListInvalidArgumentType,
+		"tm_joinlist: expected list(list(string)) as second argument, got %s", got)
+}
+
+// JoinListInvalidElementType is returned when an element in the list is not a list or tuple of strings.
+const JoinListInvalidElementType errors.Kind = "tm_joinlist: invalid element type"
+
+// JoinListInvalidElementTypeError creates an error for invalid element type.
+func JoinListInvalidElementTypeError(index int64, got string) error {
+	return errors.E(JoinListInvalidElementType,
+		"tm_joinlist: expected all elements to be list(string), got %s at index %d", got, index)
+}
+
+// JoinListInvalidListElementType is returned when a list element contains non-string values.
+const JoinListInvalidListElementType errors.Kind = "tm_joinlist: invalid list element type"
+
+// JoinListInvalidListElementTypeError creates an error for invalid list element type.
+func JoinListInvalidListElementTypeError(index int64, got string) error {
+	return errors.E(JoinListInvalidListElementType,
+		"tm_joinlist: expected all elements to be list(string), got list(%s) at index %d", got, index)
+}
+
+// JoinListInvalidTupleElementType is returned when a tuple element contains non-string values.
+const JoinListInvalidTupleElementType errors.Kind = "tm_joinlist: invalid tuple element type"
+
+// JoinListInvalidTupleElementTypeError creates an error for invalid tuple element type.
+func JoinListInvalidTupleElementTypeError(listIndex int64, elementIndex int, got string) error {
+	return errors.E(JoinListInvalidTupleElementType,
+		"tm_joinlist: expected all elements to be list(string), got tuple with %s at element %d of index %d",
+		got, elementIndex, listIndex)
+}

--- a/stdlib/funcs_join_list_test.go
+++ b/stdlib/funcs_join_list_test.go
@@ -1,0 +1,337 @@
+// Copyright 2025 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+package stdlib_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/madlambda/spells/assert"
+	"github.com/terramate-io/terramate/errors"
+	"github.com/terramate-io/terramate/hcl/ast"
+	"github.com/terramate-io/terramate/hcl/eval"
+	"github.com/terramate-io/terramate/stdlib"
+	"github.com/terramate-io/terramate/test"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestTmJoinList(t *testing.T) {
+	dir := test.TempDir(t)
+	funcs := stdlib.Functions(dir, []string{})
+
+	t.Run("basic join - single elements", func(t *testing.T) {
+		evalctx := eval.NewContext(funcs)
+		expr, err := ast.ParseExpression(`tm_joinlist("-", [["a"], ["b"], ["c"]])`, "test.tm")
+		assert.NoError(t, err)
+		val, err := evalctx.Eval(expr)
+		assert.NoError(t, err)
+
+		expected := []string{"a", "b", "c"}
+		result := extractStringList(t, val)
+		assert.EqualInts(t, len(expected), len(result))
+		for i, exp := range expected {
+			assert.EqualStrings(t, exp, result[i])
+		}
+	})
+
+	t.Run("basic join - multiple elements", func(t *testing.T) {
+		evalctx := eval.NewContext(funcs)
+		expr, err := ast.ParseExpression(`tm_joinlist("-", [["a"], ["a","b"], ["a","b","c"]])`, "test.tm")
+		assert.NoError(t, err)
+		val, err := evalctx.Eval(expr)
+		assert.NoError(t, err)
+
+		expected := []string{"a", "a-b", "a-b-c"}
+		result := extractStringList(t, val)
+		assert.EqualInts(t, len(expected), len(result))
+		for i, exp := range expected {
+			assert.EqualStrings(t, exp, result[i])
+		}
+	})
+
+	t.Run("slash separator for paths", func(t *testing.T) {
+		evalctx := eval.NewContext(funcs)
+		expr, err := ast.ParseExpression(`tm_joinlist("/", [["root"], ["root", "child"], ["root", "child", "leaf"]])`, "test.tm")
+		assert.NoError(t, err)
+		val, err := evalctx.Eval(expr)
+		assert.NoError(t, err)
+
+		expected := []string{"root", "root/child", "root/child/leaf"}
+		result := extractStringList(t, val)
+		assert.EqualInts(t, len(expected), len(result))
+		for i, exp := range expected {
+			assert.EqualStrings(t, exp, result[i])
+		}
+	})
+
+	t.Run("empty input list", func(t *testing.T) {
+		evalctx := eval.NewContext(funcs)
+		expr, err := ast.ParseExpression(`tm_joinlist("/", [])`, "test.tm")
+		assert.NoError(t, err)
+		val, err := evalctx.Eval(expr)
+		assert.NoError(t, err)
+
+		result := extractStringList(t, val)
+		assert.EqualInts(t, 0, len(result))
+	})
+
+	t.Run("empty sublist", func(t *testing.T) {
+		evalctx := eval.NewContext(funcs)
+		expr, err := ast.ParseExpression(`tm_joinlist("/", [["a"], []])`, "test.tm")
+		assert.NoError(t, err)
+		val, err := evalctx.Eval(expr)
+		assert.NoError(t, err)
+
+		expected := []string{"a", ""}
+		result := extractStringList(t, val)
+		assert.EqualInts(t, len(expected), len(result))
+		for i, exp := range expected {
+			assert.EqualStrings(t, exp, result[i])
+		}
+	})
+
+	t.Run("complex tree-like structure", func(t *testing.T) {
+		evalctx := eval.NewContext(funcs)
+		expr, err := ast.ParseExpression(`tm_joinlist("/", [
+			["Grand Parent A"], 
+			["Grand Parent A", "Parent A"], 
+			["Grand Parent A", "Parent A", "Child A"], 
+			["Grand Parent A", "Parent A", "Child B"]
+		])`, "test.tm")
+		assert.NoError(t, err)
+		val, err := evalctx.Eval(expr)
+		assert.NoError(t, err)
+
+		expected := []string{
+			"Grand Parent A",
+			"Grand Parent A/Parent A",
+			"Grand Parent A/Parent A/Child A",
+			"Grand Parent A/Parent A/Child B",
+		}
+		result := extractStringList(t, val)
+		assert.EqualInts(t, len(expected), len(result))
+		for i, exp := range expected {
+			assert.EqualStrings(t, exp, result[i])
+		}
+	})
+
+	t.Run("single character separator", func(t *testing.T) {
+		evalctx := eval.NewContext(funcs)
+		expr, err := ast.ParseExpression(`tm_joinlist("|", [["x", "y", "z"]])`, "test.tm")
+		assert.NoError(t, err)
+		val, err := evalctx.Eval(expr)
+		assert.NoError(t, err)
+
+		expected := []string{"x|y|z"}
+		result := extractStringList(t, val)
+		assert.EqualInts(t, len(expected), len(result))
+		for i, exp := range expected {
+			assert.EqualStrings(t, exp, result[i])
+		}
+	})
+
+	t.Run("multi-character separator", func(t *testing.T) {
+		evalctx := eval.NewContext(funcs)
+		expr, err := ast.ParseExpression(`tm_joinlist(" :: ", [["namespace", "module", "function"]])`, "test.tm")
+		assert.NoError(t, err)
+		val, err := evalctx.Eval(expr)
+		assert.NoError(t, err)
+
+		expected := []string{"namespace :: module :: function"}
+		result := extractStringList(t, val)
+		assert.EqualInts(t, len(expected), len(result))
+		for i, exp := range expected {
+			assert.EqualStrings(t, exp, result[i])
+		}
+	})
+
+	t.Run("empty string separator", func(t *testing.T) {
+		evalctx := eval.NewContext(funcs)
+		expr, err := ast.ParseExpression(`tm_joinlist("", [["a", "b", "c"]])`, "test.tm")
+		assert.NoError(t, err)
+		val, err := evalctx.Eval(expr)
+		assert.NoError(t, err)
+
+		expected := []string{"abc"}
+		result := extractStringList(t, val)
+		assert.EqualInts(t, len(expected), len(result))
+		for i, exp := range expected {
+			assert.EqualStrings(t, exp, result[i])
+		}
+	})
+}
+
+func TestTmJoinListErrors(t *testing.T) {
+	dir := test.TempDir(t)
+	funcs := stdlib.Functions(dir, []string{})
+
+	t.Run("wrong element type - number instead of list", func(t *testing.T) {
+		evalctx := eval.NewContext(funcs)
+		expr, err := ast.ParseExpression(`tm_joinlist("/", [42])`, "test.tm")
+		assert.NoError(t, err)
+		_, err = evalctx.Eval(expr)
+		assert.Error(t, err)
+		assert.IsTrue(t, strings.Contains(err.Error(), "tm_joinlist: expected all elements to be list(string), got number at index 0"))
+	})
+
+	t.Run("wrong nested element type - list(number) instead of list(string)", func(t *testing.T) {
+		evalctx := eval.NewContext(funcs)
+		expr, err := ast.ParseExpression(`tm_joinlist("/", [[1, 2]])`, "test.tm")
+		assert.NoError(t, err)
+		_, err = evalctx.Eval(expr)
+		assert.Error(t, err)
+		// HCL parses [1, 2] as tuple(number, number), so the error message will be different
+		assert.IsTrue(t, strings.Contains(err.Error(), "tm_joinlist: expected all elements to be list(string)") &&
+			(strings.Contains(err.Error(), "tuple with number") || strings.Contains(err.Error(), "list(number)")))
+	})
+
+	t.Run("mixed types in list", func(t *testing.T) {
+		evalctx := eval.NewContext(funcs)
+		expr, err := ast.ParseExpression(`tm_joinlist("/", [["valid"], "invalid"])`, "test.tm")
+		assert.NoError(t, err)
+		_, err = evalctx.Eval(expr)
+		assert.Error(t, err)
+		assert.IsTrue(t, strings.Contains(err.Error(), "tm_joinlist: expected all elements to be list(string), got string at index 1"))
+	})
+
+	t.Run("wrong element type at different index", func(t *testing.T) {
+		evalctx := eval.NewContext(funcs)
+		expr, err := ast.ParseExpression(`tm_joinlist("/", [["valid1"], ["valid2"], ["valid3"], true])`, "test.tm")
+		assert.NoError(t, err)
+		_, err = evalctx.Eval(expr)
+		assert.Error(t, err)
+		assert.IsTrue(t, strings.Contains(err.Error(), "tm_joinlist: expected all elements to be list(string), got bool at index 3"))
+	})
+}
+
+func TestTmJoinListDeterminism(t *testing.T) {
+	dir := test.TempDir(t)
+	funcs := stdlib.Functions(dir, []string{})
+
+	// Test that the function produces identical results for identical inputs
+	evalctx := eval.NewContext(funcs)
+	expr, err := ast.ParseExpression(`tm_joinlist("/", [["a", "b"], ["c", "d"]])`, "test.tm")
+	assert.NoError(t, err)
+
+	// Call the function multiple times
+	var results [][]string
+	for i := 0; i < 5; i++ {
+		val, err := evalctx.Eval(expr)
+		assert.NoError(t, err)
+		result := extractStringList(t, val)
+		results = append(results, result)
+	}
+
+	// Verify all results are identical
+	for i := 1; i < len(results); i++ {
+		assert.EqualInts(t, len(results[0]), len(results[i]))
+		for j, exp := range results[0] {
+			assert.EqualStrings(t, exp, results[i][j])
+		}
+	}
+}
+
+func TestTmJoinListCustomErrorTypes(t *testing.T) {
+	t.Parallel()
+
+	// Test that we get the specific custom error types
+	fn := stdlib.JoinListFunc()
+
+	t.Run("JoinListInvalidArgumentTypeError", func(t *testing.T) {
+		_, err := fn.Call([]cty.Value{
+			cty.StringVal("/"),
+			cty.StringVal("not a list"),
+		})
+
+		assert.IsTrue(t, errors.IsKind(err, stdlib.JoinListInvalidArgumentType))
+		assert.IsTrue(t, strings.Contains(err.Error(), "string"))
+	})
+
+	t.Run("JoinListInvalidElementTypeError", func(t *testing.T) {
+		_, err := fn.Call([]cty.Value{
+			cty.StringVal("/"),
+			cty.ListVal([]cty.Value{
+				cty.NumberIntVal(42),
+			}),
+		})
+
+		assert.IsTrue(t, errors.IsKind(err, stdlib.JoinListInvalidElementType))
+		assert.IsTrue(t, strings.Contains(err.Error(), "number"))
+		assert.IsTrue(t, strings.Contains(err.Error(), "index 0"))
+	})
+
+	t.Run("JoinListInvalidListElementTypeError", func(t *testing.T) {
+		_, err := fn.Call([]cty.Value{
+			cty.StringVal("/"),
+			cty.ListVal([]cty.Value{
+				cty.ListVal([]cty.Value{cty.NumberIntVal(1), cty.NumberIntVal(2)}),
+			}),
+		})
+
+		assert.IsTrue(t, errors.IsKind(err, stdlib.JoinListInvalidListElementType))
+		assert.IsTrue(t, strings.Contains(err.Error(), "number"))
+		assert.IsTrue(t, strings.Contains(err.Error(), "index 0"))
+	})
+
+	t.Run("JoinListInvalidTupleElementTypeError", func(t *testing.T) {
+		_, err := fn.Call([]cty.Value{
+			cty.StringVal("/"),
+			cty.TupleVal([]cty.Value{
+				cty.TupleVal([]cty.Value{cty.StringVal("valid"), cty.NumberIntVal(42)}),
+			}),
+		})
+
+		assert.IsTrue(t, errors.IsKind(err, stdlib.JoinListInvalidTupleElementType))
+		assert.IsTrue(t, strings.Contains(err.Error(), "number"))
+		assert.IsTrue(t, strings.Contains(err.Error(), "element 1"))
+		assert.IsTrue(t, strings.Contains(err.Error(), "index 0"))
+	})
+}
+
+func TestTmJoinListOrderPreservation(t *testing.T) {
+	dir := test.TempDir(t)
+	funcs := stdlib.Functions(dir, []string{})
+
+	evalctx := eval.NewContext(funcs)
+	expr, err := ast.ParseExpression(`tm_joinlist("|", [
+		["first", "element"], 
+		["second", "element"], 
+		["third", "element"]
+	])`, "test.tm")
+	assert.NoError(t, err)
+	val, err := evalctx.Eval(expr)
+	assert.NoError(t, err)
+
+	expected := []string{
+		"first|element",
+		"second|element",
+		"third|element",
+	}
+	result := extractStringList(t, val)
+	assert.EqualInts(t, len(expected), len(result))
+	for i, exp := range expected {
+		assert.EqualStrings(t, exp, result[i])
+	}
+}
+
+// Helper function to extract string list from cty.Value
+func extractStringList(t *testing.T, val cty.Value) []string {
+	t.Helper()
+
+	if !val.Type().IsListType() {
+		t.Fatalf("expected list type, got %s", val.Type().FriendlyName())
+	}
+
+	var result []string
+	it := val.ElementIterator()
+	for it.Next() {
+		_, element := it.Element()
+		if !element.Type().Equals(cty.String) {
+			t.Fatalf("expected string element, got %s", element.Type().FriendlyName())
+		}
+		result = append(result, element.AsString())
+	}
+
+	return result
+}


### PR DESCRIPTION
## What this PR does / why we need it:

This PR introduces a new built-in Terramate function `tm_joinlist()` that joins nested lists of strings with a separator. This function enables users to efficiently convert hierarchical list structures into joined string paths, complementing functions like `tm_tree()` for code generation workflows.

  Key features:
  - Converts list of string lists into list of joined strings
  - Supports any string separator (single character, multi-character, or empty)
  - Returns deterministic, order-preserving output
  - Handles both HCL list and tuple types seamlessly
  - Comprehensive error handling with custom error types

  Implementation details:
  - Added tm_joinlist() function in stdlib/funcs_join_list.go
  - Created custom error types in stdlib/funcs_join_list_errors.go for better error reporting
  - Comprehensive test suite with 100% coverage of all error cases
  - Registered function in the standard library at stdlib/funcs.go:104

## Which issue(s) this PR fixes:

  Fixes # (if applicable)

## Special notes for your reviewer:

The function implements all requirements from the PRD including:
  - Type validation for separator (must be string)
  - Type validation for list_of_lists (must be list/tuple of list/tuple of strings)
  - Proper handling of empty lists and empty sublists
  - Order preservation from input to output
  - Deterministic results for identical inputs
  - All error conditions return descriptive, actionable error messages using custom error types

The implementation uses custom error types (following the pattern established in `tm_tree`) to provide clear feedback when input data is malformed or contains type errors.

## Does this PR introduce a user-facing change?

Yes - adds new `tm_joinlist()` function to Terramate's standard library.

## Example usage:

```hcl
  locals {
    paths = tm_joinlist("/", [
      ["root"],
      ["root", "child"],
      ["root", "child", "leaf"]
    ])
    # Returns: ["root", "root/child", "root/child/leaf"]
  }

  # Particularly useful with tree structures:
  locals {
    branches = [
      ["Grand Parent A"],
      ["Grand Parent A", "Parent A"],
      ["Grand Parent A", "Parent A", "Child A"],
      ["Grand Parent A", "Parent A", "Child B"]
    ]
    joined_paths = tm_joinlist("/", local.branches)
    # Returns: [
    #   "Grand Parent A",
    #   "Grand Parent A/Parent A",
    #   "Grand Parent A/Parent A/Child A",
    #   "Grand Parent A/Parent A/Child B"
    # ]
  }

  # Works seamlessly with tm_tree output:
  locals {
    tree_branches = tm_tree([
      [null, "root"],
      ["root", "child1"],
      ["root", "child2"],
      ["child1", "grandchild"]
    ])
    paths = tm_joinlist("/", local.tree_branches)
    # Returns: ["root", "root/child1", "root/child1/grandchild", "root/child2"]
  }
```

Function signature:

tm_joinlist(separator: string, list_of_lists: list(list(string))) -> list(string)

The function provides a concise alternative to verbose HCL expressions like `[for list in list_of_lists : tm_join(separator, list)]`, improving code readability and maintainability.
