### PR TITLE
fix: tokenizing tm_slug(null) in collection types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 
 - Add support for multi-project workspaces to Terramate language server.
 
+### Fixed
+
+- Fix `tm_slug(null)` expressions turning their containing HCL collection types to `null` during code generation.
+
 ## 0.15.0
 
 ### Changed

--- a/hcl/ast/value.go
+++ b/hcl/ast/value.go
@@ -31,10 +31,11 @@ func (builder *tokenBuilder) fromValue(val cty.Value) {
 		builder.fromExpr(customdecode.ExpressionFromVal(val))
 	case val.IsNull():
 		builder.add(ident("null", 0))
-	case !val.IsWhollyKnown():
+	case !val.IsKnown():
 		// Handle unknown values (including dynamic pseudo-type unknowns)
 		// These represent values that couldn't be resolved during evaluation
 		// Render as null to avoid panics when trying to extract concrete values
+		// TODO(snk): Implement tm_slug differently, then we can probably remove this.
 		builder.add(ident("null", 0))
 	case typ == cty.Bool:
 		if val.True() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/terramate-io/terramate/blob/main/CONTRIBUTING.md
2. If the PR is unfinished, mark it as draft: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request
3. Please update the PR title using the Conventional Commits convention: https://www.conventionalcommits.org/en/v1.0.0/
    Example: feat: add support for XYZ.
-->

## What this PR does / why we need it:

The change done in #2206 will cause an expression with any collection type (object, map, list, tuple) that contains an unknown value to be tokenized as `null`. This affects more than just `tm_slug(null) -> null`.

The PR relaxes this to unknown values themselves rather than their containing expression and also refactors the respective tests so that they test whats closer to the actual usage scenario.

## Does this PR introduce a user-facing change?
<!--
If no, just write "no" in the block below.
If yes, please explain the change and update documentation and the CHANGELOG.md file accordingly.
-->
```
yes, see changelog
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure `tm_slug(null)` no longer turns enclosing HCL collections into `null` during codegen by treating only unknown values as `null`, and update tests accordingly.
> 
> - **HCL AST/tokenization**:
>   - Use `val.IsKnown()` instead of `IsWhollyKnown()` to detect unknowns and render only unknown values as `null`.
>   - Preserve collection structures when elements are dynamic/null (e.g., `{a="hello", b=tm_slug(null)}` tokenizes to `b=null`).
> - **Stdlib tests (`tm_slug`)**:
>   - Refactor eval tests to assert `cty.Value` equality and add cases for `tm_slug(null)` and within objects.
>   - Add tokenization assertion showing objects with dynamic/null members render correctly.
> - **Changelog**:
>   - Document fix for `tm_slug(null)` no longer turning containing HCL collection types to `null` during code generation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb8675fa83bb0a49460b4ff4c0e4d34e6a246fbf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->