### PR TITLE
feat: allow to define bundles and components anywhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,10 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
     This is supported for inputs and attributes.
 - Add `terramate.stack.parent.tags` metadata to stacks that are part of a parent-child hierarchy.
 
+### Changed
+
+- Local bundles and component definitions are no longer limited to the `/bundles` and `/components` root, but can be anywhere in the project.
+
 ## 0.16.0
 
 ### Merged from Terramate Catalyst

--- a/commands/package/create/create.go
+++ b/commands/package/create/create.go
@@ -63,12 +63,12 @@ func (s *Spec) Exec(_ context.Context, cli commands.CLI) error {
 	}
 
 	// TODO: Could both be done in a single pass.
-	localBundles, err := config.ListLocalBundleDefinitions(root, evalctx, project.NewPath("/bundles"))
+	localBundles, err := config.ListLocalBundleDefinitions(root, evalctx, project.NewPath("/"))
 	if err != nil {
 		return err
 	}
 
-	localComponents, err := config.ListLocalComponentDefinitions(root, evalctx, project.NewPath("/components"))
+	localComponents, err := config.ListLocalComponentDefinitions(root, evalctx, project.NewPath("/"))
 	if err != nil {
 		return err
 	}

--- a/commands/scaffold/scaffold.go
+++ b/commands/scaffold/scaffold.go
@@ -89,7 +89,7 @@ func (s *Spec) Exec(ctx context.Context, cli commands.CLI) error {
 
 	// TODO: We could only do this when the local collection is selected,
 	// but to simplify the local, we do it all the time.
-	localBundleDefs, err := config.ListLocalBundleDefinitions(root, evalctx, project.NewPath("/bundles"))
+	localBundleDefs, err := config.ListLocalBundleDefinitions(root, evalctx, project.NewPath("/"))
 	if err != nil {
 		return err
 	}

--- a/commands/ui/ui.go
+++ b/commands/ui/ui.go
@@ -65,7 +65,7 @@ func (s *Spec) Exec(ctx context.Context, cli commands.CLI) error {
 		return err
 	}
 
-	localBundleDefs, err := config.ListLocalBundleDefinitions(root, evalctx, project.NewPath("/bundles"))
+	localBundleDefs, err := config.ListLocalBundleDefinitions(root, evalctx, project.NewPath("/"))
 	if err != nil {
 		return err
 	}
@@ -167,7 +167,6 @@ func makeLocalCollection(localBundleDefs []config.BundleDefinitionEntry) *manife
 	return &manifest.Collection{
 		Name:        "Local Repository",
 		Description: "Bundles from local /bundles directory",
-		Location:    "/bundles",
 		Bundles:     bundles,
 	}
 }

