### PR TITLE
fix: add missing filter flags to debug show commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,9 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 
 ### Fixed
 
-- Fix filter flag inconsistencies for `trigger` command. Some flags were listed in the help, but ignored by the command.
-  The following flags work as intended now:
+- Fix filter flag inconsistencies for `trigger` and `debug show {metadata,globals,generate-origins,runtime-env}` commands.
+  Some flags were listed in the help, but ignored by the command. The following flags work as intended now:
+  - `--status`
   - `--drift-status`
   - `--deployment-status`
   - `--tags`

--- a/commands/debug/show/globals/globals.go
+++ b/commands/debug/show/globals/globals.go
@@ -19,10 +19,13 @@ import (
 
 // Spec is the command specification for the debug globals command.
 type Spec struct {
-	WorkingDir string
-	Engine     *engine.Engine
-	Printers   printer.Printers
-	GitFilter  engine.GitFilter
+	WorkingDir    string
+	Engine        *engine.Engine
+	Printers      printer.Printers
+	GitFilter     engine.GitFilter
+	StatusFilters resources.StatusFilters
+	Tags          []string
+	NoTags        []string
 }
 
 // Name returns the name of the command.
@@ -30,13 +33,13 @@ func (s *Spec) Name() string { return "debug globals" }
 
 // Exec executes the debug globals command.
 func (s *Spec) Exec(_ context.Context) error {
-	report, err := s.Engine.ListStacks(s.GitFilter, cloudstack.AnyTarget, resources.NoStatusFilters(), false)
+	report, err := s.Engine.ListStacks(s.GitFilter, cloudstack.AnyTarget, s.StatusFilters, false)
 	if err != nil {
 		return err
 	}
 	cfg := s.Engine.Config()
 
-	filteredStacks, err := s.Engine.FilterStacks(report.Stacks, engine.ByWorkingDir())
+	filteredStacks, err := s.Engine.FilterStacks(report.Stacks, engine.ByWorkingDir(), engine.ByTags(s.Tags, s.NoTags))
 	if err != nil {
 		return err
 	}

--- a/commands/debug/show/runtime_env/runtime_env.go
+++ b/commands/debug/show/runtime_env/runtime_env.go
@@ -19,10 +19,13 @@ import (
 
 // Spec is the command specification for the show-runtime-env command.
 type Spec struct {
-	WorkingDir string
-	Engine     *engine.Engine
-	Printers   printer.Printers
-	GitFilter  engine.GitFilter
+	WorkingDir    string
+	Engine        *engine.Engine
+	Printers      printer.Printers
+	GitFilter     engine.GitFilter
+	StatusFilters resources.StatusFilters
+	Tags          []string
+	NoTags        []string
 }
 
 // Name returns the name of the command.
@@ -30,12 +33,12 @@ func (s *Spec) Name() string { return "debug show runtime-env" }
 
 // Exec executes the show-runtime-env command.
 func (s *Spec) Exec(_ context.Context) error {
-	report, err := s.Engine.ListStacks(s.GitFilter, cloudstack.AnyTarget, resources.NoStatusFilters(), false)
+	report, err := s.Engine.ListStacks(s.GitFilter, cloudstack.AnyTarget, s.StatusFilters, false)
 	if err != nil {
 		return errors.E(err, "listing stacks")
 	}
 
-	stackEntries, err := s.Engine.FilterStacks(report.Stacks, engine.ByWorkingDir())
+	stackEntries, err := s.Engine.FilterStacks(report.Stacks, engine.ByWorkingDir(), engine.ByTags(s.Tags, s.NoTags))
 	if err != nil {
 		return err
 	}

--- a/ui/tui/cli_handler.go
+++ b/ui/tui/cli_handler.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/rs/zerolog/log"
 	"github.com/terramate-io/go-checkpoint"
+	"github.com/terramate-io/terramate/cloud/api/status"
 	"github.com/terramate-io/terramate/commands"
 	clonecmd "github.com/terramate-io/terramate/commands/clone"
 	clouddriftshowcmd "github.com/terramate-io/terramate/commands/cloud/drift/show"
@@ -722,11 +723,23 @@ func DefaultAfterConfigHandler(ctx context.Context, c *CLI) (commands.Executor, 
 			return nil, false, false, err
 		}
 
+		statusFilters, err := status.ParseFilters(
+			parsedArgs.Debug.Show.Globals.Status,
+			parsedArgs.Debug.Show.Globals.DriftStatus,
+			parsedArgs.Debug.Show.Globals.DeploymentStatus,
+		)
+		if err != nil {
+			return nil, false, false, err
+		}
+
 		return &debugglobalscmd.Spec{
-			WorkingDir: c.state.wd,
-			Engine:     c.Engine(),
-			Printers:   c.printers,
-			GitFilter:  gitfilter,
+			WorkingDir:    c.state.wd,
+			Engine:        c.Engine(),
+			Printers:      c.printers,
+			GitFilter:     gitfilter,
+			Tags:          parsedArgs.Tags,
+			NoTags:        parsedArgs.NoTags,
+			StatusFilters: statusFilters,
 		}, true, false, nil
 
 	case "debug show generate-origins":
@@ -740,11 +753,23 @@ func DefaultAfterConfigHandler(ctx context.Context, c *CLI) (commands.Executor, 
 			return nil, false, false, err
 		}
 
+		statusFilters, err := status.ParseFilters(
+			parsedArgs.Debug.Show.GenerateOrigins.Status,
+			parsedArgs.Debug.Show.GenerateOrigins.DriftStatus,
+			parsedArgs.Debug.Show.GenerateOrigins.DeploymentStatus,
+		)
+		if err != nil {
+			return nil, false, false, err
+		}
+
 		return &generateoriginscmd.Spec{
-			WorkingDir: c.state.wd,
-			Engine:     c.Engine(),
-			Printers:   c.printers,
-			GitFilter:  gitfilter,
+			WorkingDir:    c.state.wd,
+			Engine:        c.Engine(),
+			Printers:      c.printers,
+			GitFilter:     gitfilter,
+			Tags:          parsedArgs.Tags,
+			NoTags:        parsedArgs.NoTags,
+			StatusFilters: statusFilters,
 		}, true, false, nil
 
 	case "debug show metadata":
@@ -757,11 +782,24 @@ func DefaultAfterConfigHandler(ctx context.Context, c *CLI) (commands.Executor, 
 		if err != nil {
 			return nil, false, false, err
 		}
+
+		statusFilters, err := status.ParseFilters(
+			parsedArgs.Debug.Show.Metadata.Status,
+			parsedArgs.Debug.Show.Metadata.DriftStatus,
+			parsedArgs.Debug.Show.Metadata.DeploymentStatus,
+		)
+		if err != nil {
+			return nil, false, false, err
+		}
+
 		return &debugshowmetadatacmd.Spec{
-			WorkingDir: c.state.wd,
-			Engine:     c.Engine(),
-			Printers:   c.printers,
-			GitFilter:  gitfilter,
+			WorkingDir:    c.state.wd,
+			Engine:        c.Engine(),
+			Printers:      c.printers,
+			GitFilter:     gitfilter,
+			Tags:          parsedArgs.Tags,
+			NoTags:        parsedArgs.NoTags,
+			StatusFilters: statusFilters,
 		}, true, false, nil
 	case "debug show runtime-env":
 		c.InitAnalytics("debug-show-runtime-env")
@@ -773,11 +811,23 @@ func DefaultAfterConfigHandler(ctx context.Context, c *CLI) (commands.Executor, 
 		if err != nil {
 			return nil, false, false, err
 		}
+		statusFilters, err := status.ParseFilters(
+			parsedArgs.Debug.Show.RuntimeEnv.Status,
+			parsedArgs.Debug.Show.RuntimeEnv.DriftStatus,
+			parsedArgs.Debug.Show.RuntimeEnv.DeploymentStatus,
+		)
+		if err != nil {
+			return nil, false, false, err
+		}
+
 		return &debugshowruntimeenv.Spec{
-			WorkingDir: c.state.wd,
-			Engine:     c.Engine(),
-			Printers:   c.printers,
-			GitFilter:  gitfilter,
+			WorkingDir:    c.state.wd,
+			Engine:        c.Engine(),
+			Printers:      c.printers,
+			GitFilter:     gitfilter,
+			Tags:          parsedArgs.Tags,
+			NoTags:        parsedArgs.NoTags,
+			StatusFilters: statusFilters,
 		}, true, false, nil
 
 	case "experimental run-graph":

--- a/ui/tui/cli_spec.go
+++ b/ui/tui/cli_spec.go
@@ -80,11 +80,18 @@ type FlagSpec struct {
 
 	Debug struct {
 		Show struct {
-			Metadata        struct{} `cmd:"" help:"Show metadata available in stacks."`
-			Globals         struct{} `cmd:"" help:"Show globals available in stacks."`
+			Metadata struct {
+				cloudFilterFlags
+			} `cmd:"" help:"Show metadata available in stacks."`
+			Globals struct {
+				cloudFilterFlags
+			} `cmd:"" help:"Show globals available in stacks."`
 			GenerateOrigins struct {
+				cloudFilterFlags
 			} `cmd:"" help:"Show details about generated code in stacks."`
-			RuntimeEnv struct{} `cmd:"" help:"Show available run-time environment variables (ENV) in stacks."`
+			RuntimeEnv struct {
+				cloudFilterFlags
+			} `cmd:"" help:"Show available run-time environment variables (ENV) in stacks."`
 		} `cmd:"" help:"Show configuration details of stacks."`
 	} `cmd:"" help:"Debug Terramate configuration."`
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/terramate-io/terramate/blob/main/CONTRIBUTING.md
2. If the PR is unfinished, mark it as draft: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request
3. Please update the PR title using the Conventional Commits convention: https://www.conventionalcommits.org/en/v1.0.0/
    Example: feat: add support for XYZ.
-->

## What this PR does / why we need it:

This PR adds filter flags to the debug commands `terramate debug show {metadata,globals,generate-origins,runtime-env}`, in particular: `--status`, `--drift-status`, `--deployment-status`, `--tags`, `--no-tags`.

## Does this PR introduce a user-facing change?
<!--
If no, just write "no" in the block below.
If yes, please explain the change and update documentation and the CHANGELOG.md file accordingly.
-->
```
yes, it adds new flags
```
