### PR TITLE
chore: fix tests with newer terraform versions

### DIFF
--- a/e2etests/cloud/run_cloud_drift_test.go
+++ b/e2etests/cloud/run_cloud_drift_test.go
@@ -919,10 +919,10 @@ func assertRunDrifts(t *testing.T, cloudData *cloudstore.Data, tmcAddr string, e
 		if diff := cmp.Diff(gotPlan, wantPlan,
 			cmpopts.IgnoreUnexported(tfjson.Plan{}),
 			// TODO (snk): Could also supply two planfiles, but I think this is fine, too.
-			cmpopts.IgnoreFields(tfjson.Plan{}, "Timestamp", "FormatVersion", "TerraformVersion"),
+			cmpopts.IgnoreFields(tfjson.Plan{}, "Timestamp", "FormatVersion", "TerraformVersion", "Complete"),
 			cmpopts.IgnoreFields(tfjson.ResourceChange{}, "ProviderName"),
 			cmpopts.IgnoreFields(tfjson.ProviderConfig{}, "FullName"),
-			cmpopts.IgnoreFields(tfjson.StateResource{}, "ProviderName")); diff != "" {
+			cmpopts.IgnoreFields(tfjson.StateResource{}, "ProviderName", "SensitiveValues")); diff != "" {
 			t.Logf("want: %+v", expected.Details.ChangesetJSON)
 			t.Logf("got: %+v", got.Details.ChangesetJSON)
 			t.Fatal(diff)

--- a/e2etests/core/list_git_test.go
+++ b/e2etests/core/list_git_test.go
@@ -387,12 +387,12 @@ func TestGitGlobalConfigIsUsed(t *testing.T) {
 	t.Parallel()
 
 	// code below configures a global config with a global ignore file which
-	// ignores *.test files.
+	// ignores *.testignore files.
 
 	s1 := sandbox.NoGit(t, false)
 	s1.BuildTree([]string{
 		"f:.gitconfig:",
-		"f:.gitignore:*.test",
+		"f:.gitignore:*.testignore",
 	})
 
 	tempGlobalConfig := filepath.Join(s1.RootDir(), ".gitconfig")
@@ -425,7 +425,7 @@ func TestGitGlobalConfigIsUsed(t *testing.T) {
 	subdir := stack.CreateDir("sub/dir")
 
 	// this file must be ignored when using the global config.
-	_ = subdir.CreateFile("something.test", "# nothing")
+	_ = subdir.CreateFile("something.testignore", "# nothing")
 
 	// double check the repository has untracked files
 	cli := NewCLI(t, repo.RootDir())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/terramate-io/terramate/blob/main/CONTRIBUTING.md
2. If the PR is unfinished, mark it as draft: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request
3. Please update the PR title using the Conventional Commits convention: https://www.conventionalcommits.org/en/v1.0.0/
    Example: feat: add support for XYZ.
-->

## What this PR does / why we need it:

Adds additional fields to ignore in the cloud drift test comparison:
- Ignores the `Complete` field in the `tfjson.Plan` struct
- Ignores the `SensitiveValues` field in the `tfjson.StateResource` struct

In newer versions of tofu and terraform, these fields are present but don't affect the actual test validation logic.

## Which issue(s) this PR fixes:

Fixes #

## Special notes for your reviewer:

This change helps prevent flaky tests by ignoring non-essential fields during plan comparison.

## Does this PR introduce a user-facing change?

No