### PR TITLE
fix: improve scaling

### DIFF
--- a/commands/ui/inputs_form.go
+++ b/commands/ui/inputs_form.go
@@ -100,13 +100,27 @@ type InputsForm struct {
 	// Validation error shown at the top of the completed panel (e.g. from finalizeChange).
 	validationErr error
 
+	// Layout — dynamic panel dimensions; 0 means use defaults.
+	PanelWidth  int
+	PanelHeight int
+
 	// Result
 	state InputsFormState
 }
 
+// effectivePanelHeight returns the Height() budget for the input-form panel.
+// When PanelHeight has been set (via WindowSizeMsg), it is used directly;
+// otherwise a default derived from minContentHeight is returned.
+func (f InputsForm) effectivePanelHeight() int {
+	if f.PanelHeight > 0 {
+		return f.PanelHeight
+	}
+	return minContentHeight + 6
+}
+
 // NewInputsForm creates a new inputs form for the given inputs and schemas
 func NewInputsForm(inputDefs []*config.InputDefinition, schemactx typeschema.EvalContext, registry *Registry, env *config.Environment) InputsForm {
-	vp := viewport.New(uiWidth, uiInputsPanelHeight)
+	vp := viewport.New(uiWidth, minContentHeight+6)
 	vp.SetContent("")
 
 	prompted := filterPrompted(inputDefs)
@@ -147,7 +161,7 @@ func NewInputsForm(inputDefs []*config.InputDefinition, schemactx typeschema.Eva
 
 // NewInputsFormWithValues creates an inputs form pre-populated with existing values.
 func NewInputsFormWithValues(inputDefs []*config.InputDefinition, schemactx typeschema.EvalContext, registry *Registry, env, fromEnv *config.Environment, values, originalValues map[string]cty.Value) InputsForm {
-	vp := viewport.New(uiWidth, uiInputsPanelHeight)
+	vp := viewport.New(uiWidth, minContentHeight+6)
 	vp.SetContent("")
 
 	prompted := filterPrompted(inputDefs)
@@ -961,7 +975,10 @@ func (f InputsForm) updateButtons(msg tea.KeyMsg) (InputsForm, tea.Cmd) {
 //
 // Review mode (edit-change) renders a single review list instead.
 func (f InputsForm) View() string {
-	panelWidth := uiWidth
+	panelWidth := f.PanelWidth
+	if panelWidth <= 0 {
+		panelWidth = uiWidth
+	}
 	innerWidth := panelWidth - 6 // border (2) + padding (4)
 
 	sectionTitleStyle := lipgloss.NewStyle().Bold(true).Foreground(colorText)
@@ -1069,7 +1086,7 @@ func (f InputsForm) View() string {
 
 	// Compute available height for the bottom panel.
 	topHeight := lipgloss.Height(topPanel)
-	botMaxContent := uiInputsPanelHeight - topHeight - botBorderOverhead - botTitleLines
+	botMaxContent := f.effectivePanelHeight() - topHeight - botBorderOverhead - botTitleLines
 	if botMaxContent < 1 {
 		botMaxContent = 1
 	}
@@ -1119,7 +1136,7 @@ func (f InputsForm) View() string {
 	}
 
 	// Fix the bottom panel height so the total layout stays consistent.
-	botFixedHeight := uiInputsPanelHeight - topHeight
+	botFixedHeight := f.effectivePanelHeight() - topHeight
 	if botFixedHeight < 6 {
 		botFixedHeight = 6
 	}
@@ -1176,7 +1193,7 @@ func (f InputsForm) renderSingleCompletedPanel(
 
 	completedContent := f.renderCompletedPanelContent()
 
-	maxContent := uiInputsPanelHeight - borderOverhead - titleLines
+	maxContent := f.effectivePanelHeight() - borderOverhead - titleLines
 	if maxContent < 1 {
 		maxContent = 1
 	}
@@ -1216,7 +1233,7 @@ func (f InputsForm) renderSingleCompletedPanel(
 	}
 	parts = append(parts, contentBlock)
 	inner := lipgloss.JoinVertical(lipgloss.Left, parts...)
-	return focusedBorder.Height(uiInputsPanelHeight - borderOverhead).Render(inner)
+	return focusedBorder.Height(f.effectivePanelHeight() - borderOverhead).Render(inner)
 }
 
 // renderScrollbar renders a vertical scrollbar track with a thumb.
@@ -1458,7 +1475,7 @@ func (f InputsForm) renderActiveSection() string {
 
 		var lines []string
 		if def.Description != "" {
-			descStyle := activeDescStyle.PaddingLeft(2).Width(f.activeWidget.WidgetContext().Width - 6)
+			descStyle := activeDescStyle.PaddingLeft(2).Width(f.activeWidget.WidgetContext().Width)
 			lines = append(lines, descStyle.Render(def.Description), "")
 		}
 

--- a/commands/ui/model.go
+++ b/commands/ui/model.go
@@ -183,9 +183,47 @@ type Model struct {
 	cancelled bool
 }
 
-const uiWidth = 100
-const uiContentHeight = 26                          // Max visible content lines inside bordered panels
-const uiInputsPanelHeight = uiContentHeight + 2 + 4 // Match select-panel outer height (content + padding + border)
+const uiWidth = 100         // Default/preferred panel width
+const minPanelWidth = 72    // Minimum panel width (fits 80-col terminals)
+const minContentHeight = 12 // Minimum visible content lines inside bordered panels
+
+// effectiveContentHeight returns the number of content lines available inside
+// bordered panels, scaling with the terminal height. The value is clamped to a
+// minimum of minContentHeight so the UI stays usable on small terminals.
+func (m Model) effectiveContentHeight() int {
+	if m.height <= 0 {
+		return minContentHeight
+	}
+	// Chrome: outer padding(2) + header(1) + help(1) + border(2) + inner padding(2) + margin(2) = 10
+	h := m.height - 10
+	if h < minContentHeight {
+		return minContentHeight
+	}
+	return h
+}
+
+// effectiveInputsPanelHeight returns the Height() budget for input-form panels.
+// It equals effectiveContentHeight()+6 so that input-form views fill the same
+// terminal space as select-panel views.
+func (m Model) effectiveInputsPanelHeight() int {
+	return m.effectiveContentHeight() + 6
+}
+
+// effectiveWidth returns the effective panel width for views,
+// clamped between minPanelWidth and uiWidth*2 based on available terminal space.
+func (m Model) effectiveWidth() int {
+	if m.width <= 0 {
+		return uiWidth
+	}
+	w := m.width - 6 // outer Padding(1, 2) = 2 left + 2 right + border 1 left + 1 right
+	if w < minPanelWidth {
+		return minPanelWidth
+	}
+	if w > uiWidth*2 {
+		return uiWidth * 2
+	}
+	return w
+}
 
 // NewModel creates a new prompt model.
 func NewModel(est *EngineState) Model {
@@ -238,6 +276,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height
+		m.inputsForm.PanelWidth = m.effectiveWidth()
+		m.inputsForm.PanelHeight = m.effectiveInputsPanelHeight()
 		return m, nil
 
 	case ctrlCResetMsg:

--- a/commands/ui/theme.go
+++ b/commands/ui/theme.go
@@ -15,7 +15,6 @@ var (
 	// Primary brand colors
 	colorPrimary   = lipgloss.AdaptiveColor{Light: "#7C3AED", Dark: "#A78BFA"} // Purple/Violet
 	colorSecondary = lipgloss.AdaptiveColor{Light: "#059669", Dark: "#34D399"} // Green
-	colorAccent    = lipgloss.AdaptiveColor{Light: "#0891B2", Dark: "#22D3EE"} // Cyan
 
 	// Semantic colors
 	colorError   = lipgloss.AdaptiveColor{Light: "#DC2626", Dark: "#F87171"} // Red

--- a/commands/ui/view_cloud_login.go
+++ b/commands/ui/view_cloud_login.go
@@ -82,17 +82,19 @@ func (m Model) nextViewAfterCloudLogin() ViewState {
 }
 
 func (m Model) renderCloudLoginView() string {
+	panelWidth := m.effectiveWidth()
+
 	borderStyle := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(colorBorderFocus).
 		Padding(1, 2).
-		Width(uiWidth)
+		Width(panelWidth)
 
 	helpStyle := lipgloss.NewStyle().
 		Foreground(colorTextMuted).
-		Width(uiWidth)
+		Width(panelWidth)
 
-	header := m.renderHeader("welcome")
+	header := m.renderHeader("welcome", panelWidth)
 
 	titleStyle := lipgloss.NewStyle().
 		Bold(true).

--- a/commands/ui/view_create.go
+++ b/commands/ui/view_create.go
@@ -161,6 +161,8 @@ func (m Model) updateCreateInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 		schemactx := m.inputsForm.Schemactx.ChildContext()
 		m.inputsForm = NewInputsForm(req.InputDefs, schemactx, est.Registry, m.selectedEnv)
+		m.inputsForm.PanelWidth = m.effectiveWidth()
+		m.inputsForm.PanelHeight = m.effectiveInputsPanelHeight()
 		if req.EditMode {
 			m.inputsForm.SeedValues(req.Values)
 		}
@@ -205,9 +207,10 @@ func setupExplicitBundleAlias(evalctx *eval.Context, bundleDef *hcl.DefineBundle
 
 func (m Model) renderCreateInputView() string {
 	est := m.EngineState
+	panelWidth := m.effectiveWidth()
 	helpStyle := lipgloss.NewStyle().
 		Foreground(colorTextMuted).
-		Width(uiWidth)
+		Width(panelWidth)
 
 	collName := strings.ToLower(est.Collections[m.selectedCollIdx].Name)
 	bundleName := ""
@@ -223,7 +226,7 @@ func (m Model) renderCreateInputView() string {
 		headerContext = fmt.Sprintf("add bundle / %s / %s", collName, bundleName)
 	}
 
-	title := m.renderHeader(headerContext)
+	title := m.renderHeader(headerContext, panelWidth)
 
 	var help string
 	if m.confirmingCreateExit {
@@ -263,7 +266,7 @@ func (m Model) renderCreateInputView() string {
 		if name := m.inputsForm.HighlightedInputName(); name != "" {
 			hintRendered := lipgloss.NewStyle().Foreground(colorTextMuted).Render("[" + name + "]")
 			leftRendered := lipgloss.NewStyle().Foreground(colorTextMuted).Render(helpText)
-			gap := uiWidth + 2 - lipgloss.Width(leftRendered) - lipgloss.Width(hintRendered)
+			gap := panelWidth + 2 - lipgloss.Width(leftRendered) - lipgloss.Width(hintRendered)
 			if gap < 2 {
 				gap = 2
 			}

--- a/commands/ui/view_create_select.go
+++ b/commands/ui/view_create_select.go
@@ -167,6 +167,8 @@ func (m *Model) loadBundleDef(collIdx, bundleIdx int) error {
 	m.selectedBundleDefEntry = bde
 	m.selectedBundleSource = source
 	m.inputsForm = NewInputsForm(inputDefs, schemactx, est.Registry, m.selectedEnv)
+	m.inputsForm.PanelWidth = m.effectiveWidth()
+	m.inputsForm.PanelHeight = m.effectiveInputsPanelHeight()
 	return nil
 }
 
@@ -232,18 +234,19 @@ func checkBundleEnabled(evalctx *eval.Context, def *hcl.DefineBundle) error {
 
 func (m Model) renderBundleSelectView() string {
 	est := m.EngineState
-	innerWidth := uiWidth - 4
+	panelWidth := m.effectiveWidth()
+	innerWidth := panelWidth - 4
 
 	borderStyle := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(colorBorderFocus).
 		Padding(1, 2).
-		Width(uiWidth).
-		Height(uiContentHeight + 2)
+		Width(panelWidth).
+		Height(m.effectiveContentHeight() + 2)
 
 	helpStyle := lipgloss.NewStyle().
 		Foreground(colorTextMuted).
-		Width(uiWidth)
+		Width(panelWidth)
 
 	contentStyle := lipgloss.NewStyle().
 		Width(innerWidth)
@@ -258,7 +261,7 @@ func (m Model) renderBundleSelectView() string {
 		headerContext = fmt.Sprintf("add bundle / %s", collName)
 	}
 
-	title := m.renderHeader(headerContext)
+	title := m.renderHeader(headerContext, panelWidth)
 
 	helpText := m.finalHelpText("esc: back")
 	help := helpStyle.Render(helpText)
@@ -367,7 +370,7 @@ func renderScrollbar(totalItems, visibleCount, offset, trackHeight int) string {
 
 func (m Model) renderCollectionPage() string {
 	est := m.EngineState
-	innerWidth := uiWidth - 4
+	innerWidth := m.effectiveWidth() - 4
 	scrollbarGutter := 4 // left gap(1) + scrollbar(1) + right gap(2)
 	contentWidth := innerWidth - scrollbarGutter
 
@@ -403,7 +406,7 @@ func (m Model) renderCollectionPage() string {
 	desc := descStyle.Render("Choose a collection containing bundles")
 	header := lipgloss.JoinVertical(lipgloss.Left, title, desc, "")
 	headerHeight := lipgloss.Height(header)
-	availableHeight := uiContentHeight - headerHeight
+	availableHeight := m.effectiveContentHeight() - headerHeight
 
 	var items []renderedItem
 	for i, coll := range est.Collections {
@@ -443,7 +446,7 @@ func (m Model) renderCollectionPage() string {
 
 func (m Model) renderBundlePage() string {
 	est := m.EngineState
-	innerWidth := uiWidth - 4
+	innerWidth := m.effectiveWidth() - 4
 	scrollbarGutter := 4 // left gap(1) + scrollbar(1) + right gap(2)
 	contentWidth := innerWidth - scrollbarGutter
 
@@ -479,7 +482,7 @@ func (m Model) renderBundlePage() string {
 	desc := descStyle.Render(fmt.Sprintf("Bundles in %s", coll.Name))
 	header := lipgloss.JoinVertical(lipgloss.Left, title, desc, "")
 	headerHeight := lipgloss.Height(header)
-	availableHeight := uiContentHeight - headerHeight
+	availableHeight := m.effectiveContentHeight() - headerHeight
 
 	var items []renderedItem
 	for i, bundle := range coll.Bundles {

--- a/commands/ui/view_edit.go
+++ b/commands/ui/view_edit.go
@@ -103,19 +103,22 @@ func (m *Model) openEditChange(idx int) error {
 		change.InputDefs, schemactx, m.EngineState.Registry, change.Env, change.FromEnv,
 		change.Values, change.OriginalValues,
 	)
+	m.inputsForm.PanelWidth = m.effectiveWidth()
+	m.inputsForm.PanelHeight = m.effectiveInputsPanelHeight()
 
 	m.viewState = ViewEdit
 	return nil
 }
 
 func (m Model) renderEditChangeView() string {
+	panelWidth := m.effectiveWidth()
 	helpStyle := lipgloss.NewStyle().
 		Foreground(colorTextMuted).
-		Width(uiWidth)
+		Width(panelWidth)
 
 	change := m.PendingChanges()[m.editingChangeIdx]
 	headerContext := fmt.Sprintf("edit bundle / %s", change.Name)
-	title := m.renderHeader(headerContext)
+	title := m.renderHeader(headerContext, panelWidth)
 
 	formView := m.inputsForm.View()
 

--- a/commands/ui/view_env_select.go
+++ b/commands/ui/view_env_select.go
@@ -31,18 +31,20 @@ func (m Model) updateEnvSelect(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 func (m Model) renderEnvSelectView() string {
 	est := m.EngineState
+	panelWidth := m.effectiveWidth()
+
 	borderStyle := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(colorBorderFocus).
 		Padding(1, 2).
-		Width(uiWidth).
-		Height(uiContentHeight + 2)
+		Width(panelWidth).
+		Height(m.effectiveContentHeight() + 2)
 
 	helpStyle := lipgloss.NewStyle().
 		Foreground(colorTextMuted).
-		Width(uiWidth)
+		Width(panelWidth)
 
-	header := m.renderHeader("select environment")
+	header := m.renderHeader("select environment", panelWidth)
 
 	titleStyle := lipgloss.NewStyle().
 		Bold(true).

--- a/commands/ui/view_overview.go
+++ b/commands/ui/view_overview.go
@@ -349,7 +349,8 @@ func changeLogEntry(c Change) string {
 
 func (m Model) renderOverviewView() string {
 	est := m.EngineState
-	innerWidth := uiWidth - 4
+	panelWidth := m.effectiveWidth()
+	innerWidth := panelWidth - 4
 
 	sectionTitleStyle := lipgloss.NewStyle().
 		Bold(true).
@@ -359,24 +360,24 @@ func (m Model) renderOverviewView() string {
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(colorBorderFocus).
 		Padding(1, 2).
-		Width(uiWidth)
+		Width(panelWidth)
 
 	unfocusedBorderStyle := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(colorBorder).
 		Padding(1, 2).
-		Width(uiWidth)
+		Width(panelWidth)
 
 	helpStyle := lipgloss.NewStyle().
 		Foreground(colorTextMuted).
-		Width(uiWidth)
+		Width(panelWidth)
 
 	contentStyle := lipgloss.NewStyle().
 		Width(innerWidth)
 
-	title := m.renderHeader("overview")
+	title := m.renderHeader("overview", panelWidth)
 
-	commandsGrid := m.renderCommandGrid()
+	commandsGrid := m.renderCommandGrid(panelWidth)
 
 	var mainContent string
 
@@ -416,7 +417,7 @@ func (m Model) renderOverviewView() string {
 	if hint != "" {
 		hintRendered := lipgloss.NewStyle().Foreground(colorTextMuted).Italic(true).Render(hint)
 		leftRendered := lipgloss.NewStyle().Foreground(colorTextMuted).Render(helpText)
-		gap := uiWidth + 2 - lipgloss.Width(leftRendered) - lipgloss.Width(hintRendered)
+		gap := panelWidth + 2 - lipgloss.Width(leftRendered) - lipgloss.Width(hintRendered)
 		if gap < 2 {
 			gap = 2
 		}
@@ -441,9 +442,9 @@ func (m Model) renderOverviewView() string {
 
 		var summaryFull string
 		if m.changesApplied {
-			summaryFull = contentStyle.Render(m.renderSavedSummary())
+			summaryFull = contentStyle.Render(m.renderSavedSummary(panelWidth))
 		} else {
-			summaryBody := m.renderSummary()
+			summaryBody := m.renderSummary(panelWidth)
 			parts := []string{summaryTitle}
 			if m.saveErr != nil {
 				errStyle := lipgloss.NewStyle().Foreground(colorError).PaddingLeft(2).Width(innerWidth)
@@ -523,7 +524,8 @@ func (m Model) renderSummaryButtons() string {
 }
 
 // renderHeader renders the header with breadcrumbs and optional environment label.
-func (m Model) renderHeader(context string) string {
+// panelWidth controls the total span used to right-align the environment name.
+func (m Model) renderHeader(context string, panelWidth int) string {
 	slashStyle := lipgloss.NewStyle().
 		Foreground(colorText)
 
@@ -547,7 +549,7 @@ func (m Model) renderHeader(context string) string {
 	envStyle := lipgloss.NewStyle().Foreground(colorText)
 	envLabel := envStyle.Render(m.selectedEnv.Name)
 
-	gap := uiWidth + 2 - lipgloss.Width(left) - lipgloss.Width(envLabel)
+	gap := panelWidth + 2 - lipgloss.Width(left) - lipgloss.Width(envLabel)
 	if gap < 2 {
 		gap = 2
 	}
@@ -562,13 +564,11 @@ var commandMeta = map[string]struct {
 	"Create":      {color: colorCreate, hint: "Create infrastructure in your project"},
 	"Reconfigure": {color: colorReconfig, hint: "Reconfigure existing infrastructure"},
 	"Promote":     {color: colorPromote, hint: "Promote infrastructure to this environment"},
-	"Upgrade":     {color: colorAccent, hint: "Upgrade a bundle to a newer version"},
-	"Destroy":     {color: colorError, hint: "Remove a bundle from your project"},
 	"Quit":        {color: colorTextMuted, hint: "Quit Terramate"},
 }
 
-func (m Model) renderCommandGrid() string {
-	innerWidth := uiWidth - 4
+func (m Model) renderCommandGrid(panelWidth int) string {
+	innerWidth := panelWidth - 4
 
 	if m.confirmingExit {
 		promptStyle := lipgloss.NewStyle().Foreground(colorWarning).Bold(true)
@@ -603,8 +603,6 @@ func (m Model) renderCommandGrid() string {
 		return strings.Repeat(" ", gap) + line
 	}
 
-	indent := 4
-
 	selectedStyle := lipgloss.NewStyle().Foreground(colorPrimary).Bold(true)
 	normalStyle := lipgloss.NewStyle().Foreground(colorText)
 
@@ -613,24 +611,7 @@ func (m Model) renderCommandGrid() string {
 		return ""
 	}
 
-	totalTextWidth := 0
-	for _, cmd := range cmds {
-		totalTextWidth += len(cmd)
-	}
-
-	usableWidth := innerWidth - indent
-	totalButtonText := len(cmds)*indent + totalTextWidth
-	totalGap := usableWidth - totalButtonText
-	if totalGap < 0 {
-		totalGap = 0
-	}
-	numGaps := len(cmds) - 1
-	baseGap := 0
-	extraGaps := 0
-	if numGaps > 0 {
-		baseGap = totalGap / numGaps
-		extraGaps = totalGap % numGaps
-	}
+	const buttonGap = 6
 
 	var rowStr string
 	for i, cmd := range cmds {
@@ -648,11 +629,7 @@ func (m Model) renderCommandGrid() string {
 		}
 
 		if i > 0 {
-			g := baseGap
-			if i-1 < extraGaps {
-				g++
-			}
-			rowStr += strings.Repeat(" ", g)
+			rowStr += strings.Repeat(" ", buttonGap)
 		}
 		rowStr += rendered
 	}
@@ -671,7 +648,7 @@ func (m Model) selectedCommandHint() string {
 	return ""
 }
 
-func (m Model) renderSummary() string {
+func (m Model) renderSummary(panelWidth int) string {
 	if len(m.PendingChanges()) == 0 {
 		dimStyle := lipgloss.NewStyle().
 			Foreground(colorTextMuted).
@@ -753,7 +730,7 @@ func (m Model) renderSummary() string {
 		if change.Source != "" {
 			row += dimStyle.Render("from " + change.Source)
 		}
-		row = truncateStyledRow(row, uiWidth-4)
+		row = truncateStyledRow(row, panelWidth-4)
 		rows = append(rows, row)
 
 		if len(change.Warnings) > 0 {
@@ -766,12 +743,12 @@ func (m Model) renderSummary() string {
 	return strings.Join(rows, "\n")
 }
 
-func (m Model) renderSavedSummary() string {
+func (m Model) renderSavedSummary(panelWidth int) string {
 	actionStyle := lipgloss.NewStyle().Foreground(colorText)
 	nameStyle := lipgloss.NewStyle().Foreground(colorText).Bold(true)
 	dimStyle := lipgloss.NewStyle().Foreground(colorTextMuted)
 
-	innerWidth := uiWidth - 8
+	innerWidth := panelWidth - 8
 
 	type fileLine struct {
 		action string

--- a/commands/ui/view_promote.go
+++ b/commands/ui/view_promote.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/terramate-io/terramate/config"
 	"github.com/terramate-io/terramate/errors"
-	"github.com/terramate-io/terramate/project"
 )
 
 func (m Model) updatePromoteSelect(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
@@ -69,6 +68,8 @@ func (m *Model) loadPromoteBundle(b *config.Bundle) error {
 	m.promoteBundle = b
 	m.selectedBundleDefEntry = bde
 	m.inputsForm = NewInputsFormWithValues(inputDefs, schemactx, est.Registry, m.selectedEnv, b.Environment, values, values)
+	m.inputsForm.PanelWidth = m.effectiveWidth()
+	m.inputsForm.PanelHeight = m.effectiveInputsPanelHeight()
 	return nil
 }
 
@@ -117,112 +118,55 @@ func (m Model) renderPromoteSelectView() string {
 
 	promoteFromName := envNameForID(est.Registry.Environments, m.selectedEnv.PromoteFrom)
 
+	panelWidth := m.effectiveWidth()
+	innerWidth := panelWidth - 4
+	scrollbarGutter := 4 // left gap(1) + scrollbar(1) + right gap(2)
+	contentWidth := innerWidth - scrollbarGutter
+
 	borderStyle := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(colorBorderFocus).
 		Padding(1, 2).
-		Width(uiWidth).
-		Height(uiContentHeight + 2)
+		Width(panelWidth).
+		Height(m.effectiveContentHeight() + 2)
 
 	helpStyle := lipgloss.NewStyle().
 		Foreground(colorTextMuted).
-		Width(uiWidth)
+		Width(panelWidth)
 
-	idStyle := lipgloss.NewStyle().
-		Foreground(colorTextSubtle)
+	contentStyle := lipgloss.NewStyle().Width(innerWidth)
 
-	contentStyle := lipgloss.NewStyle().Width(uiWidth - 4)
-
-	title := m.renderHeader("promote")
+	title := m.renderHeader("promote", panelWidth)
 
 	sectionTitle := lipgloss.NewStyle().Bold(true).Foreground(colorText).MarginBottom(1).Render("Select a Bundle to Promote")
 	desc := lipgloss.NewStyle().Foreground(colorTextMuted).MarginBottom(2).
 		Render("These bundles from " + promoteFromName + " are not yet in " + m.selectedEnv.Name + ".")
 
-	selectedStyle := lipgloss.NewStyle().Foreground(colorPrimary).Bold(true)
-	headerNameStyle := lipgloss.NewStyle().Bold(true).Foreground(colorText)
-	fromStyle := lipgloss.NewStyle().Foreground(colorTextMuted)
+	header := lipgloss.JoinVertical(lipgloss.Left, sectionTitle, desc, "")
+	headerHeight := lipgloss.Height(header)
+	availableHeight := m.effectiveContentHeight() - headerHeight
 
 	groups := groupBundles(m.promoteBundles)
+	selectedGroupIdx, items := m.renderGroupedBundleItems(groups, m.promoteCursor, contentWidth)
 
-	const colGap = 2
+	start, end := scrollWindowVar(selectedGroupIdx, items, availableHeight)
 
-	type entryRow struct {
-		left      string
-		leftWidth int
-		source    string
+	var sb strings.Builder
+	for i := start; i < end; i++ {
+		if i > start {
+			sb.WriteString("\n\n")
+		}
+		sb.WriteString(items[i].content)
 	}
-	type groupRow struct {
-		headerLeft      string
-		headerLeftWidth int
-		headerSource    string
-		entries         []entryRow
-	}
+	listContent := sb.String()
 
-	// See renderReconfigSelectView
-	groupRows := make([]groupRow, len(groups))
-	globalMaxLeft := 0
-	visualIdx := 0
-	for gi, g := range groups {
-		b0 := g.bundles[0]
-		version := "v" + b0.DefinitionMetadata.Version
-
-		headerLeft := "    " + headerNameStyle.Render(g.name) + " " + fromStyle.Render(version)
-		headerLeftWidth := lipgloss.Width(headerLeft)
-		if headerLeftWidth > globalMaxLeft {
-			globalMaxLeft = headerLeftWidth
-		}
-
-		entries := make([]entryRow, len(g.bundles))
-		for i, b := range g.bundles {
-			filename := project.PrjAbsPath(est.Root.HostDir(), b.Info.HostPath()).String()
-			isSelected := visualIdx == m.promoteCursor
-			visualIdx++
-			var left string
-			displayName := displayNameFromAlias(b.Alias, b.Name)
-			if isSelected {
-				left = selectedStyle.Render("  › " + displayName)
-			} else {
-				left = "    " + displayName
-			}
-			if b.Environment != nil {
-				idTag := idStyle.Render("[" + b.Environment.ID + "]")
-				left += " " + idTag
-			}
-
-			w := lipgloss.Width(left)
-			if w > globalMaxLeft {
-				globalMaxLeft = w
-			}
-			entries[i] = entryRow{left: left, leftWidth: w, source: filename}
-		}
-
-		groupRows[gi] = groupRow{
-			headerLeft:      headerLeft,
-			headerLeftWidth: headerLeftWidth,
-			headerSource:    b0.Source,
-			entries:         entries,
-		}
+	if len(items) > end-start {
+		trackHeight := lipgloss.Height(listContent)
+		scrollbar := renderScrollbar(len(items), end-start, start, trackHeight)
+		listContent = lipgloss.JoinHorizontal(lipgloss.Top, listContent, " ", scrollbar, "  ")
 	}
 
-	// Second pass: render lines with a unified source column.
-	var lines []string
-	for gi, gr := range groupRows {
-		if gi > 0 {
-			lines = append(lines, "")
-		}
-
-		headerPad := strings.Repeat(" ", globalMaxLeft-gr.headerLeftWidth+colGap)
-		lines = append(lines, gr.headerLeft+headerPad+fromStyle.Render(gr.headerSource))
-
-		for _, r := range gr.entries {
-			entryPad := strings.Repeat(" ", globalMaxLeft-r.leftWidth+colGap)
-			lines = append(lines, r.left+entryPad+fromStyle.Render(r.source))
-		}
-	}
-
-	listContent := strings.Join(lines, "\n")
-	inner := contentStyle.Render(lipgloss.JoinVertical(lipgloss.Left, sectionTitle, desc, listContent))
+	inner := contentStyle.Render(lipgloss.JoinVertical(lipgloss.Left, header, listContent))
 
 	help := helpStyle.Render(m.finalHelpText("esc: back"))
 
@@ -237,13 +181,14 @@ func (m Model) renderPromoteSelectView() string {
 }
 
 func (m Model) renderPromoteInputView() string {
+	panelWidth := m.effectiveWidth()
 	helpStyle := lipgloss.NewStyle().
 		Foreground(colorTextMuted).
-		Width(uiWidth)
+		Width(panelWidth)
 
 	b := m.promoteBundle
 	headerContext := fmt.Sprintf("promote / %s", b.Name)
-	title := m.renderHeader(headerContext)
+	title := m.renderHeader(headerContext, panelWidth)
 
 	formView := m.inputsForm.View()
 

--- a/commands/ui/view_reconfig.go
+++ b/commands/ui/view_reconfig.go
@@ -70,6 +70,8 @@ func (m *Model) loadReconfigBundle(b *config.Bundle) error {
 	m.reconfigBundle = b
 	m.selectedBundleDefEntry = bde
 	m.inputsForm = NewInputsFormWithValues(inputDefs, schemactx, est.Registry, m.selectedEnv, nil, values, values)
+	m.inputsForm.PanelWidth = m.effectiveWidth()
+	m.inputsForm.PanelHeight = m.effectiveInputsPanelHeight()
 	return nil
 }
 
@@ -170,37 +172,19 @@ func groupBundles(bundles []*config.Bundle) []bundleGroup {
 	return groups
 }
 
-func (m Model) renderReconfigSelectView() string {
+// renderGroupedBundleItems renders each bundle group as a single renderedItem block
+// and returns the group index containing the cursor, suitable for scrollWindowVar.
+// contentWidth controls the fixed width each line is padded/truncated to so that
+// the scrollbar column stays right-aligned.
+func (m Model) renderGroupedBundleItems(groups []bundleGroup, cursor, contentWidth int) (int, []renderedItem) {
 	est := m.EngineState
 
-	borderStyle := lipgloss.NewStyle().
-		Border(lipgloss.RoundedBorder()).
-		BorderForeground(colorBorderFocus).
-		Padding(1, 2).
-		Width(uiWidth).
-		Height(uiContentHeight + 2)
-
-	helpStyle := lipgloss.NewStyle().
-		Foreground(colorTextMuted).
-		Width(uiWidth)
-
-	idStyle := lipgloss.NewStyle().
-		Foreground(colorTextSubtle)
-
-	contentStyle := lipgloss.NewStyle().Width(uiWidth - 4)
-
-	title := m.renderHeader("reconfig")
-
-	sectionTitle := lipgloss.NewStyle().Bold(true).Foreground(colorText).MarginBottom(1).Render("Select a Bundle to Reconfigure")
-	desc := lipgloss.NewStyle().Foreground(colorTextMuted).MarginBottom(2).Render("These bundles are currently deployed in your project.")
-
+	idStyle := lipgloss.NewStyle().Foreground(colorTextSubtle)
 	selectedStyle := lipgloss.NewStyle().Foreground(colorPrimary).Bold(true)
 	headerNameStyle := lipgloss.NewStyle().Bold(true).Foreground(colorText)
 	fromStyle := lipgloss.NewStyle().Foreground(colorTextMuted)
 
-	innerWidth := uiWidth - 8
-
-	groups := groupBundles(m.reconfigBundles)
+	lineStyle := lipgloss.NewStyle().Width(contentWidth)
 
 	const colGap = 2
 
@@ -209,7 +193,7 @@ func (m Model) renderReconfigSelectView() string {
 		leftWidth int
 		source    string
 	}
-	type groupRow struct {
+	type groupData struct {
 		headerLeft      string
 		headerLeftWidth int
 		headerSource    string
@@ -217,11 +201,9 @@ func (m Model) renderReconfigSelectView() string {
 	}
 
 	// First pass: build all rows and find the global max left width.
-	// visualIdx counts entries in the same order they will be displayed so that
-	// it matches m.reconfigCursor (which is also a sequential visual index
-	// thanks to buildReconfigBundles returning bundles in grouped order).
-	groupRows := make([]groupRow, len(groups))
+	allGroups := make([]groupData, len(groups))
 	globalMaxLeft := 0
+	selectedGroupIdx := 0
 	visualIdx := 0
 	for gi, g := range groups {
 		b0 := g.bundles[0]
@@ -236,7 +218,10 @@ func (m Model) renderReconfigSelectView() string {
 		entries := make([]entryRow, len(g.bundles))
 		for i, b := range g.bundles {
 			filename := project.PrjAbsPath(est.Root.HostDir(), b.Info.HostPath()).String()
-			isSelected := visualIdx == m.reconfigCursor
+			isSelected := visualIdx == cursor
+			if isSelected {
+				selectedGroupIdx = gi
+			}
 			visualIdx++
 			var left string
 			displayName := displayNameFromAlias(b.Alias, b.Name)
@@ -257,7 +242,7 @@ func (m Model) renderReconfigSelectView() string {
 			entries[i] = entryRow{left: left, leftWidth: w, source: filename}
 		}
 
-		groupRows[gi] = groupRow{
+		allGroups[gi] = groupData{
 			headerLeft:      headerLeft,
 			headerLeftWidth: headerLeftWidth,
 			headerSource:    b0.Source,
@@ -265,28 +250,72 @@ func (m Model) renderReconfigSelectView() string {
 		}
 	}
 
-	// Second pass: render lines with a unified source column.
-	var lines []string
-	for gi, gr := range groupRows {
-		if gi > 0 {
-			lines = append(lines, "")
-		}
-
+	// Second pass: render each group as a single block with fixed-width lines.
+	items := make([]renderedItem, len(allGroups))
+	for gi, gr := range allGroups {
+		var lines []string
 		headerPad := strings.Repeat(" ", globalMaxLeft-gr.headerLeftWidth+colGap)
-		header := gr.headerLeft + headerPad + fromStyle.Render(gr.headerSource)
-		header = truncateStyledRow(header, innerWidth)
-		lines = append(lines, header)
-
+		lines = append(lines, lineStyle.Render(gr.headerLeft+headerPad+fromStyle.Render(gr.headerSource)))
 		for _, r := range gr.entries {
 			entryPad := strings.Repeat(" ", globalMaxLeft-r.leftWidth+colGap)
-			line := r.left + entryPad + fromStyle.Render(r.source)
-			line = truncateStyledRow(line, innerWidth)
-			lines = append(lines, line)
+			lines = append(lines, lineStyle.Render(r.left+entryPad+fromStyle.Render(r.source)))
 		}
+		block := strings.Join(lines, "\n")
+		items[gi] = renderedItem{content: block, height: lipgloss.Height(block)}
 	}
 
-	listContent := strings.Join(lines, "\n")
-	inner := contentStyle.Render(lipgloss.JoinVertical(lipgloss.Left, sectionTitle, desc, listContent))
+	return selectedGroupIdx, items
+}
+
+func (m Model) renderReconfigSelectView() string {
+	panelWidth := m.effectiveWidth()
+	innerWidth := panelWidth - 4
+	scrollbarGutter := 4 // left gap(1) + scrollbar(1) + right gap(2)
+	contentWidth := innerWidth - scrollbarGutter
+
+	borderStyle := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(colorBorderFocus).
+		Padding(1, 2).
+		Width(panelWidth).
+		Height(m.effectiveContentHeight() + 2)
+
+	helpStyle := lipgloss.NewStyle().
+		Foreground(colorTextMuted).
+		Width(panelWidth)
+
+	contentStyle := lipgloss.NewStyle().Width(innerWidth)
+
+	title := m.renderHeader("reconfigure", panelWidth)
+
+	sectionTitle := lipgloss.NewStyle().Bold(true).Foreground(colorText).MarginBottom(1).Render("Select a Bundle to Reconfigure")
+	desc := lipgloss.NewStyle().Foreground(colorTextMuted).MarginBottom(2).Render("These bundles are currently deployed in your project.")
+
+	header := lipgloss.JoinVertical(lipgloss.Left, sectionTitle, desc, "")
+	headerHeight := lipgloss.Height(header)
+	availableHeight := m.effectiveContentHeight() - headerHeight
+
+	groups := groupBundles(m.reconfigBundles)
+	selectedGroupIdx, items := m.renderGroupedBundleItems(groups, m.reconfigCursor, contentWidth)
+
+	start, end := scrollWindowVar(selectedGroupIdx, items, availableHeight)
+
+	var sb strings.Builder
+	for i := start; i < end; i++ {
+		if i > start {
+			sb.WriteString("\n\n")
+		}
+		sb.WriteString(items[i].content)
+	}
+	listContent := sb.String()
+
+	if len(items) > end-start {
+		trackHeight := lipgloss.Height(listContent)
+		scrollbar := renderScrollbar(len(items), end-start, start, trackHeight)
+		listContent = lipgloss.JoinHorizontal(lipgloss.Top, listContent, " ", scrollbar, "  ")
+	}
+
+	inner := contentStyle.Render(lipgloss.JoinVertical(lipgloss.Left, header, listContent))
 
 	help := helpStyle.Render(m.finalHelpText("esc: back"))
 
@@ -301,13 +330,14 @@ func (m Model) renderReconfigSelectView() string {
 }
 
 func (m Model) renderReconfigInputView() string {
+	panelWidth := m.effectiveWidth()
 	helpStyle := lipgloss.NewStyle().
 		Foreground(colorTextMuted).
-		Width(uiWidth)
+		Width(panelWidth)
 
 	b := m.reconfigBundle
 	headerContext := fmt.Sprintf("reconfigure / %s", b.Name)
-	title := m.renderHeader(headerContext)
+	title := m.renderHeader(headerContext, panelWidth)
 
 	formView := m.inputsForm.View()
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/terramate-io/terramate/blob/main/CONTRIBUTING.md
2. If the PR is unfinished, mark it as draft: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request
3. Please update the PR title using the Conventional Commits convention: https://www.conventionalcommits.org/en/v1.0.0/
    Example: feat: add support for XYZ.
-->

## What this PR does / why we need it:

This PR fixes several width/height scaling issues with `terramate ui`. It should now display properly in a 100x24 terminal.

## Does this PR introduce a user-facing change?
<!--
If no, just write "no" in the block below.
If yes, please explain the change and update documentation and the CHANGELOG.md file accordingly.
-->
```
no, fix to RC-only feature
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches most `terramate ui` views to compute widths/heights from `WindowSizeMsg`, so regressions could cause clipped content or broken navigation on edge terminal sizes. No auth/data-path changes; impact is limited to TUI layout/rendering.
> 
> **Overview**
> Improves `terramate ui` terminal scaling by replacing fixed panel dimensions with dynamic width/height calculations derived from `tea.WindowSizeMsg` (`effectiveWidth`, `effectiveContentHeight`). Input forms now accept per-instance `PanelWidth`/`PanelHeight` and use them to size split/single panels and viewports consistently.
> 
> Updates all major views (cloud login, env select, bundle select, create/edit/reconfigure/promote, overview) to render with the computed `panelWidth` and content height, including header right-alignment and help-line spacing. Reworks grouped bundle selection (reconfigure/promote) to render variable-height group blocks with a shared scroll-window/scrollbar implementation, and simplifies command button spacing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b344ede55051ccfa808e2a95d6cbe8c522c13d2a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->