### PR TITLE
fix: make bundle lookup key unambigious

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 
 - Fix misleading error message when a remote bundle/component source is not found.
 - Fix missing scrolling in `terramate ui` scaffold environment selection.
+- Fix bundle lookup when the same alias is used for bundles of different classes.
 
 ## 0.17.1
 

--- a/config/hcl_func.go
+++ b/config/hcl_func.go
@@ -26,25 +26,28 @@ type Registry struct {
 	Bundles      []*Bundle
 }
 
-// BundleAliasAwaitKey computes the preempt await key for a bundle alias and environment ID.
-func BundleAliasAwaitKey(alias, envID string) string {
-	return fmt.Sprintf("%s:%s", envID, alias)
+// BundleAliasAwaitKey computes the preempt await key for a bundle with the given
+// class and alias, looked up from the environment envID.
+func BundleAliasAwaitKey(class, alias, envID string) string {
+	return fmt.Sprintf("alias:%s:%s:%s", envID, class, alias)
 }
 
-// BundleUUIDAwaitKey computes the preempt await key for a bundle UUID and environment ID.
-func BundleUUIDAwaitKey(uuid, envID string) string {
-	return fmt.Sprintf("%s:%s", envID, uuid)
+// BundleUUIDAwaitKey computes the preempt await key for a bundle with the given class
+// and UUID, looked up from the environment envID.
+func BundleUUIDAwaitKey(class, uuid, envID string) string {
+	return fmt.Sprintf("uuid:%s:%s:%s", envID, class, uuid)
 }
 
-// BundleAwaitKeys returns all preempt await keys for the given bundle.
+// BundleAwaitKeys returns all preempt await keys produced by the given bundle.
 func BundleAwaitKeys(b *Bundle) []string {
 	envID := ""
 	if b.Environment != nil {
 		envID = b.Environment.ID
 	}
-	keys := []string{BundleAliasAwaitKey(b.Alias, envID)}
+	class := b.DefinitionMetadata.Class
+	keys := []string{BundleAliasAwaitKey(class, b.Alias, envID)}
 	if b.UUID != "" {
-		keys = append(keys, BundleUUIDAwaitKey(b.UUID, envID))
+		keys = append(keys, BundleUUIDAwaitKey(class, b.UUID, envID))
 	}
 	return keys
 }
@@ -87,14 +90,14 @@ func BundleFunc(ctx context.Context, reg *Registry, currentEnv *Environment, use
 				pred = func(b *Bundle) bool {
 					return b.UUID == key
 				}
-				awaitKey = BundleUUIDAwaitKey(key, envID)
+				awaitKey = BundleUUIDAwaitKey(class, key, envID)
 
 			} else {
 				keyKind = "alias"
 				pred = func(b *Bundle) bool {
 					return b.Alias == key
 				}
-				awaitKey = BundleAliasAwaitKey(key, envID)
+				awaitKey = BundleAliasAwaitKey(class, key, envID)
 			}
 
 			if useAwait {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Please read our contribution policy: https://github.com/terramate-io/terramate/blob/main/CONTRIBUTING.md
   Note: All code contributions are managed exclusively by the Terramate team.
2. If the PR is unfinished, mark it as draft: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request
3. Please update the PR title using the Conventional Commits convention: https://www.conventionalcommits.org/en/v1.0.0/
    Example: feat: add support for XYZ.
-->

## What this PR does / why we need it:

This PR fixes that the unique await key would not include the bundle class, so bundles with the same alias but different class would be mixed together. It also prefixes the key type for uuid and alias, though a collision here would be unlikely.

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Keep it empty if not applicable.
-->
Fixes #2367 
Thanks @Wihrt for investigating the bug and finding the root cause.

## Does this PR introduce a user-facing change?
<!--
If no, just write "no" in the block below.
If yes, please explain the change and update documentation and the CHANGELOG.md file accordingly.
-->
```
yes, see changelog
```
