### PR TITLE
feat: check promote for missing bundle references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 - Backward compatibility in versions `0.0.z` is **not guaranteed** when `z` is increased.
 - Backward compatibility in versions `0.y.z` is **not guaranteed** when `y` is increased.
 
+## Unreleased
+
+### Added
+
+- Hide bundles in the `terrmate ui` promote list, if they reference other bundles that would not exist in the target environment.
+  - This prevents errors that would otherwise occur once the bundle has been promoted.
+
 ## 0.17.0
 
 ### Added

--- a/commands/ui/view_promote.go
+++ b/commands/ui/view_promote.go
@@ -9,6 +9,7 @@ import (
 	"github.com/charmbracelet/bubbles/key"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/zclconf/go-cty/cty"
 
 	"github.com/terramate-io/terramate/config"
 	"github.com/terramate-io/terramate/errors"
@@ -130,7 +131,7 @@ func (m Model) buildPromoteFilters() []envFilterState {
 			if b.Environment == nil || b.Environment.ID != targetEnv.PromoteFrom {
 				continue
 			}
-			if !envAliases[b.Alias] {
+			if !envAliases[b.Alias] && len(missingBundleRefs(b, envAliases)) == 0 {
 				targetEnvHas[targetEnv.ID] = true
 				break
 			}
@@ -190,6 +191,9 @@ func (m Model) buildAllPromoteBundles() ([]*config.Bundle, []*config.Environment
 			if existing[b.Alias] {
 				continue
 			}
+			if len(missingBundleRefs(b, existing)) > 0 {
+				continue
+			}
 			bundles = append(bundles, b)
 			targetEnvs = append(targetEnvs, targetEnv)
 		}
@@ -207,6 +211,54 @@ func (m Model) buildAllPromoteBundles() ([]*config.Bundle, []*config.Environment
 		}
 	}
 	return sorted, sortedEnvs
+}
+
+// missingBundleRefs walks the inputs of b and returns the aliases of any
+// referenced bundles (cty objects with alias, class, environment.available==true)
+// that are absent from targetAliases.
+func missingBundleRefs(b *config.Bundle, targetAliases map[string]bool) []string {
+	seen := make(map[string]bool)
+	var missing []string
+
+	var walk func(v cty.Value)
+	walk = func(v cty.Value) {
+		if !v.IsKnown() || v.IsNull() {
+			return
+		}
+		t := v.Type()
+		if t.IsObjectType() &&
+			t.HasAttribute("alias") &&
+			t.HasAttribute("class") &&
+			t.HasAttribute("environment") {
+			envVal := v.GetAttr("environment")
+			if envVal.IsKnown() && !envVal.IsNull() &&
+				envVal.Type().IsObjectType() &&
+				envVal.Type().HasAttribute("available") {
+				avail := envVal.GetAttr("available")
+				if avail.IsKnown() && !avail.IsNull() && avail.True() {
+					alias := v.GetAttr("alias").AsString()
+					if !targetAliases[alias] && !seen[alias] {
+						seen[alias] = true
+						missing = append(missing, alias)
+					}
+				}
+			}
+			return // do not descend into the referenced bundle's embedded inputs/exports
+		}
+
+		if t.IsObjectType() || t.IsMapType() ||
+			t.IsListType() || t.IsTupleType() || t.IsSetType() {
+			for it := v.ElementIterator(); it.Next(); {
+				_, elem := it.Element()
+				walk(elem)
+			}
+		}
+	}
+
+	for _, v := range b.Inputs {
+		walk(v)
+	}
+	return missing
 }
 
 func envNameForID(envs []*config.Environment, envID string) string {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Please read our contribution policy: https://github.com/terramate-io/terramate/blob/main/CONTRIBUTING.md
   Note: All code contributions are managed exclusively by the Terramate team.
2. If the PR is unfinished, mark it as draft: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request
3. Please update the PR title using the Conventional Commits convention: https://www.conventionalcommits.org/en/v1.0.0/
    Example: feat: add support for XYZ.
-->

## What this PR does / why we need it:

This PR hides bundles from the promote list, if they have bundle references that do not yet exist in the target environment.

## Does this PR introduce a user-facing change?
<!--
If no, just write "no" in the block below.
If yes, please explain the change and update documentation and the CHANGELOG.md file accordingly.
-->
```
yes, see changelog
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `terramate ui` promote selection logic to exclude bundles based on parsed input references, which could unintentionally hide promotable bundles or miss edge cases in `cty` value traversal.
> 
> **Overview**
> Updates `terramate ui`'s promote selection to **hide bundles that reference other bundles not present in the target environment**, preventing promotions that would later fail.
> 
> Implements a new `missingBundleRefs()` walker over bundle `Inputs` (using `cty`) and applies it both when deciding which target environments have promotable bundles and when building the promotable bundle list. Adds a corresponding entry to `CHANGELOG.md` under *Unreleased*.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a9c118af8986d80fb674d42bb857d31eb801e1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->