### PR TITLE
feat: add support for new terragrunt flags and env vars

### DIFF
--- a/.github/workflows/ci-sync-deployment.yml
+++ b/.github/workflows/ci-sync-deployment.yml
@@ -37,7 +37,7 @@ jobs:
 
       - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # pin@v5
         with:
-          go-version-file: 'go.mod'
+          go-version-file: "go.mod"
 
       - uses: opentofu/setup-opentofu@592200bd4b9bbf4772ace78f887668b1aee8f716 # pin@v1.0.5
         with:
@@ -49,6 +49,12 @@ jobs:
         with:
           terraform_version: "1.7.5"
           terraform_wrapper: false
+
+      - name: Install Terragrunt
+        uses: gruntwork-io/terragrunt-action@95fc057922e3c3d4cc021a81a213f088f333ddef # pin@v3.0.2
+        with:
+          tg_version: "0.88.0"
+          tf_path: "/usr/local/bin/terraform"
 
       - name: Install Terramate
         uses: terramate-io/terramate-action@b733b79e37eda5caba8703a75b522e9053d0846e # pin@i4k-fix-macos
@@ -129,7 +135,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # pin@v5
         with:
-          go-version-file: 'go.mod'
+          go-version-file: "go.mod"
       - name: install cosign
         run: go install github.com/sigstore/cosign/v2/cmd/cosign@v2.2.4
       - name: install goreleaser
@@ -170,7 +176,7 @@ jobs:
 
       - name: Verify checksums with cosign
         run: |
-          cosign verify-blob --key cosign.pub --signature ${{ env.SIGNATURE_FILE }} ${{ env.CHECKSUM_FILE }}       
+          cosign verify-blob --key cosign.pub --signature ${{ env.SIGNATURE_FILE }} ${{ env.CHECKSUM_FILE }}
   ci:
     needs:
       - build_test

--- a/.github/workflows/ci-sync-preview.yml
+++ b/.github/workflows/ci-sync-preview.yml
@@ -6,7 +6,6 @@ name: ci
 on:
   pull_request:
 
-
 jobs:
   build_test:
     name: Build and Test
@@ -35,7 +34,7 @@ jobs:
 
       - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # pin@v5
         with:
-          go-version-file: 'go.mod'
+          go-version-file: "go.mod"
 
       - name: check all packages with tests are Terramate Stacks
         run: ./hack/check-stacks.sh
@@ -50,6 +49,12 @@ jobs:
         with:
           terraform_version: "1.7.5"
           terraform_wrapper: false
+
+      - name: Install Terragrunt
+        uses: gruntwork-io/terragrunt-action@95fc057922e3c3d4cc021a81a213f088f333ddef # pin@v3.0.2
+        with:
+          tg_version: "0.88.0"
+          tf_path: "/usr/local/bin/terraform"
 
       - name: Install Terramate
         uses: terramate-io/terramate-action@b733b79e37eda5caba8703a75b522e9053d0846e # pin@i4k-fix-macos
@@ -184,7 +189,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # pin@v5
         with:
-          go-version-file: 'go.mod'
+          go-version-file: "go.mod"
       - name: install cosign
         run: go install github.com/sigstore/cosign/v2/cmd/cosign@v2.2.4
       - name: install goreleaser
@@ -225,7 +230,7 @@ jobs:
 
       - name: Verify checksums with cosign
         run: |
-          cosign verify-blob --key cosign.pub --signature ${{ env.SIGNATURE_FILE }} ${{ env.CHECKSUM_FILE }}       
+          cosign verify-blob --key cosign.pub --signature ${{ env.SIGNATURE_FILE }} ${{ env.CHECKSUM_FILE }}
   ci:
     needs:
       - build_test

--- a/e2etests/cmd/helper/terragrunt.go
+++ b/e2etests/cmd/helper/terragrunt.go
@@ -7,31 +7,71 @@ import (
 	"fmt"
 	"log"
 	"os"
+
+	"github.com/terramate-io/terramate/versions"
 )
 
 func terragrunt(args ...string) {
+	if len(args) == 0 {
+		log.Printf("error: terragrunt requires at least one argument")
+		os.Exit(1)
+	}
+
 	switch args[0] {
+	case "--version":
+		version := getTerragruntVersion()
+		fmt.Printf("terragrunt version v%s\n", version)
 	case "show":
-		forwardTfStdout := os.Getenv("TERRAGRUNT_FORWARD_TF_STDOUT")
+		version := getTerragruntVersion()
+		useTG, err := versions.Match(version, ">= 0.73.0", false)
+		if err != nil {
+			// Default to modern TG_* env when version parsing fails
+			useTG = true
+		}
+
+		var forwardTfStdout, logFormat string
+		var forwardEnvName, logEnvName string
+
+		if useTG {
+			forwardEnvName = "TG_FORWARD_TF_STDOUT"
+			logEnvName = "TG_LOG_FORMAT"
+			forwardTfStdout = os.Getenv(forwardEnvName)
+			logFormat = os.Getenv(logEnvName)
+		} else {
+			forwardEnvName = "TERRAGRUNT_FORWARD_TF_STDOUT"
+			logEnvName = "TERRAGRUNT_LOG_FORMAT"
+			forwardTfStdout = os.Getenv(forwardEnvName)
+			logFormat = os.Getenv(logEnvName)
+		}
+
 		if forwardTfStdout == "" {
-			log.Printf("error: TERRAGRUNT_FORWARD_TF_STDOUT is not set")
+			log.Printf("error: %s is not set", forwardEnvName)
 			os.Exit(1)
 		}
 		if forwardTfStdout != "true" {
-			log.Printf("error: TERRAGRUNT_FORWARD_TF_STDOUT is not true; got %q", forwardTfStdout)
+			log.Printf("error: %s is not true; got %q", forwardEnvName, forwardTfStdout)
 			os.Exit(1)
 		}
 
-		logFormat := os.Getenv("TERRAGRUNT_LOG_FORMAT")
 		if logFormat == "" {
-			log.Printf("error: TERRAGRUNT_LOG_FORMAT is not set")
+			log.Printf("error: %s is not set", logEnvName)
 			os.Exit(1)
 		}
 		if logFormat != "bare" {
-			log.Printf("error: TERRAGRUNT_LOG_FORMAT is not bare; got %q", logFormat)
+			log.Printf("error: %s is not bare; got %q", logEnvName, logFormat)
 			os.Exit(1)
 		}
 
 		fmt.Println(`TERRAGRUNT SHOW TEST OUTPUT`)
 	}
+}
+
+func getTerragruntVersion() string {
+	// Allow tests to override the version
+	version := os.Getenv("TM_TEST_HELPER_TERRAGRUNT_VERSION")
+	if version == "" {
+		// Default to 0.88.0 which matches the installed version in tests
+		version = "0.88.0"
+	}
+	return version
 }

--- a/e2etests/internal/runner/installers.go
+++ b/e2etests/internal/runner/installers.go
@@ -5,9 +5,14 @@ package runner
 
 import (
 	"context"
+	"fmt"
+	"io"
 	"log"
+	"net/http"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -17,6 +22,7 @@ import (
 	"github.com/hashicorp/hc-install/releases"
 	"github.com/hashicorp/hc-install/src"
 	"github.com/terramate-io/terramate/errors"
+	"github.com/terramate-io/terramate/test"
 )
 
 // InstallTerraform installs Terraform (if needed). The preferredVersion is used
@@ -65,4 +71,140 @@ func InstallTerraform(preferredVersion string) (string, string, func(), error) {
 			log.Printf("failed to remove terraform installation")
 		}
 	}, nil
