### PR TITLE
feat: add terramate.stack.parent.tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
     }
     ```
     This is supported for inputs and attributes.
+- Add `terramate.stack.parent.tags` metadata to stacks that are part of a parent-child hierarchy.
 
 ## 0.16.0
 

--- a/config/stack.go
+++ b/config/stack.go
@@ -236,7 +236,8 @@ func (s *Stack) RuntimeValues(root *Root) map[string]cty.Value {
 	}
 	if parentStack != nil {
 		stackMapVals["parent"] = cty.ObjectVal(map[string]cty.Value{
-			"id": cty.StringVal(parentStack.Node.Stack.ID),
+			"id":   cty.StringVal(parentStack.Node.Stack.ID),
+			"tags": toCtyStringList(parentStack.Node.Stack.Tags),
 		})
 	}
 	stack := cty.ObjectVal(stackMapVals)

--- a/e2etests/core/exp_eval_test.go
+++ b/e2etests/core/exp_eval_test.go
@@ -258,6 +258,36 @@ func TestExpEval(t *testing.T) {
 			},
 		},
 		{
+			name: "terramate.stack.parent.tags with tagged parent",
+			layout: []string{
+				`s:parent:id=parent-id;tags=["infra","prod"]`,
+				`s:parent/child`,
+			},
+			wd:   "parent/child",
+			expr: `terramate.stack.parent.tags`,
+			wantEval: RunExpected{
+				Stdout: addnl(`["infra", "prod"]`),
+			},
+			wantPartial: RunExpected{
+				Stdout: addnl(`["infra", "prod"]`),
+			},
+		},
+		{
+			name: "terramate.stack.parent.tags with untagged parent",
+			layout: []string{
+				`s:parent:id=parent-id`,
+				`s:parent/child`,
+			},
+			wd:   "parent/child",
+			expr: `terramate.stack.parent.tags`,
+			wantEval: RunExpected{
+				Stdout: addnl(`[]`),
+			},
+			wantPartial: RunExpected{
+				Stdout: addnl(`[]`),
+			},
+		},
+		{
 			// issue: https://github.com/terramate-io/terramate/issues/1327
 			name: "regression check: globals containing percents",
 			overrideGlobals: map[string]string{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/terramate-io/terramate/blob/main/CONTRIBUTING.md
2. If the PR is unfinished, mark it as draft: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request
3. Please update the PR title using the Conventional Commits convention: https://www.conventionalcommits.org/en/v1.0.0/
    Example: feat: add support for XYZ.
-->

## What this PR does / why we need it:

Adds `terramate.stack.parent.tags`.

## Does this PR introduce a user-facing change?
<!--
If no, just write "no" in the block below.
If yes, please explain the change and update documentation and the CHANGELOG.md file accordingly.
-->
```
yes, see changelog
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small additive metadata change plus tests/docs; low risk aside from potential consumers relying on the exact shape of `terramate.stack.parent`.
> 
> **Overview**
> Adds `terramate.stack.parent.tags` to the runtime metadata for stacks in a parent/child hierarchy by exposing the parent stack’s tag list alongside the existing parent `id`.
> 
> Updates end-to-end eval tests to cover both tagged and untagged parent stacks (expecting a list of tags or an empty list), and documents the new metadata field in `CHANGELOG.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dba81da57cf6ac8475e1773a031663f950e60d2a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->