### PR TITLE
fix: add scrolling to environment selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 ### Fixed
 
 - Fix misleading error message when a remote bundle/component source is not found.
+- Fix missing scrolling in `terramate ui` scaffold environment selection.
 
 ## 0.17.1
 

--- a/commands/ui/view_create_select.go
+++ b/commands/ui/view_create_select.go
@@ -402,34 +402,64 @@ func (m Model) renderCreateEnvSelectView() string {
 		detailBox = renderDetailBox(innerWidth, "Bundle Details", fields)
 	}
 
+	scrollbarGutter := 4
+	contentWidth := innerWidth - scrollbarGutter
+
 	itemStyle := lipgloss.NewStyle().
-		PaddingLeft(2)
+		PaddingLeft(2).
+		Width(contentWidth)
 
 	selectedStyle := lipgloss.NewStyle().
 		PaddingLeft(2).
 		Foreground(colorPrimary).
-		Bold(true)
+		Bold(true).
+		Width(contentWidth)
 
 	itemDescStyle := lipgloss.NewStyle().
 		PaddingLeft(4).
-		Foreground(colorTextMuted)
+		Foreground(colorTextMuted).
+		Width(contentWidth)
 
 	idStyle := lipgloss.NewStyle().
 		Foreground(colorTextSubtle)
 
-	var items []string
+	envHeader := lipgloss.JoinVertical(lipgloss.Left, detailBox, "")
+	availableHeight := m.effectiveContentHeight() - lipgloss.Height(envHeader)
+
+	var items []renderedItem
 	for i, env := range est.Registry.Environments {
 		idTag := idStyle.Render("[" + env.ID + "]")
+
+		var block string
 		if i == m.createEnvCursor {
-			items = append(items, selectedStyle.Render("› "+env.Name)+" "+idTag)
+			block = selectedStyle.Render("› " + env.Name + " " + idTag)
 		} else {
-			items = append(items, itemStyle.Render("  "+env.Name)+" "+idTag)
+			block = itemStyle.Render("  " + env.Name + " " + idTag)
 		}
-		items = append(items, itemDescStyle.Render(env.Description))
-		items = append(items, "")
+		if env.Description != "" {
+			block += "\n" + itemDescStyle.Render(summaryLine(strings.TrimSpace(env.Description)))
+		}
+		items = append(items, renderedItem{content: block, height: lipgloss.Height(block)})
 	}
 
-	panelContent := lipgloss.JoinVertical(lipgloss.Left, append([]string{detailBox, ""}, items...)...)
+	start, end := scrollWindowVar(m.createEnvCursor, items, availableHeight, 1)
+
+	var sb strings.Builder
+	for i := start; i < end; i++ {
+		if i > start {
+			sb.WriteString("\n\n")
+		}
+		sb.WriteString(items[i].content)
+	}
+	listContent := sb.String()
+
+	if len(items) > end-start {
+		trackHeight := lipgloss.Height(listContent)
+		scrollbar := renderScrollbar(len(items), end-start, start, trackHeight)
+		listContent = lipgloss.JoinHorizontal(lipgloss.Top, listContent, " ", scrollbar, "  ")
+	}
+
+	panelContent := lipgloss.JoinVertical(lipgloss.Left, envHeader, listContent)
 	panel := borderStyle.Render(panelContent)
 
 	help := helpStyle.Render(m.finalHelpText("↑↓: Select Environment • esc: back"))


### PR DESCRIPTION
## What this PR does / why we need it:

This PR adds scrolling to the environment selection during `terramate ui` scaffold.

## Does this PR introduce a user-facing change?
<!--
If no, just write "no" in the block below.
If yes, please explain the change and update documentation and the CHANGELOG.md file accordingly.
-->
```
yes, see changelog
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> TUI-only rendering change in the create/env-select view; no auth, data, or scaffold logic changes beyond layout and scrolling.
> 
> **Overview**
> Fixes **missing scroll** on the `terramate ui` scaffold step where you pick an environment after choosing a bundle.
> 
> The environment list now uses the same **variable-height viewport** as bundle selection: space below the bundle detail box is computed with `scrollWindowVar`, only visible rows are drawn, and a **scrollbar** appears when not all environments fit. Each row is one block (name, ID, optional description on the next line) instead of rendering every environment’s description at once.
> 
> **CHANGELOG** documents the fix under Unreleased → Fixed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51368fa37b5d749a9b261893a14a0e8021526bdd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->