+}
+
+// InstallTerragrunt installs Terragrunt (if needed). The preferredVersion is used
+// if terragrunt is not yet installed.
+func InstallTerragrunt(preferredVersion string) (string, string, func(), error) {
+	requireVersion := os.Getenv("TM_TEST_TERRAGRUNT_REQUIRED_VERSION")
+	tgExecPath, err := exec.LookPath("terragrunt")
+	if err == nil {
+		cmd := exec.Command("terragrunt", "--version")
+		output, err := cmd.Output()
+		if err == nil && len(output) > 0 {
+			lines := strings.Split(string(output), "\n")
+			// Terragrunt version output format: "terragrunt version v0.55.21"
+			versionLine := strings.TrimSpace(lines[0])
+			parts := strings.Fields(versionLine)
+			if len(parts) >= 3 {
+				terragruntVersion := strings.TrimPrefix(parts[2], "v")
+				if requireVersion == "" || terragruntVersion == requireVersion {
+					log.Printf("Terragrunt detected version: %s", terragruntVersion)
+					return tgExecPath, terragruntVersion, func() {}, nil
+				}
+			}
+		}
+	}
+
+	installVersion := preferredVersion
+	if requireVersion != "" {
+		installVersion = requireVersion
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	// Create a temporary directory for the installation
+	tmpDir, err := os.MkdirTemp("", "terragrunt-install-")
+	if err != nil {
+		return "", "", nil, errors.E(err, "creating temp directory for terragrunt installation")
+	}
+
+	// Download terragrunt binary
+	execPath, err := downloadTerragrunt(ctx, installVersion, tmpDir)
+	if err != nil {
+		if rmErr := os.RemoveAll(tmpDir); rmErr != nil {
+			log.Printf("failed to remove temp directory %q: %v", tmpDir, rmErr)
+		}
+		return "", "", nil, errors.E(err, "installing Terragrunt")
+	}
+
+	log.Printf("Terragrunt installed version: %s", installVersion)
+	return execPath, installVersion, func() {
+		err := os.RemoveAll(tmpDir)
+		if err != nil {
+			log.Printf("failed to remove terragrunt installation directory: %v", err)
+		}
+	}, nil
+}
+
+func downloadTerragrunt(ctx context.Context, version, installDir string) (string, error) {
+	// Determine the platform-specific binary name and download URL
+	var binaryName, downloadURL string
+
+	switch runtime.GOOS {
+	case "darwin":
+		switch runtime.GOARCH {
+		case "amd64":
+			binaryName = "terragrunt"
+			downloadURL = fmt.Sprintf("https://github.com/gruntwork-io/terragrunt/releases/download/v%s/terragrunt_darwin_amd64", version)
+		case "arm64":
+			binaryName = "terragrunt"
+			downloadURL = fmt.Sprintf("https://github.com/gruntwork-io/terragrunt/releases/download/v%s/terragrunt_darwin_arm64", version)
+		default:
+			return "", fmt.Errorf("unsupported architecture for darwin: %s", runtime.GOARCH)
+		}
+	case "linux":
+		switch runtime.GOARCH {
+		case "amd64":
+			binaryName = "terragrunt"
+			downloadURL = fmt.Sprintf("https://github.com/gruntwork-io/terragrunt/releases/download/v%s/terragrunt_linux_amd64", version)
+		case "arm64":
+			binaryName = "terragrunt"
+			downloadURL = fmt.Sprintf("https://github.com/gruntwork-io/terragrunt/releases/download/v%s/terragrunt_linux_arm64", version)
+		default:
+			return "", fmt.Errorf("unsupported architecture for linux: %s", runtime.GOARCH)
+		}
+	case "windows":
+		binaryName = "terragrunt.exe"
+		downloadURL = fmt.Sprintf("https://github.com/gruntwork-io/terragrunt/releases/download/v%s/terragrunt_windows_amd64.exe", version)
+	default:
+		return "", fmt.Errorf("unsupported operating system: %s", runtime.GOOS)
+	}
+
+	// Create HTTP request with context
+	req, err := http.NewRequestWithContext(ctx, "GET", downloadURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("creating HTTP request: %w", err)
+	}
+
+	// Download the binary
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("downloading terragrunt: %w", err)
+	}
+	defer func() {
+		if cerr := resp.Body.Close(); cerr != nil {
+			log.Printf("failed to close HTTP response body: %v", cerr)
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("failed to download terragrunt: HTTP %d", resp.StatusCode)
+	}
+
+	// Write to file
+	execPath := filepath.Join(installDir, binaryName)
+	file, err := os.Create(execPath)
+	if err != nil {
+		return "", fmt.Errorf("creating terragrunt binary file: %w", err)
+	}
+	defer func() {
+		if cerr := file.Close(); cerr != nil {
+			log.Printf("failed to close file %q: %v", execPath, cerr)
+		}
+	}()
+
+	_, err = io.Copy(file, resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("writing terragrunt binary: %w", err)
+	}
+
+	// Make executable (use test.Chmod for proper Windows ACL handling)
+	err = test.Chmod(execPath, 0755)
+	if err != nil {
+		return "", fmt.Errorf("making terragrunt binary executable: %w", err)
+	}
+
+	return execPath, nil
 }

--- a/e2etests/internal/runner/setup.go
+++ b/e2etests/internal/runner/setup.go
@@ -15,6 +15,7 @@ import (
 )
 
 const terraformInstallVersion = "1.5.0"
+const terragruntInstallVersion = "0.88.0"
 
 // toolsetTestPath is the path to the directory containing the Terramate binary and
 // other tools.
@@ -26,7 +27,14 @@ var TerraformVersion string
 // TerraformTestPath is the path to the installed terraform binary.
 var TerraformTestPath string
 
+// TerragruntVersion is the detected or installed Terragrunt version.
+var TerragruntVersion string
+
+// TerragruntTestPath is the path to the installed terragrunt binary.
+var TerragruntTestPath string
+
 var terraformCleanup func()
+var terragruntCleanup func()
 
 // HelperPath is the path to the test binary we compiled for test purposes
 var HelperPath string
@@ -88,6 +96,12 @@ func Setup(projectRoot string) (err error) {
 			err = errors.E(err, "failed to setup Terraform binary")
 			return
 		}
+
+		TerragruntTestPath, TerragruntVersion, terragruntCleanup, err = InstallTerragrunt(terragruntInstallVersion)
+		if err != nil {
+			err = errors.E(err, "failed to setup Terragrunt binary")
+			return
+		}
 	})
 
 	if err == nil {
@@ -104,5 +118,8 @@ func Teardown() {
 	}
 	if terraformCleanup != nil {
 		terraformCleanup()
+	}
+	if terragruntCleanup != nil {
+		terragruntCleanup()
 	}
 }

--- a/run/cli_runner.go
+++ b/run/cli_runner.go
@@ -1,0 +1,21 @@
+// Copyright 2025 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+package run
+
+import (
+	"context"
+	"os/exec"
+)
+
+// CLIRunner abstracts common CLI operations used by terraform, terragrunt and tofu runners.
+// Implementations should be thin wrappers around the actual binaries and must not mutate
+// provided arguments. Methods that execute commands return a prepared *exec.Cmd ready to run.
+type CLIRunner interface {
+	// Name returns the CLI runner name (e.g. "terraform", "terragrunt", "tofu").
+	Name() string
+	// Version returns the cached semantic version string of the underlying CLI.
+	// Must use the shared version cache to avoid repeated shell-outs.
+	Version(ctx context.Context) string
+	ShowCommand(ctx context.Context, planfile string, flags ...string) (*exec.Cmd, error)
+}

