### PR TITLE
fix: terramate list --changed --why flag not working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 - Add orchestration metadata fields to `terramate debug show metadata` command output.
   - The command now displays `before`, `after`, `wants`, and `wanted_by` fields for each stack.
 
+### Fixed
+
+- Fix `terramate list --changed --why` flag not working.
+
 ## 0.15.5
 
 ### Fixed

--- a/commands/stack/list/list.go
+++ b/commands/stack/list/list.go
@@ -99,7 +99,7 @@ func (s *Spec) printStacksList(allStacks []stack.Entry) error {
 	stacks := make(config.List[*config.SortableStack], len(filteredStacks))
 	for i, entry := range filteredStacks {
 		stacks[i] = entry.Stack.Sortable()
-		reasons[entry.Stack.ID] = entry.Reason
+		reasons[entry.Stack.Dir.String()] = entry.Reason
 	}
 
 	// Apply dependency filters
@@ -127,7 +127,7 @@ func (s *Spec) printStacksList(allStacks []stack.Entry) error {
 			continue
 		}
 		if s.Reason {
-			printer.Stdout.Println(fmt.Sprintf("%s - %s", friendlyDir, reasons[st.ID]))
+			printer.Stdout.Println(fmt.Sprintf("%s - %s", friendlyDir, reasons[dir]))
 		} else {
 			printer.Stdout.Println(friendlyDir)
 		}

--- a/ui/tui/cli_handler.go
+++ b/ui/tui/cli_handler.go
@@ -199,6 +199,7 @@ func SelectCommand(ctx context.Context, c *CLI, command string, flags any) (cmd 
 		}
 		return &listcmd.Spec{
 			GitFilter: gitfilter,
+			Reason:    parsedArgs.List.Why,
 			Target:    parsedArgs.List.Target,
 			StatusFilters: listcmd.StatusFilters{
 				StackStatus:      statusStr,


### PR DESCRIPTION
## What this PR does / why we need it:

Fixes the `--why` flag for `terramate list --changed` command which stopped working since version 0.14.0. The flag was being parsed correctly but never passed to the command spec, causing it to have no effect.

Additionally, fixes an issue where reasons were stored using stack ID (which can be empty), causing problems with reason lookup for stacks without IDs.

## Which issue(s) this PR fixes:

Fixes #2260

## Special notes for your reviewer:

- The `--why` flag is now properly passed from CLI parsing to the command spec
- Reason lookup now uses stack directory path instead of stack ID, ensuring it works for all stacks regardless of whether they have an ID
- This maintains backward compatibility and doesn't change the output format

## Does this PR introduce a user-facing change?
```
Yes. The `--why` flag now works correctly with `terramate list --changed`, showing the reason why each stack was marked as changed. This restores functionality that was present in version 0.11.0 but stopped working in later versions.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CLI wiring and lookup-key change limited to `list --why` output; no changes to selection/filtering logic or data persistence.
> 
> **Overview**
> Restores `terramate list --changed --why` output by wiring the parsed `--why` flag through the TUI/CLI command selection into `listcmd.Spec`.
> 
> Fixes reason reporting for stacks without IDs by keying change reasons by stack directory (instead of `stack.id`) when building and printing the `--why` output. Updates the changelog accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1418ea198a2fed935434b8128564c417d240a034. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->