### PR TITLE
fix: results of tm_bundle should have deterministic order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,10 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 
 - Local bundles and component definitions are no longer limited to the `/bundles` and `/components` root, but can be anywhere in the project.
 
+### Fixed
+
+- Fix non-deterministic order of `tm_bundles` results.
+
 ## 0.16.0
 
 ### Merged from Terramate Catalyst

--- a/config/hcl_func.go
+++ b/config/hcl_func.go
@@ -4,9 +4,11 @@
 package config
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/google/uuid"
@@ -154,7 +156,7 @@ func BundlesFunc(reg *Registry, currentEnv *Environment) function.Function {
 				envID = currentEnv.ID
 			}
 
-			var r []cty.Value
+			var matched []*Bundle
 			for _, b := range reg.Bundles {
 				if class != "*" && class != b.DefinitionMetadata.Class {
 					continue
@@ -166,12 +168,30 @@ func BundlesFunc(reg *Registry, currentEnv *Environment) function.Function {
 						continue
 					}
 				}
-
-				r = append(r, MakeObjectFromBundle(b))
+				matched = append(matched, b)
+			}
+			if len(matched) == 0 {
+				return cty.EmptyTupleVal, nil
 			}
 
-			if len(r) == 0 {
-				return cty.EmptyTupleVal, nil
+			slices.SortFunc(matched, func(a, b *Bundle) int {
+				aEnv, bEnv := "", ""
+				if a.Environment != nil {
+					aEnv = a.Environment.ID
+				}
+				if b.Environment != nil {
+					bEnv = b.Environment.ID
+				}
+				return cmp.Or(
+					cmp.Compare(a.DefinitionMetadata.Class, b.DefinitionMetadata.Class),
+					cmp.Compare(aEnv, bEnv),
+					cmp.Compare(a.Alias, b.Alias),
+				)
+			})
+
+			r := make([]cty.Value, 0, len(matched))
+			for _, b := range matched {
+				r = append(r, MakeObjectFromBundle(b))
 			}
 			return cty.TupleVal(r), nil
 		},

--- a/config/hcl_func_test.go
+++ b/config/hcl_func_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 
 	"github.com/madlambda/spells/assert"
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/terramate-io/terramate/config"
 	"github.com/terramate-io/terramate/hcl/eval"
 	"github.com/terramate-io/terramate/stdlib"
@@ -133,4 +135,177 @@ func TestTmSource(t *testing.T) {
 			assert.EqualStrings(t, tc.want, val.AsString())
 		})
 	}
