### PR TITLE
feat: add CLI.Reload hook runner

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -44,7 +44,7 @@ type CLI interface {
 	Config() cliconfig.Config
 
 	// Engine returns the engine.
-	// Will only be available for commands that have the engine requirement.
+	// Will only be available for commands that have EngineRequirement.
 	Engine() *engine.Engine
 
 	// Reload reloads the engine config and re-runs post-init hooks.

--- a/ui/tui/cli.go
+++ b/ui/tui/cli.go
@@ -217,6 +217,9 @@ func (c *CLI) Printers() printer.Printers { return c.printers }
 
 // Reload reloads the engine configuration and re-runs post-init hooks.
 func (c *CLI) Reload(ctx context.Context) error {
+	if c.state.engine == nil {
+		return errors.E("engine not initialized: Reload requires EngineRequirement")
+	}
 	if err := c.state.engine.ReloadConfig(); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary
- add `CLI.Reload(ctx)` to reload config and re-run post-init hooks
- implement reload on `*tui.CLI`

## Test plan
- [x] go test ./ui/tui/...

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core CLI/command interfaces and re-invokes initialization hooks, which could affect multiple commands if hook ordering or side effects aren’t reload-safe. Scope is small and gated on engine initialization.
> 
> **Overview**
> Adds `CLI.Reload(ctx)` to the `commands.CLI` interface so engine-dependent commands can **reload engine configuration and re-run post-init engine hooks** without restarting the process.
> 
> Implements `Reload` on `*tui.CLI`: validates the engine is initialized (requires `EngineRequirement`), calls `engine.ReloadConfig()`, then re-invokes all registered `postInitEngineHooks` and returns the first error.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b5a75ee48e35022ac2c0ad1aec19991151406b81. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->