--- a/run/lookpath_test.go
+++ b/run/lookpath_test.go
@@ -1,0 +1,67 @@
+// Copyright 2025 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+package run
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/madlambda/spells/assert"
+)
+
+func TestLookPath_FindsExecutableInPATH(t *testing.T) {
+	tmpDir := t.TempDir()
+	binName := "tm-foo"
+	if runtime.GOOS == "windows" {
+		binName += ".exe"
+	}
+	binPath := filepath.Join(tmpDir, binName)
+	assert.NoError(t, os.WriteFile(binPath, []byte("#!/bin/sh\nexit 0\n"), 0o755))
+
+	env := append([]string{}, os.Environ()...)
+	// Prepend tmpDir to PATH
+	pathKey := "PATH"
+	if runtime.GOOS == "windows" {
+		pathKey = "Path"
+	}
+	curPath, _ := Getenv(pathKey, env)
+	newPath := tmpDir
+	if curPath != "" {
+		if runtime.GOOS == "windows" {
+			newPath += ";" + curPath
+		} else {
+			newPath += ":" + curPath
+		}
+	}
+	env = append(env, pathKey+"="+newPath)
+
+	found, err := LookPath("tm-foo", env)
+	assert.NoError(t, err)
+	assert.EqualStrings(t, found, binPath)
+}
+
+func TestLookPath_AbsolutePath(t *testing.T) {
+	tmpDir := t.TempDir()
+	binName := "tm-abs"
+	if runtime.GOOS == "windows" {
+		binName += ".exe"
+	}
+	binPath := filepath.Join(tmpDir, binName)
+	assert.NoError(t, os.WriteFile(binPath, []byte("#!/bin/sh\nexit 0\n"), 0o755))
+
+	found, err := LookPath(binPath, os.Environ())
+	assert.NoError(t, err)
+	assert.EqualStrings(t, found, binPath)
+}
+
+func TestLookPath_NotFound(t *testing.T) {
+	env := append([]string{}, os.Environ()...)
+	// Ensure PATH is empty to avoid false positives
+	env = append(env, "PATH=")
+
+	_, err := LookPath("definitely-not-found-xyz", env)
+	assert.Error(t, err)
+}

--- a/run/terraform/_test_mock.tf
+++ b/run/terraform/_test_mock.tf
@@ -1,0 +1,15 @@
+// TERRAMATE: GENERATED AUTOMATICALLY DO NOT EDIT
+
+resource "local_file" "terraform" {
+  content = <<-EOT
+package terraform // import "github.com/terramate-io/terramate/run/terraform"
+
+Package terraform provides utilities for executing terraform commands with
+configurable arguments.
+
+type Runner struct{ ... }
+    func NewRunner(env []string, workingDir string) *Runner
+EOT
+
+  filename = "${path.module}/mock-terraform.ignore"
+}

--- a/run/terraform/stack.tm.hcl
+++ b/run/terraform/stack.tm.hcl
@@ -1,0 +1,9 @@
+// Copyright 2025 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+stack {
+  name        = "package terraform // import \"github.com/terramate-io/terramate/run/terraform\""
+  description = "package terraform // import \"github.com/terramate-io/terramate/run/terraform\"\n\nPackage terraform provides utilities for executing terraform commands with\nconfigurable arguments.\n\ntype Runner struct{ ... }\n    func NewRunner(env []string, workingDir string) *Runner"
+  tags        = ["golang", "run", "terraform"]
+  id          = "9f8e8a93-3680-488d-b8fb-c347d0f19745"
+}

--- a/run/terraform/terraform.go
+++ b/run/terraform/terraform.go
@@ -1,0 +1,76 @@
+// Copyright 2025 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+// Package terraform provides utilities for executing terraform commands with configurable arguments.
+package terraform
+
+import (
+	"context"
+	"os/exec"
+	"sync"
+
+	runpkg "github.com/terramate-io/terramate/run"
+)
+
+// Runner provides methods to execute terraform commands with configurable arguments.
+type Runner struct {
+	// Environment variables for the command
+	Env []string
+	// Working directory for the command
+	WorkingDir string
+
+	// resolvedPath caches the absolute path to the terraform binary
+	resolvedPath string
+	resolveOnce  sync.Once
+	resolveErr   error
+}
+
+// Ensure Runner implements run.CLIRunner at compile time.
+var _ runpkg.CLIRunner = (*Runner)(nil)
+
+// NewRunner creates a new terraform runner with the given environment and working directory.
+func NewRunner(env []string, workingDir string) *Runner {
+	return &Runner{
+		Env:        env,
+		WorkingDir: workingDir,
+	}
+}
+
+// Name returns the CLI name for this runner.
+func (r *Runner) Name() string { return "terraform" }
+
+// Version returns the semantic version string of the terraform binary.
+func (r *Runner) Version(ctx context.Context) string {
+	return r.terraformVersion(ctx)
+}
+
+func (r *Runner) command(ctx context.Context, args ...string) (*exec.Cmd, error) {
+	r.resolveOnce.Do(func() {
+		r.resolvedPath, r.resolveErr = runpkg.LookPath("terraform", r.Env)
+	})
+	if r.resolveErr != nil {
+		return nil, r.resolveErr
+	}
+
+	cmd := exec.CommandContext(ctx, r.resolvedPath, args...)
+	cmd.Dir = r.WorkingDir
+	cmd.Env = r.Env
+
+	return cmd, nil
+}
+
+// ShowCommand builds a command to execute `terraform show` for the given planfile.
+func (r *Runner) ShowCommand(ctx context.Context, planfile string, flags ...string) (*exec.Cmd, error) {
+	args := []string{"show"}
+	args = append(args, flags...)
+	args = append(args, planfile)
+
+	return r.command(ctx, args...)
+}
+
+// terraformVersion returns the parsed semantic version (e.g., 1.6.2) of the resolved terraform binary.
+// It shells out at most once per resolved binary path across the entire process.
+func (r *Runner) terraformVersion(ctx context.Context) string {
+	// Use cached path when available; still honor test overrides by binary name.
+	return runpkg.ResolveVersionFor(ctx, r.Env, "terraform", r.resolvedPath)
+}

--- a/run/terraform/terraform_test.go
+++ b/run/terraform/terraform_test.go
@@ -1,0 +1,83 @@
+// Copyright 2025 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+package terraform_test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/madlambda/spells/assert"
+	runpkg "github.com/terramate-io/terramate/run"
+	"github.com/terramate-io/terramate/run/terraform"
+)
+
+func TestNewRunner(t *testing.T) {
+	tmpDir := t.TempDir()
+	env := os.Environ()
+
+	runner := terraform.NewRunner(env, tmpDir)
+
+	assert.EqualStrings(t, runner.WorkingDir, tmpDir)
+}
+
+func TestRunner_Version(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	env := os.Environ()
+
+	runner := &terraform.Runner{
+		Env:        env,
+		WorkingDir: tmpDir,
+	}
+
+	runpkg.SetTestVersionOverride("terraform", "1.2.3")
+	t.Cleanup(func() { runpkg.SetTestVersionOverride("terraform", "") })
+
+	ctx := context.Background()
+	v := runner.Version(ctx)
+
+	assert.EqualStrings(t, v, "1.2.3")
+}
+
+func TestRunner_ShowCommand(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+	}{
+		{"terraform"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			env := os.Environ()
+
+			runner := &terraform.Runner{
+				Env:        env,
+				WorkingDir: tmpDir,
+			}
+
+			ctx := context.Background()
+			planfile := "plan.tfplan"
+			cmd, err := runner.ShowCommand(ctx, planfile, "--json")
+
+			// We expect an error because the binary might not be in PATH, but check the command structure
+			if err == nil {
+				assert.EqualStrings(t, cmd.Dir, tmpDir)
+
+				// Check that the command includes the expected args
+				args := cmd.Args
+				expectedArgs := []string{"show", "--json", planfile}
+				assert.IsTrue(t, len(args) >= len(expectedArgs)+1, "expected at least %d args, got %d", len(expectedArgs)+1, len(args))
+
+				for i, expectedArg := range expectedArgs {
+					assert.EqualStrings(t, args[i+1], expectedArg, "arg %d mismatch", i+1)
+				}
+			}
+		})
+	}
+}