--- a/commands/ui/view_create_select.go
+++ b/commands/ui/view_create_select.go
@@ -665,11 +665,7 @@ func (m Model) renderFlatBundleList(innerWidth int) string {
 		fields = append(fields, detailField{}) // separator
 		// Collection: name and location
 		coll := est.Collections[entry.collIdx]
-		collDetail := coll.Name
-		if coll.Location != "" {
-			collDetail += " (" + coll.Location + ")"
-		}
-		fields = append(fields, detailField{label: "Collection", value: collDetail})
+		fields = append(fields, detailField{label: "Collection", value: coll.Name})
 		// Source: the real resolved source path to the bundle definition
 		var source string
 		if entry.isLocal && entry.bundleIdx < len(est.LocalBundleDefs) {

--- a/config/bundle_test.go
+++ b/config/bundle_test.go
@@ -3,6 +3,106 @@
 
 package config_test
 
+import (
+	"sort"
+	"testing"
+
+	"github.com/madlambda/spells/assert"
+
+	"github.com/terramate-io/terramate/config"
+	"github.com/terramate-io/terramate/hcl/eval"
+	"github.com/terramate-io/terramate/project"
+	"github.com/terramate-io/terramate/stdlib"
+	. "github.com/terramate-io/terramate/test/hclwrite/hclutils"
+	"github.com/terramate-io/terramate/test/sandbox"
+)
+
+func defineBundleHCL(name string) string {
+	return Block("define",
+		Labels("bundle"),
+		Block("metadata",
+			Str("class", "test_class"),
+			Str("name", name),
+			Str("version", "1.0.0"),
+		),
+	).String()
+}
+
+func newEvalCtxForRoot(root *config.Root) *eval.Context {
+	evalctx := eval.NewContext(stdlib.Functions(root.HostDir(), root.Tree().Node.Experiments()))
+	evalctx.SetNamespace("terramate", root.Runtime())
+	return evalctx
+}
+
+func sourcesOf(entries []config.BundleDefinitionEntry) []string {
+	out := make([]string, 0, len(entries))
+	for _, e := range entries {
+		out = append(out, e.Source)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func TestListLocalBundleDefinitionsFromRoot(t *testing.T) {
+	t.Parallel()
+
+	s := sandbox.NoGit(t, true)
+	s.BuildTree([]string{
+		"f:/bundles/a/define.tm:" + defineBundleHCL("bundle_a"),
+		"f:/custom/place/b/define.tm:" + defineBundleHCL("bundle_b"),
+		"f:/deeply/nested/path/c/define.tm:" + defineBundleHCL("bundle_c"),
+	})
+
+	root, err := config.LoadRoot(s.RootDir(), false)
+	assert.NoError(t, err)
+
+	entries, err := config.ListLocalBundleDefinitions(root, newEvalCtxForRoot(root), project.NewPath("/"))
+	assert.NoError(t, err)
+
+	got := sourcesOf(entries)
+	want := []string{"/bundles/a", "/custom/place/b", "/deeply/nested/path/c"}
+	assert.EqualInts(t, len(want), len(got), "got: %v", got)
+	for i, w := range want {
+		assert.EqualStrings(t, w, got[i])
+	}
+}
+
+func TestListLocalBundleDefinitionsSkipsInstalledRemotePackages(t *testing.T) {
+	t.Parallel()
+
+	s := sandbox.NoGit(t, true)
+	s.BuildTree([]string{
+		"f:/bundles/a/define.tm:" + defineBundleHCL("bundle_a"),
+		"f:/.terramate/bundles/remote/define.tm:" + defineBundleHCL("remote_bundle"),
+	})
+
+	root, err := config.LoadRoot(s.RootDir(), false)
+	assert.NoError(t, err)
+
+	entries, err := config.ListLocalBundleDefinitions(root, newEvalCtxForRoot(root), project.NewPath("/"))
+	assert.NoError(t, err)
+
+	got := sourcesOf(entries)
+	want := []string{"/bundles/a"}
+	assert.EqualInts(t, len(want), len(got), "got: %v", got)
+	for i, w := range want {
+		assert.EqualStrings(t, w, got[i])
+	}
+}
+
+func TestListLocalBundleDefinitionsEmpty(t *testing.T) {
+	t.Parallel()
+
+	s := sandbox.NoGit(t, true)
+
+	root, err := config.LoadRoot(s.RootDir(), false)
+	assert.NoError(t, err)
+
+	entries, err := config.ListLocalBundleDefinitions(root, newEvalCtxForRoot(root), project.NewPath("/"))
+	assert.NoError(t, err)
+	assert.EqualInts(t, 0, len(entries))
+}
+
 /*
 
 func TestEvalBundle(t *testing.T) {

--- a/config/component_test.go
+++ b/config/component_test.go
@@ -3,6 +3,98 @@
 
 package config_test
 
+import (
+	"sort"
+	"testing"
+
+	"github.com/madlambda/spells/assert"
+
+	"github.com/terramate-io/terramate/config"
+	"github.com/terramate-io/terramate/project"
+	. "github.com/terramate-io/terramate/test/hclwrite/hclutils"
+	"github.com/terramate-io/terramate/test/sandbox"
+)
+
+func defineComponentHCL(name string) string {
+	return Block("define",
+		Labels("component"),
+		Block("metadata",
+			Str("class", "test_class"),
+			Str("name", name),
+			Str("version", "1.0.0"),
+		),
+	).String()
+}
+
+func componentDirsOf(entries []config.ComponentDefinitionEntry) []string {
+	out := make([]string, 0, len(entries))
+	for _, e := range entries {
+		out = append(out, e.Tree.Dir().String())
+	}
+	sort.Strings(out)
+	return out
+}
+
+func TestListLocalComponentDefinitionsFromRoot(t *testing.T) {
+	t.Parallel()
+
+	s := sandbox.NoGit(t, true)
+	s.BuildTree([]string{
+		"f:/components/a/define.tm:" + defineComponentHCL("component_a"),
+		"f:/custom/place/b/define.tm:" + defineComponentHCL("component_b"),
+		"f:/deeply/nested/path/c/define.tm:" + defineComponentHCL("component_c"),
+	})
+
+	root, err := config.LoadRoot(s.RootDir(), false)
+	assert.NoError(t, err)
+
+	entries, err := config.ListLocalComponentDefinitions(root, newEvalCtxForRoot(root), project.NewPath("/"))
+	assert.NoError(t, err)
+
+	got := componentDirsOf(entries)
+	want := []string{"/components/a", "/custom/place/b", "/deeply/nested/path/c"}
+	assert.EqualInts(t, len(want), len(got), "got: %v", got)
+	for i, w := range want {
+		assert.EqualStrings(t, w, got[i])
+	}
+}
+
+func TestListLocalComponentDefinitionsSkipsInstalledRemotePackages(t *testing.T) {
+	t.Parallel()
+
+	s := sandbox.NoGit(t, true)
+	s.BuildTree([]string{
+		"f:/components/a/define.tm:" + defineComponentHCL("component_a"),
+		"f:/.terramate/components/remote/define.tm:" + defineComponentHCL("remote_component"),
+	})
+
+	root, err := config.LoadRoot(s.RootDir(), false)
+	assert.NoError(t, err)
+
+	entries, err := config.ListLocalComponentDefinitions(root, newEvalCtxForRoot(root), project.NewPath("/"))
+	assert.NoError(t, err)
+
+	got := componentDirsOf(entries)
+	want := []string{"/components/a"}
+	assert.EqualInts(t, len(want), len(got), "got: %v", got)
+	for i, w := range want {
+		assert.EqualStrings(t, w, got[i])
+	}
+}
+
+func TestListLocalComponentDefinitionsEmpty(t *testing.T) {
+	t.Parallel()
+
+	s := sandbox.NoGit(t, true)
+
+	root, err := config.LoadRoot(s.RootDir(), false)
+	assert.NoError(t, err)
+
+	entries, err := config.ListLocalComponentDefinitions(root, newEvalCtxForRoot(root), project.NewPath("/"))
+	assert.NoError(t, err)
+	assert.EqualInts(t, 0, len(entries))
+}
+
 /*
 import (
 	"path/filepath"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Please read our contribution policy: https://github.com/terramate-io/terramate/blob/main/CONTRIBUTING.md
   Note: All code contributions are managed exclusively by the Terramate team.
2. If the PR is unfinished, mark it as draft: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request
3. Please update the PR title using the Conventional Commits convention: https://www.conventionalcommits.org/en/v1.0.0/
    Example: feat: add support for XYZ.
-->

## What this PR does / why we need it:

This PR removes the limitation that bundles or components are only discovered in the /bundles or /components directories.

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Keep it empty if not applicable.
-->
Fixes #2307

## Does this PR introduce a user-facing change?
<!--
If no, just write "no" in the block below.
If yes, please explain the change and update documentation and the CHANGELOG.md file accordingly.
-->
```
yes, see changelog
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect how CLI/UI commands enumerate local bundles/components, which can alter what gets packaged or shown if repositories have unexpected defines outside the old directories.
> 
> **Overview**
> Local bundle/component discovery used by `package create`, `scaffold`, and `ui` now scans from the project root (`/`) instead of only `/bundles` and `/components`, allowing definitions to live anywhere in the repository.
> 
> UI copy/details were adjusted to match the new behavior (local collection no longer reports a fixed `/bundles` location, and bundle details show only collection name). New unit tests cover listing bundles/components from root, skipping installed remote packages under `/.terramate`, and the empty-repo case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84c062d1eb0d69f2969f9441f81effd7957c9de4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->