### PR TITLE
fix(bitbucket): remove trailing comma in API calls

### DIFF
--- a/cloud/integrations/bitbucket/bitbucket.go
+++ b/cloud/integrations/bitbucket/bitbucket.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/terramate-io/terramate/errors"
@@ -178,13 +179,13 @@ func (c *Client) GetPullRequestsByCommit(ctx context.Context, commit string) (pr
 		"links",
 	}
 
-	fieldsQuery := ""
+	var fieldsQuery []string
 	for _, f := range fields {
-		fieldsQuery += fmt.Sprintf("values.%s,", f)
+		fieldsQuery = append(fieldsQuery, fmt.Sprintf("values.%s", f))
 	}
 
 	url := fmt.Sprintf("%s/repositories/%s/%s/commit/%s/pullrequests?fields=%s",
-		c.baseURL(), c.Workspace, c.RepoSlug, commit, fieldsQuery)
+		c.baseURL(), c.Workspace, c.RepoSlug, commit, strings.Join(fieldsQuery, ","))
 
 	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {

--- a/cloud/integrations/bitbucket/bitbucket_test.go
+++ b/cloud/integrations/bitbucket/bitbucket_test.go
@@ -1,0 +1,47 @@
+package bitbucket
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestClient_GetPullRequestsByCommit_TrailingComma(t *testing.T) {
+	// Setup a mock server that checks for the trailing comma
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Check that the URL path and query parameters are correct
+		if !strings.Contains(r.URL.Path, "/repositories/workspace/repo/commit/commit-hash/pullrequests") {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		fields := r.URL.Query().Get("fields")
+		// Assert that 'fields' query parameter does NOT end with a comma
+		if strings.HasSuffix(fields, ",") {
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte("Trailing comma detected in fields parameter"))
+			return
+		}
+
+		// Return a valid empty response if the request is correct
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"values": []}`))
+	}))
+	defer server.Close()
+
+	client := Client{
+		BaseURL:   server.URL,
+		Workspace: "workspace",
+		RepoSlug:  "repo",
+		Token:     "token",
+	}
+
+	_, err := client.GetPullRequestsByCommit(context.Background(), "commit-hash")
+
+	// We expect NO error now
+	if err != nil {
+		t.Fatalf("Expected no error, but got: %v", err)
+	}
+}


### PR DESCRIPTION
## What this PR does / why we need it:
This PR fixes a bug in the Bitbucket integration where the [GetPullRequestsByCommit](cci:1://file:///Users/evfedoto/Documents/Projects/terramate/cloud/integrations/bitbucket/bitbucket.go:154:0-228:1) method was generating an invalid API URL.

The `fields` query parameter was being constructed by manually concatenating strings with a comma, which resulted in a **trailing comma** at the end of the query (e.g., `?fields=values.id,values.title,`). The Bitbucket Cloud API is strict and rejects these requests with a `400 Bad Request` error.

This change updates [cloud/integrations/bitbucket/bitbucket.go](cci:7://file:///Users/evfedoto/Documents/Projects/terramate/cloud/integrations/bitbucket/bitbucket.go:0:0-0:0) to use `strings.Join` for constructing the `fields` parameter, ensuring no trailing comma is added. It also adds a regression test.

## Which issue(s) this PR fixes:
Fixes `400 Bad Request` errors when using Bitbucket Pipelines integration.

## Special notes for your reviewer:
I added a new test file [cloud/integrations/bitbucket/bitbucket_test.go](cci:7://file:///Users/evfedoto/Documents/Projects/terramate/cloud/integrations/bitbucket/bitbucket_test.go:0:0-0:0) which reproduces the bug (it fails without the fix) and passes with the fix.

## Does this PR introduce a user-facing change?
yes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Constructs the Bitbucket `fields` query using `strings.Join` to avoid a trailing comma and adds a test to prevent regressions.
> 
> - **Bitbucket integration**:
>   - Update `GetPullRequestsByCommit` in `cloud/integrations/bitbucket/bitbucket.go` to build `fields` via `strings.Join`, eliminating the trailing comma in the query string.
> - **Tests**:
>   - Add `cloud/integrations/bitbucket/bitbucket_test.go` with a mock server test ensuring the `fields` parameter does not end with a comma.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4d20cde713a37df31fb9303ae633f02e4291466e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->