### PR TITLE
refactor: add validate step for merged blocks parsing

### DIFF
--- a/hcl/block_globals_parser.go
+++ b/hcl/block_globals_parser.go
@@ -49,3 +49,8 @@ func validateGlobals(block *ast.MergedBlock) error {
 	}
 	return errs.AsError()
 }
+
+// Validate postconditions after parsing.
+func (*GlobalsBlockParser) Validate(*TerramateParser) error {
+	return nil
+}

--- a/hcl/block_terramate_parser.go
+++ b/hcl/block_terramate_parser.go
@@ -90,3 +90,8 @@ func (*TerramateBlockParser) Parse(p *TerramateParser, block *ast.MergedBlock) e
 	return nil
 
 }
+
+// Validate postconditions after parsing.
+func (*TerramateBlockParser) Validate(*TerramateParser) error {
+	return nil
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/terramate-io/terramate/blob/main/CONTRIBUTING.md
2. If the PR is unfinished, mark it as draft: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request
3. Please update the PR title using the Conventional Commits convention: https://www.conventionalcommits.org/en/v1.0.0/
    Example: feat: add support for XYZ.
-->

## What this PR does / why we need it:

This PR refactors the interface for merged block handlers (with and without labels) to include an additional `Validate` function that will be called after parsing. This allows handlers to validate postconditions that can only be checked after parsing (i.e. to support incremental definitions).

This is not used by anything within Terramate itself, but will be required by external code.

## Does this PR introduce a user-facing change?
```
no
```