+}
+
+func TestTmBundles(t *testing.T) {
+	t.Parallel()
+
+	envProd := &config.Environment{ID: "prod-id", Name: "prod"}
+	envDev := &config.Environment{ID: "dev-id", Name: "dev"}
+
+	newBundle := func(alias, class string, env *config.Environment) *config.Bundle {
+		return &config.Bundle{
+			Alias:              alias,
+			DefinitionMetadata: config.Metadata{Class: class},
+			Environment:        env,
+			Inputs:             map[string]cty.Value{},
+			Exports:            map[string]cty.Value{},
+		}
+	}
+
+	aliasesOf := func(t *testing.T, val cty.Value) []string {
+		t.Helper()
+		var out []string
+		for it := val.ElementIterator(); it.Next(); {
+			_, v := it.Element()
+			out = append(out, v.GetAttr("alias").AsString())
+		}
+		return out
+	}
+
+	evalBundles := func(t *testing.T, reg *config.Registry, currentEnv *config.Environment, expr string) cty.Value {
+		t.Helper()
+		rootdir := test.TempDir(t)
+		ctx := eval.NewContext(stdlib.Functions(rootdir, []string{}))
+		ctx.SetFunction("tm_bundles", config.BundlesFunc(reg, currentEnv))
+
+		val, err := ctx.Eval(test.NewExpr(t, expr))
+		assert.NoError(t, err)
+		return val
+	}
+
+	t.Run("results are sorted by alias regardless of registry order", func(t *testing.T) {
+		reg := &config.Registry{
+			Bundles: []*config.Bundle{
+				newBundle("charlie", "team", nil),
+				newBundle("alpha", "team", nil),
+				newBundle("bravo", "team", nil),
+			},
+		}
+
+		got := aliasesOf(t, evalBundles(t, reg, nil, `tm_bundles("team")`))
+		assert.EqualInts(t, 3, len(got))
+		assert.EqualStrings(t, "alpha", got[0])
+		assert.EqualStrings(t, "bravo", got[1])
+		assert.EqualStrings(t, "charlie", got[2])
+	})
+
+	t.Run("sort order is class, then env ID, then alias", func(t *testing.T) {
+		// Env-less bundles (env sort key "") must come before env-scoped bundles
+		// within the same class. Env filter keeps only one non-empty env ID in the
+		// result set, so that edge is where the env tiebreaker matters.
+		reg := &config.Registry{
+			Bundles: []*config.Bundle{
+				newBundle("z", "team-b", envProd),
+				newBundle("a", "team-b", nil),
+				newBundle("b", "team-a", envProd),
+				newBundle("a", "team-a", envProd),
+				newBundle("c", "team-a", nil),
+			},
+		}
+
+		val := evalBundles(t, reg, envProd, `tm_bundles("*")`)
+		type row struct{ class, env, alias string }
+		var got []row
+		for it := val.ElementIterator(); it.Next(); {
+			_, v := it.Element()
+			envAttr := v.GetAttr("environment")
+			env := ""
+			if envAttr.GetAttr("available").True() {
+				env = envAttr.GetAttr("id").AsString()
+			}
+			got = append(got, row{
+				class: v.GetAttr("class").AsString(),
+				env:   env,
+				alias: v.GetAttr("alias").AsString(),
+			})
+		}
+		want := []row{
+			{"team-a", "", "c"},
+			{"team-a", "prod-id", "a"},
+			{"team-a", "prod-id", "b"},
+			{"team-b", "", "a"},
+			{"team-b", "prod-id", "z"},
+		}
+		assert.EqualInts(t, len(want), len(got))
+		for i := range want {
+			assert.EqualStrings(t, want[i].class, got[i].class, fmt.Sprintf("row %d class", i))
+			assert.EqualStrings(t, want[i].env, got[i].env, fmt.Sprintf("row %d env", i))
+			assert.EqualStrings(t, want[i].alias, got[i].alias, fmt.Sprintf("row %d alias", i))
+		}
+	})
+
+	t.Run("filters by class", func(t *testing.T) {
+		reg := &config.Registry{
+			Bundles: []*config.Bundle{
+				newBundle("a", "team", nil),
+				newBundle("b", "other", nil),
+				newBundle("c", "team", nil),
+			},
+		}
+
+		got := aliasesOf(t, evalBundles(t, reg, nil, `tm_bundles("team")`))
+		assert.EqualInts(t, 2, len(got))
+		assert.EqualStrings(t, "a", got[0])
+		assert.EqualStrings(t, "c", got[1])
+	})
+
+	t.Run("wildcard class matches all", func(t *testing.T) {
+		reg := &config.Registry{
+			Bundles: []*config.Bundle{
+				newBundle("b", "other", nil),
+				newBundle("a", "team", nil),
+			},
+		}
+
+		got := aliasesOf(t, evalBundles(t, reg, nil, `tm_bundles("*")`))
+		// Sorted by class first: "other" < "team".
+		assert.EqualInts(t, 2, len(got))
+		assert.EqualStrings(t, "b", got[0])
+		assert.EqualStrings(t, "a", got[1])
+	})
+
+	t.Run("filters by current environment", func(t *testing.T) {
+		reg := &config.Registry{
+			Bundles: []*config.Bundle{
+				newBundle("a", "team", envProd),
+				newBundle("b", "team", envDev),
+				newBundle("c", "team", nil), // env-less bundles are always included
+			},
+		}
+
+		got := aliasesOf(t, evalBundles(t, reg, envProd, `tm_bundles("team")`))
+		// Env-less (sort key "") comes before env-scoped ("prod-id").
+		assert.EqualInts(t, 2, len(got))
+		assert.EqualStrings(t, "c", got[0])
+		assert.EqualStrings(t, "a", got[1])
+	})
+
+	t.Run("explicit env arg overrides current environment", func(t *testing.T) {
+		reg := &config.Registry{
+			Bundles: []*config.Bundle{
+				newBundle("a", "team", envProd),
+				newBundle("b", "team", envDev),
+			},
+		}
+
+		got := aliasesOf(t, evalBundles(t, reg, envProd, `tm_bundles("team", "dev-id")`))
+		assert.EqualInts(t, 1, len(got))
+		assert.EqualStrings(t, "b", got[0])
+	})
+
+	t.Run("empty registry returns empty tuple", func(t *testing.T) {
+		got := aliasesOf(t, evalBundles(t, &config.Registry{}, nil, `tm_bundles("team")`))
+		assert.EqualInts(t, 0, len(got))
+	})
+
+	t.Run("no class match returns empty tuple", func(t *testing.T) {
+		reg := &config.Registry{
+			Bundles: []*config.Bundle{
+				newBundle("a", "other", nil),
+			},
+		}
+		got := aliasesOf(t, evalBundles(t, reg, nil, `tm_bundles("team")`))
+		assert.EqualInts(t, 0, len(got))
+	})
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Please read our contribution policy: https://github.com/terramate-io/terramate/blob/main/CONTRIBUTING.md
   Note: All code contributions are managed exclusively by the Terramate team.
2. If the PR is unfinished, mark it as draft: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request
3. Please update the PR title using the Conventional Commits convention: https://www.conventionalcommits.org/en/v1.0.0/
    Example: feat: add support for XYZ.
-->

## What this PR does / why we need it:

This PR orders the results of `tm_bundles()`. Before, the resulting order was non-deterministic. We use `.Alias` as the ordering key, is stable and unique for each entry, and should usually correspond to the ordering show in input forms.

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Keep it empty if not applicable.
-->
Fixes #2342

## Does this PR introduce a user-facing change?
<!--
If no, just write "no" in the block below.
If yes, please explain the change and update documentation and the CHANGELOG.md file accordingly.
-->
```
yes, see changelog
```


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to ordering logic plus new tests; main impact is user-visible output order, which may affect callers relying on previous incidental ordering.
> 
> **Overview**
> Ensures `tm_bundles()` returns results in a deterministic order by sorting matched bundles before converting them to `cty` values (ordered by class, environment ID, then alias), eliminating dependency on registry iteration order.
> 
> Adds comprehensive unit tests covering sorting behavior, class/environment filtering, wildcard class handling, and empty-result cases, and documents the fix in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cb0ebd64e156be2650192a89326c05450f8efce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->