--- a/run/terragrunt/_test_mock.tf
+++ b/run/terragrunt/_test_mock.tf
@@ -1,0 +1,15 @@
+// TERRAMATE: GENERATED AUTOMATICALLY DO NOT EDIT
+
+resource "local_file" "terragrunt" {
+  content = <<-EOT
+package terragrunt // import "github.com/terramate-io/terramate/run/terragrunt"
+
+Package terragrunt provides utilities for executing terragrunt commands with
+configurable arguments.
+
+type Runner struct{ ... }
+    func NewRunner(env []string, workingDir string) *Runner
+EOT
+
+  filename = "${path.module}/mock-terragrunt.ignore"
+}

--- a/run/terragrunt/stack.tm.hcl
+++ b/run/terragrunt/stack.tm.hcl
@@ -1,0 +1,9 @@
+// Copyright 2025 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+stack {
+  name        = "package terragrunt // import \"github.com/terramate-io/terramate/run/terragrunt\""
+  description = "package terragrunt // import \"github.com/terramate-io/terramate/run/terragrunt\"\n\nPackage terragrunt provides utilities for executing terragrunt commands with\nconfigurable arguments.\n\ntype Runner struct{ ... }\n    func NewRunner(env []string, workingDir string) *Runner"
+  tags        = ["golang", "run", "terragrunt"]
+  id          = "e27190f3-a817-43d8-8042-83b3e5c88c99"
+}

--- a/run/terragrunt/terragrunt.go
+++ b/run/terragrunt/terragrunt.go
@@ -1,0 +1,144 @@
+// Copyright 2025 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+// Package terragrunt provides utilities for executing terragrunt commands with configurable arguments.
+package terragrunt
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"sync"
+
+	runpkg "github.com/terramate-io/terramate/run"
+	"github.com/terramate-io/terramate/versions"
+)
+
+// Runner provides methods to execute terragrunt commands with configurable arguments.
+type Runner struct {
+	// Environment variables for the command
+	Env []string
+	// Working directory for the command
+	WorkingDir string
+
+	// resolvedPath caches the absolute path to the terragrunt binary
+	resolvedPath string
+	resolveOnce  sync.Once
+	resolveErr   error
+}
+
+// Ensure Runner implements run.CLIRunner at compile time.
+var _ runpkg.CLIRunner = (*Runner)(nil)
+
+// NewRunner creates a new terragrunt runner with the given environment and working directory.
+func NewRunner(env []string, workingDir string) *Runner {
+	return &Runner{
+		Env:        env,
+		WorkingDir: workingDir,
+	}
+}
+
+// Name returns the CLI name for this runner.
+func (r *Runner) Name() string { return "terragrunt" }
+
+// Version returns the semantic version string of the terragrunt binary.
+func (r *Runner) Version(ctx context.Context) string {
+	return r.terragruntVersion(ctx)
+}
+
+func (r *Runner) command(ctx context.Context, args ...string) (*exec.Cmd, error) {
+	r.resolveOnce.Do(func() {
+		r.resolvedPath, r.resolveErr = runpkg.LookPath("terragrunt", r.Env)
+	})
+	if r.resolveErr != nil {
+		return nil, r.resolveErr
+	}
+
+	cmd := exec.CommandContext(ctx, r.resolvedPath, args...)
+	cmd.Dir = r.WorkingDir
+	cmd.Env = r.Env
+
+	return cmd, nil
+}
+
+// ShowCommand builds a command to execute `terragrunt show` for the given planfile.
+func (r *Runner) ShowCommand(ctx context.Context, planfile string, flags ...string) (*exec.Cmd, error) {
+	useModern := r.useModernFlags(ctx)
+	useTG := r.useTGEnv(ctx)
+
+	args := []string{"show"}
+	if useModern {
+		args = append(args, r.rewriteTerragruntFlags(flags)...)
+		args = append(args, "--non-interactive")
+	} else {
+		args = append(args, flags...)
+		args = append(args, "--terragrunt-non-interactive")
+	}
+	args = append(args, planfile)
+
+	cmd, err := r.command(ctx, args...)
+	if err != nil {
+		return nil, err
+	}
+
+	// Set terragrunt-specific environment variables
+	env := make([]string, len(r.Env))
+	copy(env, r.Env)
+	if useTG {
+		env = append(env, "TG_FORWARD_TF_STDOUT=true")
+		env = append(env, "TG_LOG_FORMAT=bare")
+	} else {
+		env = append(env, "TERRAGRUNT_FORWARD_TF_STDOUT=true")
+		env = append(env, "TERRAGRUNT_LOG_FORMAT=bare")
+	}
+	cmd.Env = env
+
+	return cmd, nil
+}
+
+func (r *Runner) rewriteTerragruntFlags(flags []string) []string {
+	if len(flags) == 0 {
+		return flags
+	}
+	rewritten := make([]string, 0, len(flags))
+	for _, f := range flags {
+		if strings.HasPrefix(f, "--terragrunt-") {
+			rewritten = append(rewritten, "--"+strings.TrimPrefix(f, "--terragrunt-"))
+			continue
+		}
+		rewritten = append(rewritten, f)
+	}
+	return rewritten
+}
+
+func (r *Runner) useModernFlags(ctx context.Context) bool {
+	ver := r.terragruntVersion(ctx)
+	if ver == "" {
+		// Default to modern behavior when version is unknown
+		return true
+	}
+	ok, err := versions.Match(ver, ">= 0.85.0", false)
+	if err != nil {
+		// Default to modern behavior when version parsing fails
+		return true
+	}
+	return ok
+}
+
+func (r *Runner) useTGEnv(ctx context.Context) bool {
+	ver := r.terragruntVersion(ctx)
+	if ver == "" {
+		// Default to TG_* env when version is unknown
+		return true
+	}
+	ok, err := versions.Match(ver, ">= 0.73.0", false)
+	if err != nil {
+		// Default to TG_* env when version parsing fails
+		return true
+	}
+	return ok
+}
+
+func (r *Runner) terragruntVersion(ctx context.Context) string {
+	return runpkg.ResolveVersionFor(ctx, r.Env, "terragrunt", r.resolvedPath)
+}

