### PR TITLE
chore: fix flaky TestRunIOBuffering

### DIFF
--- a/e2etests/internal/runner/runner.go
+++ b/e2etests/internal/runner/runner.go
@@ -391,8 +391,10 @@ func (tm CLI) RunInteractive(ioFunc InteractiveIO, args ...string) RunResult {
 	}()
 
 	// Wait until end and all remaining data is read.
-	_ = cmd.Wait()
 	wg.Wait()
+
+	_ = cmd.Wait()
+
 	assert.NoError(t, stdoutErr)
 	assert.NoError(t, stderrErr)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/terramate-io/terramate/blob/main/CONTRIBUTING.md
2. If the PR is unfinished, mark it as draft: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request
3. Please update the PR title using the Conventional Commits convention: https://www.conventionalcommits.org/en/v1.0.0/
    Example: feat: add support for XYZ.
-->

## What this PR does / why we need it:

This fixes another flaky test introduced by #2217 . See https://github.com/terramate-io/terramate/actions/runs/18290541309/job/52076452801#step:18:24

As per documentation of StdoutPipe:
> [Cmd.Wait](https://pkg.go.dev/os/exec#Cmd.Wait) will close the pipe after seeing the command exit, so most callers need not close the pipe themselves. It is thus incorrect to call Wait before all reads from the pipe have completed.

We first wait for the goroutines reading the outputs (they will terminate when the command exits), then call `cmd.Wait()`. Otherwise, stdout/stderr readers may be closed before we have read them.

## Does this PR introduce a user-facing change?
<!--
If no, just write "no" in the block below.
If yes, please explain the change and update documentation and the CHANGELOG.md file accordingly.
-->
```
no
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> In `RunInteractive`, wait for stdout/stderr reader goroutines to finish before calling `cmd.Wait()` to avoid closing pipes prematurely.
> 
> - **Tests / Runner**:
>   - In `e2etests/internal/runner/runner.go` `RunInteractive`, reorder synchronization to `wg.Wait()` before `cmd.Wait()` so stdout/stderr are fully read before the process wait.
>   - Preserve error checks for read operations and return collected output with correct exit status.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b91779e2a5a8a9f732121a9e7aab93b7166d44de. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->