### PR TITLE
chore: upgrade to macos-15 runners

### DIFF
--- a/.github/workflows/ci-sync-deployment.yml
+++ b/.github/workflows/ci-sync-deployment.yml
@@ -26,8 +26,8 @@ jobs:
         os:
           - name: ubuntu
             value: "blacksmith-4vcpu-ubuntu-2404"
-          - name: macos-ventura
-            value: "macos-13"
+          - name: macos-15
+            value: "macos-15"
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4

--- a/.github/workflows/ci-sync-preview.yml
+++ b/.github/workflows/ci-sync-preview.yml
@@ -23,8 +23,8 @@ jobs:
         os:
           - name: ubuntu
             value: "blacksmith-4vcpu-ubuntu-2404"
-          - name: macos-ventura
-            value: "macos-13"
+          - name: macos-15
+            value: "macos-15"
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/terramate-io/terramate/blob/main/CONTRIBUTING.md
2. If the PR is unfinished, mark it as draft: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request
3. Please update the PR title using the Conventional Commits convention: https://www.conventionalcommits.org/en/v1.0.0/
    Example: feat: add support for XYZ.
-->

## What this PR does / why we need it:

`mac-13` runners will be deprecated.

## Does this PR introduce a user-facing change?
<!--
If no, just write "no" in the block below.
If yes, please explain the change and update documentation and the CHANGELOG.md file accordingly.
-->
```
no
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update CI matrices to use macos-15 instead of macos-13 in deployment and preview workflows.
> 
> - **CI Workflows**:
>   - Update OS matrix in `.github/workflows/ci-sync-deployment.yml` and `.github/workflows/ci-sync-preview.yml`:
>     - Replace `macos-ventura`/`macos-13` with `macos-15`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e319475d808ea0f9140eb83d743a20ab31f1da5c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->