### PR TITLE
feat: add version --full flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
   - `--exclude-all-dependents`: Remove all dependent stacks from the selection
   - Support for both Terragrunt and Terramate dependencies in the new dependency flags
 - Add go-to definitions and symbol renaming capabilities to the language server for `globals`, `let` and `terramate.run.env.*` statements
+- Add `--full` flag to `terramate version` to include the full product name in the version output.
 
 ### Fixed
 

--- a/commands/version/version.go
+++ b/commands/version/version.go
@@ -17,6 +17,7 @@ import (
 
 // Spec represents the version command specification.
 type Spec struct {
+	Full     bool
 	InfoChan chan *checkpoint.CheckResponse
 }
 
@@ -28,9 +29,7 @@ func (s *Spec) Requirements(context.Context, commands.CLI) any { return nil }
 
 // Exec executes the version command.
 func (s *Spec) Exec(ctx context.Context, cli commands.CLI) error {
-	// TODO(snk): Using the <product> <version> output would be a breaking change.
-	// We change this separately later.
-	if cli.Product() != "terramate" {
+	if s.Full {
 		fmt.Printf("%s %s\n", cli.Product(), cli.Version())
 	} else {
 		fmt.Println(cli.Version())

--- a/ui/tui/cli_handler.go
+++ b/ui/tui/cli_handler.go
@@ -54,12 +54,7 @@ func handleRootVersionFlagAlone(parsedSpec any, _ *CLI) (name string, val any, r
 
 	if p.VersionFlag {
 		return "--version", p.VersionFlag, func(c *CLI, _ any) error {
-			// TODO(snk): We change this later.
-			if c.Product() != "terramate" {
-				fmt.Printf("%s %s\n", c.Product(), c.Version())
-			} else {
-				fmt.Println(c.Version())
-			}
+			fmt.Println(c.Version())
 			return nil
 		}, true
 	}
@@ -88,6 +83,7 @@ func SelectCommand(ctx context.Context, c *CLI, command string, flags any) (cmd 
 	case "version":
 		return &version.Spec{
 			InfoChan: c.checkpointResponse,
+			Full:     parsedArgs.Version.Full,
 		}, nil
 
 	case "install-completions":

--- a/ui/tui/cli_spec.go
+++ b/ui/tui/cli_spec.go
@@ -178,7 +178,9 @@ type FlagSpec struct {
 
 	InstallCompletions kongplete.InstallCompletions `cmd:"" help:"Install shell completions."`
 
-	Version struct{} `cmd:"" help:"Show Terramate version"`
+	Version struct {
+		Full bool `help:"Include the product name in the version output"`
+	} `cmd:"" help:"Show Terramate version"`
 }
 
 type globalCliFlags struct {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/terramate-io/terramate/blob/main/CONTRIBUTING.md
2. If the PR is unfinished, mark it as draft: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request
3. Please update the PR title using the Conventional Commits convention: https://www.conventionalcommits.org/en/v1.0.0/
    Example: feat: add support for XYZ.
-->

## What this PR does / why we need it:

This PR adds new flag `--full` to the version command to show the product name in front of the version. Example:
```
> terramate version --full
terramate 0.15.0
```

## Does this PR introduce a user-facing change?
<!--
If no, just write "no" in the block below.
If yes, please explain the change and update documentation and the CHANGELOG.md file accordingly.
-->
```
yes, changelog will be updated in release PR.
```


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `version --full` to print `<product> <version>`, wires flag through CLI, and updates changelog.
> 
> - **CLI / Version**
>   - Add `Spec.Full` to `commands/version/version.go`; when set, `Exec` prints ``<product> <version>``; otherwise prints version only.
>   - Extend CLI spec: add `Version.Full` flag and pass it to `version.Spec` in `ui/tui/cli_handler.go`.
>   - Simplify root `--version` handler to always print version only.
> - **Docs**
>   - Update `CHANGELOG.md` with `terramate version --full` addition.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 878da3d6c6aae238b5ca90a302a6f44795d1f737. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->