### PR TITLE
refactor: move generate.Do to generate.API

### DIFF
--- a/commands/generate/generate.go
+++ b/commands/generate/generate.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 
 	"github.com/rs/zerolog/log"
+	"github.com/terramate-io/terramate/di"
 	"github.com/terramate-io/terramate/engine"
 	"github.com/terramate-io/terramate/errors"
 	"github.com/terramate-io/terramate/event"
@@ -40,7 +41,7 @@ type Spec struct {
 func (s *Spec) Name() string { return "generate" }
 
 // Exec executes the generate command.
-func (s *Spec) Exec(_ context.Context) error {
+func (s *Spec) Exec(ctx context.Context) error {
 	logger := log.With().
 		Str("action", "commands/generate").
 		Logger()
@@ -81,7 +82,13 @@ func (s *Spec) Exec(_ context.Context) error {
 	if err != nil {
 		return err
 	}
-	report := generate.Do(cfg, cwd, s.Parallel, vdir, vendorRequestEvents)
+
+	generateAPI, err := di.Get[generate.API](ctx)
+	if err != nil {
+		return err
+	}
+
+	report := generateAPI.Do(cfg, cwd, s.Parallel, vdir, vendorRequestEvents)
 
 	logger.Trace().Msg("code generation finished, waiting for vendor requests to be handled")
 

--- a/commands/stack/create/create.go
+++ b/commands/stack/create/create.go
@@ -61,7 +61,7 @@ type Spec struct {
 func (s *Spec) Name() string { return "create" }
 
 // Exec executes the create stack command.
-func (s *Spec) Exec(_ context.Context) error {
+func (s *Spec) Exec(ctx context.Context) error {
 	scanFlags := 0
 	if s.AllTerraform {
 		scanFlags++
@@ -85,7 +85,7 @@ func (s *Spec) Exec(_ context.Context) error {
 		if s.Path != "" {
 			return errors.E("Invalid args: path argument cannot be provided with --all-terraform, --all-terragrunt, --ensure-stack-ids")
 		}
-		return s.execScanCreate()
+		return s.execScanCreate(ctx)
 	}
 
 	if s.Path == "" {
@@ -179,10 +179,10 @@ func (s *Spec) Exec(_ context.Context) error {
 		Printers:      s.Printers,
 	}
 
-	return generate.Exec(context.TODO())
+	return generate.Exec(ctx)
 }
 
-func (s *Spec) execScanCreate() error {
+func (s *Spec) execScanCreate(ctx context.Context) error {
 	var flagname string
 	switch {
 	case s.EnsureStackIDs:
@@ -223,7 +223,7 @@ func (s *Spec) execScanCreate() error {
 
 	switch flagname {
 	case "--all-terraform":
-		return s.initTerraform()
+		return s.initTerraform(ctx)
 	case "--all-terragrunt":
 		return s.initTerragrunt()
 	case "--ensure-stack-ids":
@@ -301,7 +301,7 @@ func (s *Spec) initTerragrunt() error {
 	return nil
 }
 
-func (s *Spec) initTerraform() error {
+func (s *Spec) initTerraform(ctx context.Context) error {
 	err := s.initTerraformDir(s.WorkingDir)
 	if err != nil {
 		return errors.E(err, "failed to initialize some directories")
@@ -324,7 +324,7 @@ func (s *Spec) initTerraform() error {
 		MinimalReport: true,
 	}
 
-	return generate.Exec(context.Background())
+	return generate.Exec(ctx)
 }
 
 func (s *Spec) initTerraformDir(baseDir string) error {

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -196,7 +196,7 @@ func Load(root *config.Root, vendorDir project.Path) ([]LoadResult, error) {
 // failed on code generation, any failure found is added to the report but does
 // not abort the overall code generation process, so partial results can be
 // obtained and the report needs to be inspected to check.
-func Do(
+func (*apiImpl) Do(
 	root *config.Root,
 	targetDir project.Path,
 	parallel int,

--- a/generate/generate_api.go
+++ b/generate/generate_api.go
@@ -5,11 +5,26 @@ package generate
 
 import (
 	"github.com/terramate-io/terramate/config"
+	"github.com/terramate-io/terramate/event"
+	genreport "github.com/terramate-io/terramate/generate/report"
 	"github.com/terramate-io/terramate/project"
 )
 
 // API for code generation.
-// Currently, it only contains DetectOutdated, but it will be extended in the future.
 type API interface {
-	DetectOutdated(root *config.Root, target *config.Tree, vendorDir project.Path) ([]string, error)
+	// Do runs the code generation.
+	Do(
+		root *config.Root,
+		targetDir project.Path,
+		parallel int,
+		vendorDir project.Path,
+		vendorRequests chan<- event.VendorRequest,
+	) *genreport.Report
+
+	// DetectOutdated checks for outdated files that would be changed by Do, but without making any changes.
+	DetectOutdated(
+		root *config.Root,
+		target *config.Tree,
+		vendorDir project.Path,
+	) ([]string, error)
 }

--- a/generate/generate_bench_test.go
+++ b/generate/generate_bench_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/madlambda/spells/assert"
 	"github.com/terramate-io/terramate/config"
-	"github.com/terramate-io/terramate/generate"
 	"github.com/terramate-io/terramate/project"
 	"github.com/terramate-io/terramate/test/sandbox"
 )
@@ -59,9 +58,11 @@ func BenchmarkGenerate(b *testing.B) {
 	root, err := config.LoadRoot(s.RootDir(), false)
 	assert.NoError(b, err)
 
+	generateAPI := newGenerateAPIForTest(b)
+
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
-		report := generate.Do(root, project.NewPath("/"), 0, project.NewPath("/vendor"), nil)
+		report := generateAPI.Do(root, project.NewPath("/"), 0, project.NewPath("/vendor"), nil)
 		if report.HasFailures() {
 			b.Fatal(report.Full())
 		}
@@ -114,9 +115,11 @@ func BenchmarkGenerateRegex(b *testing.B) {
 	root, err := config.LoadRoot(s.RootDir(), false)
 	assert.NoError(b, err)
 
+	generateAPI := newGenerateAPIForTest((b))
+
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
-		report := generate.Do(root, project.NewPath("/"), 0, project.NewPath("/vendor"), nil)
+		report := generateAPI.Do(root, project.NewPath("/"), 0, project.NewPath("/vendor"), nil)
 		if report.HasFailures() {
 			b.Fatal(report.Full())
 		}

--- a/generate/generate_hcl_test.go
+++ b/generate/generate_hcl_test.go
@@ -2111,7 +2111,8 @@ func TestWontOverwriteManuallyDefinedTerraform(t *testing.T) {
 		fmt.Sprintf("f:stack/%s:%s", genFilename, manualTfCode),
 	})
 
-	report := generate.Do(s.Config(), project.NewPath("/"), 0, project.NewPath("/modules"), nil)
+	generateAPI := newGenerateAPIForTest(t)
+	report := generateAPI.Do(s.Config(), project.NewPath("/"), 0, project.NewPath("/modules"), nil)
 	assert.EqualInts(t, 0, len(report.Successes), "want no success")
 	assert.EqualInts(t, 1, len(report.Failures), "want single failure")
 	test.AssertReportHasError(t, report, errors.E(generate.ErrManualCodeExists))

--- a/generate/outdated_detection_test.go
+++ b/generate/outdated_detection_test.go
@@ -4,13 +4,11 @@
 package generate_test
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
 	"github.com/madlambda/spells/assert"
 	"github.com/terramate-io/terramate"
-	"github.com/terramate-io/terramate/di"
 	"github.com/terramate-io/terramate/errors"
 	"github.com/terramate-io/terramate/generate"
 	"github.com/terramate-io/terramate/project"
@@ -1562,12 +1560,7 @@ func TestOutdatedDetection(t *testing.T) {
 					}
 				}
 
-				b := di.NewBindings(t.Context())
-				assert.NoError(t, di.Bind(b, generate.NewAPI()))
-
-				ctx := di.WithBindings(context.Background(), b)
-				generateAPI, err := di.Get[generate.API](ctx)
-				assert.NoError(t, err)
+				generateAPI := newGenerateAPIForTest(t)
 
 				got, err := generateAPI.DetectOutdated(s.Config(), target, vendorDir)
 				assert.IsError(t, err, step.wantErr)

--- a/generate/vendor_test.go
+++ b/generate/vendor_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/terramate-io/terramate/event"
-	"github.com/terramate-io/terramate/generate"
 	"github.com/terramate-io/terramate/generate/report"
 	"github.com/terramate-io/terramate/project"
 	"github.com/terramate-io/terramate/test"
@@ -294,7 +293,9 @@ func TestGenerateVendorRequestEvents(t *testing.T) {
 
 	t.Log("generating code")
 
-	report := generate.Do(s.Config(), project.NewPath("/"), 0, vendorDir, events)
+	generateAPI := newGenerateAPIForTest(t)
+
+	report := generateAPI.Do(s.Config(), project.NewPath("/"), 0, vendorDir, events)
 
 	t.Logf("generation report: %s", report.Full())
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/terramate-io/terramate/blob/main/CONTRIBUTING.md
2. If the PR is unfinished, mark it as draft: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request
3. Please update the PR title using the Conventional Commits convention: https://www.conventionalcommits.org/en/v1.0.0/
    Example: feat: add support for XYZ.
-->

## What this PR does / why we need it:

This PR continues from #2200  to move the main code generation function (`generate.Do`) to the `generate.API`.
Existing callers are modified. This means overrides of the API will automatically be used by `terramate generate` and `terramate create`. 

## Does this PR introduce a user-facing change?
<!--
If no, just write "no" in the block below.
If yes, please explain the change and update documentation and the CHANGELOG.md file accordingly.
-->
```
no
```
