### PR TITLE
fix: show proper errors when loading a bundle fails

### DIFF
--- a/commands/ui/model.go
+++ b/commands/ui/model.go
@@ -181,6 +181,7 @@ type Model struct {
 
 	// Transient status
 	currentErr       error  // Shown in the overview error area, cleared on next keypress
+	bundleSelectErr  string // Inline error shown in the bundle list view, cleared on cursor move
 	ctrlCPending     bool   // true after first ctrl+c press, reset after 1s
 	errorDialogTitle string // Title for the error dialog (e.g. "Bundle is not enabled")
 	errorDialogText  string // When non-empty, shows a dismissible error dialog overlay

--- a/commands/ui/view_create_select.go
+++ b/commands/ui/view_create_select.go
@@ -61,12 +61,14 @@ func (m Model) updateCreateSelect(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case key.Matches(msg, keys.Up):
 		if m.flatBundleCursor > 0 {
 			m.flatBundleCursor--
+			m.bundleSelectErr = ""
 		}
 		return m, nil
 
 	case key.Matches(msg, keys.Down):
 		if m.flatBundleCursor < len(m.flatBundles)-1 {
 			m.flatBundleCursor++
+			m.bundleSelectErr = ""
 		}
 		return m, nil
 
@@ -87,7 +89,8 @@ func (m Model) selectFlatBundle() (tea.Model, tea.Cmd) {
 	m.selectedEnv = nil // reset so env picker shows for each bundle
 
 	if err := m.loadBundleDef(entry.collIdx, entry.bundleIdx); err != nil {
-		return m.updateError(err)
+		m.bundleSelectErr = err.Error()
+		return m, nil
 	}
 
 	// If the bundle requires an environment and environments are configured,
@@ -124,17 +127,17 @@ func (m *Model) loadBundleDef(collIdx, bundleIdx int) error {
 
 		bundleDir, err := est.ResolveAPI.Resolve(est.Root.HostDir(), source, resolve.Bundle, true)
 		if err != nil {
-			return errors.E("Failed to resolve bundle")
+			return errors.E(err, "Failed to resolve bundle")
 		}
 
 		tree, define, err := config.LoadSingleBundleDefinition(est.Root, bundleDir)
 		if err != nil {
-			return errors.E("Failed to load bundle")
+			return errors.E(err, "Failed to load bundle")
 		}
 
 		md, err := config.EvalMetadata(est.Evalctx, tree, &define.Metadata)
 		if err != nil {
-			return errors.E("Failed to load bundle")
+			return errors.E(err, "Failed to load bundle")
 		}
 
 		bde = &config.BundleDefinitionEntry{
@@ -457,7 +460,7 @@ func (m Model) renderBundleSelectView() string {
 
 	title := m.renderHeader("Create Bundle Instance")
 
-	help := helpStyle.Render(m.finalHelpText("↑↓: Select Bundle • esc: back"))
+	help := helpStyle.Render(m.finalHelpText("esc: back"))
 
 	content := m.renderFlatBundleList(innerWidth)
 
@@ -570,6 +573,45 @@ func renderDetailBox(innerWidth int, boxTitle string, fields []detailField) stri
 	return strings.Join(all, "\n")
 }
 
+// renderErrorBox renders an error message in a red-bordered box matching the
+// dimensions of the detail box.
+func renderErrorBox(innerWidth int, msg string) string {
+	borderColor := lipgloss.NewStyle().Foreground(colorError)
+	textStyle := lipgloss.NewStyle().Foreground(colorError)
+
+	contentWidth := innerWidth - 4 // border 1 + padding 1 on each side
+	if contentWidth < 20 {
+		contentWidth = 20
+	}
+
+	titleText := borderColor.Render(" Error ")
+	titleVisualWidth := lipgloss.Width(titleText)
+	fillWidth := innerWidth - 2 - 1 - titleVisualWidth
+	if fillWidth < 0 {
+		fillWidth = 0
+	}
+	topBorder := borderColor.Render("╭─") + titleText + borderColor.Render(strings.Repeat("─", fillWidth)+"╮")
+
+	// Word-wrap the message to fit inside the box.
+	wrapped := lipgloss.NewStyle().Width(contentWidth).Render(msg)
+	var contentLines []string
+	for _, line := range strings.Split(wrapped, "\n") {
+		lineWidth := lipgloss.Width(line)
+		pad := contentWidth - lineWidth
+		if pad < 0 {
+			pad = 0
+		}
+		contentLines = append(contentLines, borderColor.Render("│")+" "+textStyle.Render(line)+strings.Repeat(" ", pad)+" "+borderColor.Render("│"))
+	}
+
+	bottomBorder := borderColor.Render("╰" + strings.Repeat("─", innerWidth-2) + "╯")
+
+	all := []string{topBorder}
+	all = append(all, contentLines...)
+	all = append(all, bottomBorder)
+	return strings.Join(all, "\n")
+}
+
 // splitNameVersion splits "Some Name vX.Y.Z" into ("Some Name", "vX.Y.Z").
 func splitNameVersion(s string) (string, string) {
 	// Find the last " v" followed by a digit
@@ -639,7 +681,12 @@ func (m Model) renderFlatBundleList(innerWidth int) string {
 		detailBox = renderDetailBox(innerWidth, "Bundle Details", fields)
 	}
 
-	header := lipgloss.JoinVertical(lipgloss.Left, detailBox, "")
+	headerParts := []string{detailBox}
+	if m.bundleSelectErr != "" {
+		headerParts = append(headerParts, renderErrorBox(innerWidth, m.bundleSelectErr))
+	}
+	headerParts = append(headerParts, "")
+	header := lipgloss.JoinVertical(lipgloss.Left, headerParts...)
 	headerHeight := lipgloss.Height(header)
 	availableHeight := m.effectiveContentHeight() - headerHeight
 
@@ -660,9 +707,11 @@ func (m Model) renderFlatBundleList(innerWidth int) string {
 		Foreground(colorTextMuted).
 		Width(contentWidth)
 
+	collStyle := lipgloss.NewStyle().Foreground(colorTextMuted)
+
 	var items []renderedItem
 	for i, entry := range m.flatBundles {
-		displayName := fmt.Sprintf("%s %s", entry.bundle.Name, versionStyle.Render("v"+entry.bundle.Version))
+		displayName := entry.bundle.Name + " " + versionStyle.Render("v"+entry.bundle.Version) + " " + collStyle.Render("• "+entry.collName)
 
 		var line string
 		if i == m.flatBundleCursor {

--- a/commands/ui/view_overview.go
+++ b/commands/ui/view_overview.go
@@ -128,6 +128,7 @@ func (m *Model) executeCommand() {
 		}
 		m.viewState = ViewCreateSelect
 		m.flatBundleCursor = 0
+		m.bundleSelectErr = ""
 	case "Reconfigure":
 		m.reconfigFilterPos = -1
 		m.reconfigFilters = m.buildReconfigFilters()

--- a/commands/ui/widget_object.go
+++ b/commands/ui/widget_object.go
@@ -19,7 +19,6 @@ type ObjectWidget struct {
 	wctx    *WidgetContext
 	objType *typeschema.ObjectType
 	value   cty.Value
-	cursor  int // 0 = first action, 1 = second action (if available)
 
 	// SubFormRequest is populated when the widget signals WidgetNeedSubForm.
 	SubFormRequest *SubFormRequest
@@ -43,39 +42,20 @@ func (w *ObjectWidget) WidgetContext() *WidgetContext {
 func (w *ObjectWidget) Prepare() {
 	w.value = w.wctx.Value
 	w.SubFormRequest = nil
-	w.cursor = 0
 }
 
 // Update handles keyboard input and returns the resulting signal.
 func (w *ObjectWidget) Update(msg tea.KeyMsg) (WidgetSignal, tea.Cmd) {
 	hasValue := w.value != cty.NilVal && !w.value.IsNull()
-	maxCursor := 0
-	if hasValue {
-		maxCursor = 1
-	}
 
 	switch msg.Type {
-	case tea.KeyUp:
-		if w.cursor > 0 {
-			w.cursor--
-		}
-	case tea.KeyDown:
-		if w.cursor < maxCursor {
-			w.cursor++
-		}
 	case tea.KeyShiftTab, tea.KeyEsc:
 		return WidgetBack, nil
 	case tea.KeyEnter:
-		if hasValue && w.cursor == 1 {
-			w.value = cty.NilVal
-			w.wctx.UpdateValue(cty.NilVal)
-			w.cursor = 0
-			return WidgetContinue, nil
-		}
 		req := &SubFormRequest{
 			InputID:   w.wctx.Def.Name,
 			InputDefs: objectAttrsToInputDefs(w.wctx.Def.ObjectAttributes),
-			EditMode:  hasValue && w.cursor == 0,
+			EditMode:  hasValue,
 		}
 		if req.EditMode {
 			req.Values = extractObjectAttrs(w.value)
@@ -117,20 +97,11 @@ func (w *ObjectWidget) Render() []string {
 		lines = append(lines, "")
 	}
 
-	type action struct{ label string }
-	var actions []action
+	label := "Set values"
 	if hasValue {
-		actions = []action{{"Edit values"}, {"Reset values"}}
-	} else {
-		actions = []action{{"Set values"}}
+		label = "Edit values"
 	}
-	for i, a := range actions {
-		if w.cursor == i {
-			lines = append(lines, activeOptionStyle.Render("› "+a.label))
-		} else {
-			lines = append(lines, optionStyle.Render("  "+a.label))
-		}
-	}
+	lines = append(lines, activeOptionStyle.Render("› "+label))
 	return lines
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Please read our contribution policy: https://github.com/terramate-io/terramate/blob/main/CONTRIBUTING.md
   Note: All code contributions are managed exclusively by the Terramate team.
2. If the PR is unfinished, mark it as draft: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request
3. Please update the PR title using the Conventional Commits convention: https://www.conventionalcommits.org/en/v1.0.0/
    Example: feat: add support for XYZ.
-->

## What this PR does / why we need it:

This PR fixes the error dialog that is shown when loading a bundle fails. Before it would be shown on a new screen, not showing the actual error. Now it will look like this:
<img width="1438" height="493" alt="Screenshot 2026-04-21 at 10 59 51" src="https://github.com/user-attachments/assets/a6b55d61-2cc6-4dd1-be7d-e0f480aa85e8" />

## Does this PR introduce a user-facing change?
<!--
If no, just write "no" in the block below.
If yes, please explain the change and update documentation and the CHANGELOG.md file accordingly.
-->
```
no, RC-only fix
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily TUI presentation/state changes around error display and selection; minimal impact on core bundle evaluation logic, but could affect Create-flow navigation/display edge cases.
> 
> **Overview**
> Fixes bundle-load failures in the Create flow by keeping users on the bundle selection screen and rendering the *actual* error inline.
> 
> This introduces `bundleSelectErr` state that is set when `loadBundleDef` fails, cleared on cursor move and when entering Create, and displayed via a new red `renderErrorBox` under the bundle details; related errors are now wrapped with underlying causes. The bundle list UI is also tweaked to show the collection name per entry and simplify the help text, and `ObjectWidget` interaction is simplified to always open the sub-form (removing the prior in-widget reset/edit action selection).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13849ccf1c91c19fc0202cb481c867756bc31066. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->