### PR TITLE
fix: Recognize generated files converted to CRLF

### DIFF
--- a/generate/generate.go
+++ b/generate/generate.go
@@ -1275,6 +1275,16 @@ func hasGenHCLHeader(commentStyle genhcl.CommentStyle, code string) bool {
 		if strings.HasPrefix(code, header) {
 			return true
 		}
+		// Make sure to recognize headers also if the generated file has been converted
+		// to CRLF headers. Terramate itself never generates a file with CRLF headers, but
+		// this can happen if a tool, such as Git on Windows, converts the file endings
+		// to CRLF on checkout, e.g. if core.autocrlf.input is set to true, which is the
+		// default on Windows.
+		// Fixes bug: https://github.com/terramate-io/terramate/issues/2290
+		header_crlf := strings.ReplaceAll(header, "\n", "\r\n")
+		if strings.HasPrefix(code, header_crlf) {
+			return true
+		}
 	}
 	return false
 }

--- a/generate/generate_hcl_test.go
+++ b/generate/generate_hcl_test.go
@@ -2121,6 +2121,35 @@ func TestWontOverwriteManuallyDefinedTerraform(t *testing.T) {
 	assert.EqualStrings(t, manualTfCode, actualTfCode, "tf code altered by generate")
 }
 
+func TestWillOverwriteGeneratedTerraformConvertedToCrlf(t *testing.T) {
+	t.Parallel()
+
+	const (
+		genFilename  = "test.tf"
+		generatedTfCode = "// TERRAMATE: GENERATED AUTOMATICALLY DO NOT EDIT\r\n\r\nlocals {}\r\n"
+	)
+
+	generateHCLConfig := GenerateHCL(
+		Labels(genFilename),
+		Content(
+			Terraform(
+				Str("required_version", "1.11"),
+			),
+		),
+	)
+
+	s := sandbox.NoGit(t, true)
+	s.BuildTree([]string{
+		fmt.Sprintf("f:%s:%s", terramate.DefaultFilename, generateHCLConfig.String()),
+		"s:stack",
+		fmt.Sprintf("f:stack/%s:%s", genFilename, generatedTfCode),
+	})
+
+	generateAPI := newGenerateAPIForTest(t)
+	report := generateAPI.Do(s.Config(), project.NewPath("/"), 0, project.NewPath("/modules"), nil)
+	assert.EqualInts(t, 1, len(report.Successes), "want success")
+}
+
 func TestGenerateHCLStackFilters(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/terramate-io/terramate/blob/main/CONTRIBUTING.md
2. If the PR is unfinished, mark it as draft: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request
3. Please update the PR title using the Conventional Commits convention: https://www.conventionalcommits.org/en/v1.0.0/
    Example: feat: add support for XYZ.
-->

## What this PR does / why we need it:

terramate generate would refuse to overwrite files generated by terramate, incorrectly flagging them as manually generated files, if the file had been converted from LF to CRLF linebreaks.

This fix will allow terramate to still recognize its own headers even if the linebreaks have been mangled.



## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Keep it empty if not applicable.
-->
Fixes #2290

## Special notes for your reviewer:

First time programming in Go, so I've tried to keep the code as boring/simple as possible

## Does this PR introduce a user-facing change?
<!--
If no, just write "no" in the block below.
If yes, please explain the change and update documentation and the CHANGELOG.md file accordingly.
-->
```
no
```


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small change to generated-header prefix detection plus a regression test; the main risk is only in potentially misclassifying a file as generated, but matching is still limited to Terramate’s known headers.
> 
> **Overview**
> Prevents `terramate generate` from treating previously generated files as “manual code” when those files had their line endings converted to CRLF (common on Windows checkouts).
> 
> Updates `hasGenHCLHeader()` to also accept CRLF-normalized variants of the known Terramate headers, and adds a regression test ensuring generation succeeds (overwrites) when an existing generated Terraform file contains a CRLF header.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a0cae42835f846e90a9b8c8fa3587ff86404c7d6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->