--- a/run/terragrunt/terragrunt_test.go
+++ b/run/terragrunt/terragrunt_test.go
@@ -1,0 +1,207 @@
+// Copyright 2025 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+package terragrunt
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/madlambda/spells/assert"
+	runpkg "github.com/terramate-io/terramate/run"
+)
+
+func TestRunner_Version(t *testing.T) {
+	tmpDir := t.TempDir()
+	env := os.Environ()
+
+	runner := NewRunner(env, tmpDir)
+
+	runpkg.SetTestVersionOverride("terragrunt", "0.99.0")
+	t.Cleanup(func() { runpkg.SetTestVersionOverride("terragrunt", "") })
+
+	ctx := context.Background()
+	v := runner.Version(ctx)
+
+	assert.EqualStrings(t, v, "0.99.0")
+}
+
+func TestRunner_ShowCommand(t *testing.T) {
+	t.Run("legacy flags and TERRAGRUNT_ env for <0.73.0", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		env := os.Environ()
+
+		runner := NewRunner(env, tmpDir)
+		runpkg.SetTestVersionOverride("terragrunt", "0.72.9")
+		t.Cleanup(func() { runpkg.SetTestVersionOverride("terragrunt", "") })
+
+		ctx := context.Background()
+		planfile := "plan.tfplan"
+		cmd, err := runner.ShowCommand(ctx, planfile, "--json")
+
+		// We expect an error because the binary might not be in PATH, but check the command structure
+		if err == nil {
+			assert.EqualStrings(t, cmd.Dir, tmpDir)
+
+			args := cmd.Args
+			expectedArgs := []string{"show", "--json", "--terragrunt-non-interactive", planfile}
+			assert.IsTrue(t, len(args) >= len(expectedArgs)+1, "expected at least %d args, got %d", len(expectedArgs)+1, len(args))
+			for i, expectedArg := range expectedArgs {
+				assert.EqualStrings(t, args[i+1], expectedArg, "arg %d mismatch", i+1)
+			}
+
+			envMap := make(map[string]string)
+			for _, envVar := range cmd.Env {
+				if len(envVar) == 0 {
+					continue
+				}
+				parts := []string{"", ""}
+				if idx := findFirstEqual(envVar); idx != -1 {
+					parts[0] = envVar[:idx]
+					parts[1] = envVar[idx+1:]
+				} else {
+					parts[0] = envVar
+				}
+				envMap[parts[0]] = parts[1]
+			}
+			assert.EqualStrings(t, envMap["TERRAGRUNT_FORWARD_TF_STDOUT"], "true")
+			assert.EqualStrings(t, envMap["TERRAGRUNT_LOG_FORMAT"], "bare")
+		}
+	})
+
+	t.Run("TG_ env for >=0.73.0 and modern flags for >=0.85.0", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		env := os.Environ()
+
+		runner := NewRunner(env, tmpDir)
+		runpkg.SetTestVersionOverride("terragrunt", "0.85.0")
+		t.Cleanup(func() { runpkg.SetTestVersionOverride("terragrunt", "") })
+
+		ctx := context.Background()
+		planfile := "plan.tfplan"
+		cmd, err := runner.ShowCommand(ctx, planfile, "--json", "--terragrunt-foo")
+
+		// We expect an error because the binary might not be in PATH, but check the command structure
+		if err == nil {
+			assert.EqualStrings(t, cmd.Dir, tmpDir)
+
+			args := cmd.Args
+			// --terragrunt-foo should be rewritten to --foo and non-interactive modern flag used
+			expectedArgs := []string{"show", "--json", "--foo", "--non-interactive", planfile}
+			assert.IsTrue(t, len(args) >= len(expectedArgs)+1, "expected at least %d args, got %d", len(expectedArgs)+1, len(args))
+			for i, expectedArg := range expectedArgs {
+				assert.EqualStrings(t, args[i+1], expectedArg, "arg %d mismatch", i+1)
+			}
+
+			envMap := make(map[string]string)
+			for _, envVar := range cmd.Env {
+				if len(envVar) == 0 {
+					continue
+				}
+				parts := []string{"", ""}
+				if idx := findFirstEqual(envVar); idx != -1 {
+					parts[0] = envVar[:idx]
+					parts[1] = envVar[idx+1:]
+				} else {
+					parts[0] = envVar
+				}
+				envMap[parts[0]] = parts[1]
+			}
+			assert.EqualStrings(t, envMap["TG_FORWARD_TF_STDOUT"], "true")
+			assert.EqualStrings(t, envMap["TG_LOG_FORMAT"], "bare")
+		}
+	})
+
+	t.Run("unknown version defaults to modern flags and TG_ env", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		env := os.Environ()
+
+		runner := NewRunner(env, tmpDir)
+		// Do not set version; force unknown version path
+
+		ctx := context.Background()
+		planfile := "plan.tfplan"
+		cmd, err := runner.ShowCommand(ctx, planfile, "--json", "--terragrunt-foo")
+
+		// Only validate structure when the binary is found in PATH
+		if err == nil {
+			assert.EqualStrings(t, cmd.Dir, tmpDir)
+
+			args := cmd.Args
+			expectedArgs := []string{"show", "--json", "--foo", "--non-interactive", planfile}
+			assert.IsTrue(t, len(args) >= len(expectedArgs)+1, "expected at least %d args, got %d", len(expectedArgs)+1, len(args))
+			for i, expectedArg := range expectedArgs {
+				assert.EqualStrings(t, args[i+1], expectedArg, "arg %d mismatch", i+1)
+			}
+
+			envMap := make(map[string]string)
+			for _, envVar := range cmd.Env {
+				if len(envVar) == 0 {
+					continue
+				}
+				parts := []string{"", ""}
+				if idx := findFirstEqual(envVar); idx != -1 {
+					parts[0] = envVar[:idx]
+					parts[1] = envVar[idx+1:]
+				} else {
+					parts[0] = envVar
+				}
+				envMap[parts[0]] = parts[1]
+			}
+			assert.EqualStrings(t, envMap["TG_FORWARD_TF_STDOUT"], "true")
+			assert.EqualStrings(t, envMap["TG_LOG_FORMAT"], "bare")
+		}
+	})
+
+	t.Run("malformed version defaults to modern flags and TG_ env", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		env := os.Environ()
+
+		runner := NewRunner(env, tmpDir)
+		runpkg.SetTestVersionOverride("terragrunt", "invalid-version")
+		t.Cleanup(func() { runpkg.SetTestVersionOverride("terragrunt", "") })
+
+		ctx := context.Background()
+		planfile := "plan.tfplan"
+		cmd, err := runner.ShowCommand(ctx, planfile, "--json", "--terragrunt-foo")
+
+		// Only validate structure when the binary is found in PATH
+		if err == nil {
+			assert.EqualStrings(t, cmd.Dir, tmpDir)
+
+			args := cmd.Args
+			expectedArgs := []string{"show", "--json", "--foo", "--non-interactive", planfile}
+			assert.IsTrue(t, len(args) >= len(expectedArgs)+1, "expected at least %d args, got %d", len(expectedArgs)+1, len(args))
+			for i, expectedArg := range expectedArgs {
+				assert.EqualStrings(t, args[i+1], expectedArg, "arg %d mismatch", i+1)
+			}
+
+			envMap := make(map[string]string)
+			for _, envVar := range cmd.Env {
+				if len(envVar) == 0 {
+					continue
+				}
+				parts := []string{"", ""}
+				if idx := findFirstEqual(envVar); idx != -1 {
+					parts[0] = envVar[:idx]
+					parts[1] = envVar[idx+1:]
+				} else {
+					parts[0] = envVar
+				}
+				envMap[parts[0]] = parts[1]
+			}
+			assert.EqualStrings(t, envMap["TG_FORWARD_TF_STDOUT"], "true")
+			assert.EqualStrings(t, envMap["TG_LOG_FORMAT"], "bare")
+		}
+	})
+}
+
+func findFirstEqual(s string) int {
+	for i, c := range s {
+		if c == '=' {
+			return i
+		}
+	}
+	return -1
+}

--- a/run/tofu/_test_mock.tf
+++ b/run/tofu/_test_mock.tf
@@ -1,0 +1,15 @@
+// TERRAMATE: GENERATED AUTOMATICALLY DO NOT EDIT
+
+resource "local_file" "tofu" {
+  content = <<-EOT
+package tofu // import "github.com/terramate-io/terramate/run/tofu"
+
+Package tofu provides utilities for executing OpenTofu commands with
+configurable arguments.
+
+type Runner struct{ ... }
+    func NewRunner(env []string, workingDir string) *Runner
+EOT
+
+  filename = "${path.module}/mock-tofu.ignore"
+}

--- a/run/tofu/stack.tm.hcl
+++ b/run/tofu/stack.tm.hcl
@@ -1,0 +1,9 @@
+// Copyright 2025 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+stack {
+  name        = "package tofu // import \"github.com/terramate-io/terramate/run/tofu\""
+  description = "package tofu // import \"github.com/terramate-io/terramate/run/tofu\"\n\nPackage tofu provides utilities for executing OpenTofu commands with\nconfigurable arguments.\n\ntype Runner struct{ ... }\n    func NewRunner(env []string, workingDir string) *Runner"
+  tags        = ["golang", "run", "tofu"]
+  id          = "aab709df-643b-4a7d-8c81-97fbd2891fa9"
+}

