### PR TITLE
fix: --no-recursive supports output dependency flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 
 ### Fixed
 
+- Apply `--include-output-dependencies` and `--only-output-dependencies` flags when used together with `--no-recursive`.
 - Change the output buffering behaviour of `run` and `script run` to allow the use of interactive prompts
   (e.g. `terraform apply`) that wait for input in the same line.
   - Fix a regression for this specific use-case, which was introduced in `0.14.4`, where all output was buffered by line.

--- a/commands/run/run.go
+++ b/commands/run/run.go
@@ -132,6 +132,10 @@ func (s *Spec) Exec(ctx context.Context) error {
 		}
 
 		stacks = append(stacks, st.Sortable())
+		stacks, err = s.Engine.AddOutputDependencies(s.OutputsSharingOptions, stacks, s.Target)
+		if err != nil {
+			return err
+		}
 	} else {
 		cloudFilters, err := status.ParseFilters(
 			s.StatusFilters.StackStatus,

--- a/commands/script/run/run.go
+++ b/commands/script/run/run.go
@@ -108,6 +108,10 @@ func (s *Spec) Exec(ctx context.Context) error {
 		}
 
 		stacks = append(stacks, st.Sortable())
+		stacks, err = s.Engine.AddOutputDependencies(s.OutputsSharingOptions, stacks, s.Target)
+		if err != nil {
+			return err
+		}
 	} else {
 		cloudFilters, err := status.ParseFilters(
 			s.StatusFilters.StackStatus,

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -277,10 +277,11 @@ func (e *Engine) ComputeSelectedStacks(gitfilter GitFilter, tags filter.TagClaus
 	if err != nil {
 		return nil, errors.E(err, "adding wanted stacks")
 	}
-	return e.addOutputDependencies(outputFlags, stacks, target)
+	return e.AddOutputDependencies(outputFlags, stacks, target)
 }
 
-func (e *Engine) addOutputDependencies(outputFlags OutputsSharingOptions, stacks config.List[*config.SortableStack], target string) (config.List[*config.SortableStack], error) {
+// AddOutputDependencies takes a list of stacks and adds potential output dependencies.
+func (e *Engine) AddOutputDependencies(outputFlags OutputsSharingOptions, stacks config.List[*config.SortableStack], target string) (config.List[*config.SortableStack], error) {
 	logger := log.With().
 		Str("action", "engine.addOutputDependencies()").
 		Logger()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/terramate-io/terramate/blob/main/CONTRIBUTING.md
2. If the PR is unfinished, mark it as draft: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request
3. Please update the PR title using the Conventional Commits convention: https://www.conventionalcommits.org/en/v1.0.0/
    Example: feat: add support for XYZ.
-->

## What this PR does / why we need it:

The PR fixes that for `run` and `script run`, the `--no-recursive` flag will now correctly work together with `--include-output-dependencies` and `--only-output-dependencies`.

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Keep it empty if not applicable.
-->
Fixes #2215 

## Does this PR introduce a user-facing change?
<!--
If no, just write "no" in the block below.
If yes, please explain the change and update documentation and the CHANGELOG.md file accordingly.
-->
```
yes, see changelog
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> `--no-recursive` now respects `--include-output-dependencies` and `--only-output-dependencies` for `run` and `script run`; engine method exported; tests and changelog updated.
> 
> - **Run/Script execution**:
>   - `--no-recursive` paths now process output dependencies by invoking `Engine.AddOutputDependencies(...)` after selecting the current stack in `commands/run/run.go` and `commands/script/run/run.go`.
> - **Engine**:
>   - Export `AddOutputDependencies` (renamed from private `addOutputDependencies`) and use it in `ComputeSelectedStacks`.
> - **Tests**:
>   - Extend `e2etests/core/run_sharing_test.go` to cover `--no-recursive` with `--include-output-dependencies` and `--only-output-dependencies` (for both `run` and `script run`).
> - **Docs**:
>   - Update `CHANGELOG.md` under Unreleased Fixed to note flags now apply with `--no-recursive`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fa21abf871bab3217220f36bd3e29787c963bbf9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->