### PR TITLE
feat: allow tags to start with numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 
 - (**BREAKING CHANGE**) Upgraded Terragrunt dependency from v0.55.21 to v0.82.0. This major version jump may introduce breaking changes in Terragrunt integration, particularly around configuration parsing and hook execution behavior.
 
+### Added
+
+- Allow tags to start with numbers.
+
 ### Fixed
 
 - Fix invalid Terragrunt argument errors on Terraform hooks that use conditional "if" logic. The upgrade to Terragrunt v0.82.0 resolves issues with hook execution behavior.

--- a/config/tag/tag.go
+++ b/config/tag/tag.go
@@ -14,17 +14,17 @@ func Validate(tag string) error {
 	for i, r := range tag {
 		switch i {
 		case 0:
-			if !isLowerAlpha(r) {
+			if !isLowerAlnum(r) {
 				return errors.E(
 					ErrInvalidTag,
-					"%q: tags must start with lowercase alphabetic character ([a-z])",
+					"%q: tags must start with lowercase alphanumeric ([0-9a-z])",
 					tag)
 			}
 		case len(tag) - 1: // last rune
 			if !isLowerAlnum(r) {
 				return errors.E(
 					ErrInvalidTag,
-					"%q: tags must end with lowercase alphanumeric ([0-9a-z]+)",
+					"%q: tags must end with lowercase alphanumeric ([0-9a-z])",
 					tag)
 			}
 		default:

--- a/e2etests/core/list_test.go
+++ b/e2etests/core/list_test.go
@@ -169,14 +169,6 @@ func listTestcases() []testcase {
 			},
 		},
 		{
-			name:   "invalid stack.tags - starting with number - fails+",
-			layout: []string{`s:stack:tags=["123abc"]`},
-			want: RunExpected{
-				StderrRegex: string(config.ErrStackInvalidTag),
-				Status:      1,
-			},
-		},
-		{
 			name:   "invalid stack.tags - starting with uppercase - fails",
 			layout: []string{`s:stack:tags=["Abc"]`},
 			want: RunExpected{
@@ -222,6 +214,14 @@ func listTestcases() []testcase {
 			want: RunExpected{
 				StderrRegex: string(config.ErrStackInvalidTag),
 				Status:      1,
+			},
+		},
+		{
+			name:       "stack.tags starting with number - works",
+			layout:     []string{`s:stack:tags=["123abc"]`},
+			filterTags: []string{"123abc"},
+			want: RunExpected{
+				Stdout: nljoin("stack"),
 			},
 		},
 		{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/terramate-io/terramate/blob/main/CONTRIBUTING.md
2. If the PR is unfinished, mark it as draft: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request
3. Please update the PR title using the Conventional Commits convention: https://www.conventionalcommits.org/en/v1.0.0/
    Example: feat: add support for XYZ.
-->

## What this PR does / why we need it:

Originally, allowed format of tags was based on common rules for HCL identifiers, but there is no technical reason for that, so we drop another restriction here to allow tags that start with numbers.

## Does this PR introduce a user-facing change?
<!--
If no, just write "no" in the block below.
If yes, please explain the change and update documentation and the CHANGELOG.md file accordingly.
-->
```
yes, see changelog
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Allow tags to start with digits by relaxing validation and updating tests and changelog.
> 
> - **Tags/Validation**:
>   - Relax `config/tag/tag.go` to permit tags starting with lowercase alphanumeric (`[0-9a-z]`) instead of only letters.
>   - Update validation error messages accordingly.
> - **Tests**:
>   - Remove failure case for numeric-leading tags and add passing case in `e2etests/core/list_test.go`.
> - **Docs**:
>   - Update `CHANGELOG.md` under `v0.15.0` to note support for tags starting with numbers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0ddead3394bb521bbc56b615153f6f81999f1fed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->