--- a/run/tofu/tofu.go
+++ b/run/tofu/tofu.go
@@ -1,0 +1,75 @@
+// Copyright 2025 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+// Package tofu provides utilities for executing OpenTofu commands with configurable arguments.
+package tofu
+
+import (
+	"context"
+	"os/exec"
+	"sync"
+
+	runpkg "github.com/terramate-io/terramate/run"
+)
+
+// Runner provides methods to execute OpenTofu commands with configurable arguments.
+type Runner struct {
+	// Environment variables for the command
+	Env []string
+	// Working directory for the command
+	WorkingDir string
+
+	// resolvedPath caches the absolute path to the tofu binary
+	resolvedPath string
+	resolveOnce  sync.Once
+	resolveErr   error
+}
+
+// Ensure Runner implements run.CLIRunner at compile time.
+var _ runpkg.CLIRunner = (*Runner)(nil)
+
+// NewRunner creates a new OpenTofu runner with the given environment and working directory.
+func NewRunner(env []string, workingDir string) *Runner {
+	return &Runner{
+		Env:        env,
+		WorkingDir: workingDir,
+	}
+}
+
+// Name returns the CLI name for this runner.
+func (r *Runner) Name() string { return "tofu" }
+
+// Version returns the semantic version string of the tofu binary.
+func (r *Runner) Version(ctx context.Context) string {
+	return r.tofuVersion(ctx)
+}
+
+func (r *Runner) command(ctx context.Context, args ...string) (*exec.Cmd, error) {
+	r.resolveOnce.Do(func() {
+		r.resolvedPath, r.resolveErr = runpkg.LookPath("tofu", r.Env)
+	})
+	if r.resolveErr != nil {
+		return nil, r.resolveErr
+	}
+
+	cmd := exec.CommandContext(ctx, r.resolvedPath, args...)
+	cmd.Dir = r.WorkingDir
+	cmd.Env = r.Env
+
+	return cmd, nil
+}
+
+// ShowCommand builds a command to execute `tofu show` for the given planfile.
+func (r *Runner) ShowCommand(ctx context.Context, planfile string, flags ...string) (*exec.Cmd, error) {
+	args := []string{"show"}
+	args = append(args, flags...)
+	args = append(args, planfile)
+
+	return r.command(ctx, args...)
+}
+
+// tofuVersion returns the parsed semantic version (e.g., 1.6.2) of the resolved tofu binary.
+// It shells out at most once per resolved binary path across the entire process.
+func (r *Runner) tofuVersion(ctx context.Context) string {
+	return runpkg.ResolveVersionFor(ctx, r.Env, "tofu", r.resolvedPath)
+}

--- a/run/tofu/tofu_cache_test.go
+++ b/run/tofu/tofu_cache_test.go
@@ -1,0 +1,56 @@
+//go:build !windows
+
+// Copyright 2025 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+package tofu
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	runpkg "github.com/terramate-io/terramate/run"
+)
+
+func TestTofuVersionIsCachedPerResolvedPath(t *testing.T) {
+	// reset cache for test isolation
+	runpkg.ResetVersionCache()
+
+	tdir := t.TempDir()
+	counter := filepath.Join(tdir, "count.txt")
+	script := filepath.Join(tdir, "tofu")
+
+	scriptContent := "#!/bin/sh\n" +
+		"if [ \"$1\" = \"--version\" ]; then\n" +
+		"  echo \"OpenTofu v1.7.0\"\n" +
+		"fi\n" +
+		"echo x >> '" + strings.ReplaceAll(counter, "'", "'\\''") + "'\n"
+	if err := os.WriteFile(script, []byte(scriptContent), 0o755); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+	if err := os.Chmod(script, 0o755); err != nil {
+		t.Fatalf("chmod script: %v", err)
+	}
+
+	env := []string{"PATH=" + tdir}
+	r1 := NewRunner(env, tdir)
+	r2 := NewRunner(env, tdir)
+	ctx := context.Background()
+
+	if v := runpkg.ResolveVersion(ctx, r1.Env, "tofu"); v == "" {
+		t.Fatalf("expected version, got empty")
+	}
+	_ = runpkg.ResolveVersion(ctx, r1.Env, "tofu")
+	_ = runpkg.ResolveVersion(ctx, r2.Env, "tofu")
+
+	b, err := os.ReadFile(counter)
+	if err != nil {
+		t.Fatalf("read counter: %v", err)
+	}
+	if got := strings.Count(string(b), "x"); got != 1 {
+		t.Fatalf("expected one invocation, got %d", got)
+	}
+}

--- a/run/tofu/tofu_test.go
+++ b/run/tofu/tofu_test.go
@@ -1,0 +1,71 @@
+// Copyright 2025 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+package tofu_test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/madlambda/spells/assert"
+	runpkg "github.com/terramate-io/terramate/run"
+	"github.com/terramate-io/terramate/run/tofu"
+)
+
+func TestNewRunner(t *testing.T) {
+	tmpDir := t.TempDir()
+	env := os.Environ()
+
+	runner := tofu.NewRunner(env, tmpDir)
+
+	assert.EqualStrings(t, runner.WorkingDir, tmpDir)
+}
+
+func TestRunner_Version(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	env := os.Environ()
+
+	runner := &tofu.Runner{
+		Env:        env,
+		WorkingDir: tmpDir,
+	}
+
+	runpkg.SetTestVersionOverride("tofu", "9.9.9")
+	t.Cleanup(func() { runpkg.SetTestVersionOverride("tofu", "") })
+
+	ctx := context.Background()
+	v := runner.Version(ctx)
+
+	assert.EqualStrings(t, v, "9.9.9")
+}
+
+func TestRunner_ShowCommand(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	env := os.Environ()
+
+	runner := &tofu.Runner{
+		Env:        env,
+		WorkingDir: tmpDir,
+	}
+
+	ctx := context.Background()
+	planfile := "plan.tfplan"
+	cmd, err := runner.ShowCommand(ctx, planfile, "--json")
+
+	if err == nil {
+		assert.EqualStrings(t, cmd.Dir, tmpDir)
+
+		args := cmd.Args
+		expectedArgs := []string{"show", "--json", planfile}
+		assert.IsTrue(t, len(args) >= len(expectedArgs)+1, "expected at least %d args, got %d", len(expectedArgs)+1, len(args))
+
+		for i, expectedArg := range expectedArgs {
+			assert.EqualStrings(t, args[i+1], expectedArg, "arg %d mismatch", i+1)
+		}
+	}
+}

