### PR TITLE
Revert "chore: hide deprecated experimental trigger in help"

### DIFF
--- a/ui/tui/cli_spec.go
+++ b/ui/tui/cli_spec.go
@@ -116,7 +116,7 @@ type FlagSpec struct {
 		IgnoreChange bool   `default:"false" help:"Trigger stacks to be ignored by change detection"`
 		Reason       string `default:"" name:"reason" help:"Set a reason for triggering the stack."`
 		cloudFilterFlags
-	} `cmd:"" hidden:""  help:"Mark a stack as changed so it will be triggered in Change Detection. (DEPRECATED)"`
+	} `cmd:"" help:"Mark a stack as changed so it will be triggered in Change Detection."`
 
 	Experimental struct {
 		Clone struct {


### PR DESCRIPTION
Reverts terramate-io/terramate#2162

The `experimental trigger` command was already hidden, the reverted PR mistakenly set the top-level trigger as hidden and deprecated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes `hidden` and deprecation note from the top-level `trigger` command, making it visible in help again.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2d8e6e3a150cdfa899ec8094d651b6870f5134a8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->