--- a/run/version_cache.go
+++ b/run/version_cache.go
@@ -1,0 +1,131 @@
+// Copyright 2025 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+package run
+
+import (
+	"context"
+	"os/exec"
+	"regexp"
+	"sync"
+)
+
+type versionEntry struct {
+	once    sync.Once
+	version string
+}
+
+var (
+	versionCacheMu sync.Mutex
+	versionCache   = map[string]*versionEntry{}
+	testOverrideMu sync.Mutex
+	testOverride   = map[string]string{}
+)
+
+func getVersionEntry(resolvedPath string) *versionEntry {
+	versionCacheMu.Lock()
+	defer versionCacheMu.Unlock()
+	entry, ok := versionCache[resolvedPath]
+	if !ok {
+		entry = &versionEntry{}
+		versionCache[resolvedPath] = entry
+	}
+	return entry
+}
+
+// ResolveVersion returns the semantic version of the given binary by executing
+// "<binary> --version", parsed with a generic semver regex. The shell-out is
+// performed at most once per resolved binary path across the process.
+func ResolveVersion(ctx context.Context, environ []string, binary string) string {
+	// test override by binary name
+	testOverrideMu.Lock()
+	if v, ok := testOverride[binary]; ok && v != "" {
+		testOverrideMu.Unlock()
+		return v
+	}
+	testOverrideMu.Unlock()
+
+	cmdPath, err := LookPath(binary, environ)
+	if err != nil {
+		return ""
+	}
+
+	entry := getVersionEntry(cmdPath)
+	entry.once.Do(func() {
+		out, err := exec.CommandContext(ctx, cmdPath, "--version").CombinedOutput()
+		if err != nil {
+			return
+		}
+		re := regexp.MustCompile(`v?(\d+\.\d+\.\d+)`)
+		matches := re.FindStringSubmatch(string(out))
+		if len(matches) > 1 {
+			entry.version = matches[1]
+		}
+	})
+	return entry.version
+}
+
+// ResolveVersionForResolvedPath returns the semantic version of the given binary
+// at the provided resolved path by executing "<resolvedPath> --version".
+// The shell-out is performed at most once per resolved binary path across the process.
+func ResolveVersionForResolvedPath(ctx context.Context, resolvedPath string) string {
+	entry := getVersionEntry(resolvedPath)
+	entry.once.Do(func() {
+		out, err := exec.CommandContext(ctx, resolvedPath, "--version").CombinedOutput()
+		if err != nil {
+			return
+		}
+		re := regexp.MustCompile(`v?(\d+\.\d+\.\d+)`)
+		matches := re.FindStringSubmatch(string(out))
+		if len(matches) > 1 {
+			entry.version = matches[1]
+		}
+	})
+	return entry.version
+}
+
+// ResolveVersionFor returns the semantic version for a given binary. If a test
+// override is configured for the binary name it is returned immediately. If a
+// non-empty resolvedPath is provided, it will be used to avoid any additional
+// path lookups. Otherwise it falls back to ResolveVersion which may look up the
+// binary in PATH.
+func ResolveVersionFor(ctx context.Context, environ []string, binary, resolvedPath string) string {
+	// test override by binary name (keeps test behavior fast and deterministic)
+	testOverrideMu.Lock()
+	if v, ok := testOverride[binary]; ok && v != "" {
+		testOverrideMu.Unlock()
+		return v
+	}
+	testOverrideMu.Unlock()
+
+	if resolvedPath != "" {
+		return ResolveVersionForResolvedPath(ctx, resolvedPath)
+	}
+	return ResolveVersion(ctx, environ, binary)
+}
+
+// SeedVersionForResolvedPath sets the version for a given resolved binary path.
+// Useful for tests to avoid shelling out.
+func SeedVersionForResolvedPath(resolvedPath, version string) {
+	entry := getVersionEntry(resolvedPath)
+	entry.once.Do(func() { entry.version = version })
+}
+
+// ResetVersionCache clears the shared version cache. Intended for tests.
+func ResetVersionCache() {
+	versionCacheMu.Lock()
+	defer versionCacheMu.Unlock()
+	versionCache = map[string]*versionEntry{}
+}
+
+// SetTestVersionOverride sets a version override by binary name for tests.
+// When set, ResolveVersion will return this value without shelling out.
+func SetTestVersionOverride(binary, version string) {
+	testOverrideMu.Lock()
+	defer testOverrideMu.Unlock()
+	if version == "" {
+		delete(testOverride, binary)
+		return
+	}
+	testOverride[binary] = version
+}

--- a/run/version_cache_test.go
+++ b/run/version_cache_test.go
@@ -1,0 +1,137 @@
+//go:build !windows
+
+// Copyright 2025 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+package run
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestResolveVersionCachesPerResolvedPath(t *testing.T) {
+	ResetVersionCache()
+
+	tdir := t.TempDir()
+	counter := filepath.Join(tdir, "count.txt")
+	bin := filepath.Join(tdir, "foo")
+
+	script := "#!/bin/sh\n" +
+		"if [ \"$1\" = \"--version\" ]; then\n" +
+		"  echo \"foo v1.2.3\"\n" +
+		"fi\n" +
+		"echo x >> '" + strings.ReplaceAll(counter, "'", "'\\''") + "'\n"
+	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
+		t.Fatalf("write bin: %v", err)
+	}
+	if err := os.Chmod(bin, 0o755); err != nil {
+		t.Fatalf("chmod bin: %v", err)
+	}
+
+	env := []string{"PATH=" + tdir}
+	ctx := context.Background()
+
+	if v := ResolveVersion(ctx, env, "foo"); v == "" {
+		t.Fatalf("expected version, got empty")
+	}
+	_ = ResolveVersion(ctx, env, "foo")
+	_ = ResolveVersion(ctx, env, "foo")
+
+	b, err := os.ReadFile(counter)
+	if err != nil {
+		t.Fatalf("read counter: %v", err)
+	}
+	if got := strings.Count(string(b), "x"); got != 1 {
+		t.Fatalf("expected one invocation, got %d", got)
+	}
+}
+
+func TestResolveVersionCacheKeyIsResolvedPath(t *testing.T) {
+	ResetVersionCache()
+
+	d1 := t.TempDir()
+	d2 := t.TempDir()
+	c1 := filepath.Join(d1, "count.txt")
+	c2 := filepath.Join(d2, "count.txt")
+
+	for _, tc := range []struct{ dir, counter string }{{d1, c1}, {d2, c2}} {
+		bin := filepath.Join(tc.dir, "foo")
+		script := "#!/bin/sh\n" +
+			"if [ \"$1\" = \"--version\" ]; then\n" +
+			"  echo \"foo v1.2.3\"\n" +
+			"fi\n" +
+			"echo x >> '" + strings.ReplaceAll(tc.counter, "'", "'\\''") + "'\n"
+		if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
+			t.Fatalf("write bin: %v", err)
+		}
+		if err := os.Chmod(bin, 0o755); err != nil {
+			t.Fatalf("chmod bin: %v", err)
+		}
+	}
+
+	ctx := context.Background()
+	_ = ResolveVersion(ctx, []string{"PATH=" + d1}, "foo")
+	_ = ResolveVersion(ctx, []string{"PATH=" + d2}, "foo")
+
+	b1, err := os.ReadFile(c1)
+	if err != nil {
+		t.Fatalf("read counter1: %v", err)
+	}
+	b2, err := os.ReadFile(c2)
+	if err != nil {
+		t.Fatalf("read counter2: %v", err)
+	}
+	if strings.Count(string(b1), "x") != 1 || strings.Count(string(b2), "x") != 1 {
+		t.Fatalf("expected one invocation per resolved path")
+	}
+}
+
+func TestSetTestVersionOverrideSkipsShellOut(t *testing.T) {
+	ResetVersionCache()
+	SetTestVersionOverride("foo", "9.9.9")
+	t.Cleanup(func() { SetTestVersionOverride("foo", "") })
+
+	// no binary present; would fail without override
+	ctx := context.Background()
+	if v := ResolveVersion(ctx, []string{"PATH=/nonexistent"}, "foo"); v != "9.9.9" {
+		t.Fatalf("expected override version, got %q", v)
+	}
+}
+
+func TestSeedVersionForResolvedPathSkipsShellOut(t *testing.T) {
+	ResetVersionCache()
+
+	d := t.TempDir()
+	counter := filepath.Join(d, "count.txt")
+	bin := filepath.Join(d, "foo")
+	script := "#!/bin/sh\n" +
+		"if [ \"$1\" = \"--version\" ]; then\n" +
+		"  echo \"foo v1.2.3\"\n" +
+		"fi\n" +
+		"echo x >> '" + strings.ReplaceAll(counter, "'", "'\\''") + "'\n"
+	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
+		t.Fatalf("write bin: %v", err)
+	}
+	if err := os.Chmod(bin, 0o755); err != nil {
+		t.Fatalf("chmod bin: %v", err)
+	}
+
+	resolved, err := LookPath("foo", []string{"PATH=" + d})
+	if err != nil {
+		t.Fatalf("lookpath: %v", err)
+	}
+	SeedVersionForResolvedPath(resolved, "2.2.2")
+
+	ctx := context.Background()
+	if v := ResolveVersion(ctx, []string{"PATH=" + d}, "foo"); v != "2.2.2" {
+		t.Fatalf("expected seeded version, got %q", v)
+	}
+
+	if _, err := os.Stat(counter); err == nil {
+		t.Fatalf("expected no shell-out (counter file should not exist)")
+	}
+}

--- a/run/version_cache_windows_test.go
+++ b/run/version_cache_windows_test.go
@@ -1,0 +1,118 @@
+//go:build windows
+
+// Copyright 2025 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+package run
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeCmdScript(t *testing.T, path string, counter string, versionLine string) {
+	t.Helper()
+	// .cmd script that prints version if --version and appends to counter
+	// Use proper quoting for the counter path
+	content := "@echo off\r\n" +
+		"if \"%~1\"==\"--version\" (\r\n" +
+		"  echo " + versionLine + "\r\n" +
+		")\r\n" +
+		"echo x>>\"" + strings.ReplaceAll(counter, "\"", "\"\"") + "\"\r\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+}
+
+func TestResolveVersionCachesPerResolvedPath_Windows(t *testing.T) {
+	ResetVersionCache()
+
+	tdir := t.TempDir()
+	counter := filepath.Join(tdir, "count.txt")
+	bin := filepath.Join(tdir, "foo.cmd")
+
+	writeCmdScript(t, bin, counter, "foo v1.2.3")
+
+	env := []string{"PATH=" + tdir}
+	ctx := context.Background()
+
+	if v := ResolveVersion(ctx, env, "foo"); v == "" {
+		t.Fatalf("expected version, got empty")
+	}
+	_ = ResolveVersion(ctx, env, "foo")
+	_ = ResolveVersion(ctx, env, "foo")
+
+	b, err := os.ReadFile(counter)
+	if err != nil {
+		t.Fatalf("read counter: %v", err)
+	}
+	if got := strings.Count(string(b), "x"); got != 1 {
+		t.Fatalf("expected one invocation, got %d", got)
+	}
+}
+
+func TestResolveVersionCacheKeyIsResolvedPath_Windows(t *testing.T) {
+	ResetVersionCache()
+
+	d1 := t.TempDir()
+	d2 := t.TempDir()
+	c1 := filepath.Join(d1, "count.txt")
+	c2 := filepath.Join(d2, "count.txt")
+
+	writeCmdScript(t, filepath.Join(d1, "foo.cmd"), c1, "foo v1.2.3")
+	writeCmdScript(t, filepath.Join(d2, "foo.cmd"), c2, "foo v1.2.3")
+
+	ctx := context.Background()
+	_ = ResolveVersion(ctx, []string{"PATH=" + d1}, "foo")
+	_ = ResolveVersion(ctx, []string{"PATH=" + d2}, "foo")
+
+	b1, err := os.ReadFile(c1)
+	if err != nil {
+		t.Fatalf("read counter1: %v", err)
+	}
+	b2, err := os.ReadFile(c2)
+	if err != nil {
+		t.Fatalf("read counter2: %v", err)
+	}
+	if strings.Count(string(b1), "x") != 1 || strings.Count(string(b2), "x") != 1 {
+		t.Fatalf("expected one invocation per resolved path")
+	}
+}
+
+func TestSetTestVersionOverrideSkipsShellOut_Windows(t *testing.T) {
+	ResetVersionCache()
+	SetTestVersionOverride("foo", "9.9.9")
+	t.Cleanup(func() { SetTestVersionOverride("foo", "") })
+
+	ctx := context.Background()
+	if v := ResolveVersion(ctx, []string{"PATH=C:\\nonexistent"}, "foo"); v != "9.9.9" {
+		t.Fatalf("expected override version, got %q", v)
+	}
+}
+
+func TestSeedVersionForResolvedPathSkipsShellOut_Windows(t *testing.T) {
+	ResetVersionCache()
+
+	d := t.TempDir()
+	counter := filepath.Join(d, "count.txt")
+	bin := filepath.Join(d, "foo.cmd")
+	writeCmdScript(t, bin, counter, "foo v1.2.3")
+
+	resolved, err := LookPath("foo", []string{"PATH=" + d})
+	if err != nil {
+		t.Fatalf("lookpath: %v", err)
+	}
+	SeedVersionForResolvedPath(resolved, "2.2.2")
+
+	ctx := context.Background()
+	if v := ResolveVersion(ctx, []string{"PATH=" + d}, "foo"); v != "2.2.2" {
+		t.Fatalf("expected seeded version, got %q", v)
+	}
+
+	if _, err := os.Stat(counter); err == nil {
+		t.Fatalf("expected no shell-out (counter file should not exist)")
+	}
+}


### PR DESCRIPTION
## What this PR does / why we need it:

Terragrunt has recently renamed their environment variables from `TERRAGRUNT_*` to `TG_*` and renamed their command-line arguments from `--terragrunt-foo` to `--foo`.

We need a mechanism to detect the version of Terragrunt on `PATH` and pass the correct env vars and arguments depending on that version. Without this we can’t support all versions of Terragrunt and would be forced into a brittle version mapping (e.g., Terramate X only supports Terragrunt Y), which is untenable.

This PR:

- Adds a version-aware Terragrunt runner:
  - ≥ 0.85.0: rewrites `--terragrunt-*` → `--*` and uses `--non-interactive`
  - ≥ 0.73.0: uses `TG_FORWARD_TF_STDOUT=true` and `TG_LOG_FORMAT=bare`
  - < 0.73.0: uses `TERRAGRUNT_FORWARD_TF_STDOUT=true` and `TERRAGRUNT_LOG_FORMAT=bare`
- Introduces `run.CLIRunner` and concrete runners for Terraform, Terragrunt, and OpenTofu with consistent APIs (`Version`, `Command`, `ShowCommand`
- Updates cloud plan rendering to select the appropriate runner with improved timeout handling and logging
- Adds unit tests for runners and `LookPath`

## Special notes for reviewer:
- Behavior is gated by Terragrunt version detection; falls back to most recent version flags/envs when unknown.

## Does this PR introduce a user-facing change?

Yes.

Terramate now adapts Terragrunt flags and env vars to the installed Terragrunt version:

>= 0.85.0: uses --non-interactive; rewrites --terragrunt-* to --.
>= 0.73.0 and < 0.85.0: uses legacy flags; TG_FORWARD_TF_STDOUT=true and TG_LOG_FORMAT=bare.
< 0.73.0: uses legacy flags; TERRAGRUNT_FORWARD_TF_STDOUT=true and TERRAGRUNT_LOG_FORMAT=bare.

Impact: scripts parsing args or expecting specific env var names may see differences across machines depending on Terragrunt version.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce unified CLI runners with Terragrunt version-aware flags/env, refactor cloud plan rendering to use them, add tests, and install Terragrunt in CI/e2e.
> 
> - **Run package**:
>   - **New interface**: `run.CLIRunner` for CLI abstraction.
>   - **Runners**: Add `run/terragrunt`, `run/terraform`, `run/tofu` with `ShowCommand` and `Version`.
>   - **Version cache**: `run/version_cache.go` to parse/cache `--version` per resolved path; tests added.
> - **Cloudsync**:
>   - Refactor `cloudsync/terraform_planfile.go` to select runner (terragrunt/tofu/terraform), build `show` command via runner, and use context timeout.
> - **E2E tests**:
>   - Helper `terragrunt` now supports `--version` and validates TG/TERRAGRUNT env based on version.
>   - Add Terragrunt installer (`InstallTerragrunt`) and integrate into `setup.go` with teardown.
>   - Add tests for `LookPath` and runners (terraform/terragrunt/tofu).
> - **CI**:
>   - Workflows install Terragrunt (`gruntwork-io/terragrunt-action@v3.0.2`) and minor quoting/whitespace fixes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2aef43a64349aa569fb56a3b317b5f0a4aceede7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->