### PR TITLE
fix: preserve seeded values as user edited

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 - Fix misleading error message when a remote bundle/component source is not found.
 - Fix missing scrolling in `terramate ui` scaffold environment selection.
 - Fix bundle lookup when the same alias is used for bundles of different classes.
+- Fix input values being dropped when editing deeply nested objects with multiple attributes.
 
 ## 0.17.1
 

--- a/commands/ui/inputs_form.go
+++ b/commands/ui/inputs_form.go
@@ -743,6 +743,9 @@ func (f *InputsForm) isUserModified(idx int) bool {
 func (f *InputsForm) SeedValues(vals map[string]cty.Value) {
 	for name, v := range vals {
 		f.setValueByName(name, v)
+		if v != cty.NilVal {
+			f.userModified[name] = true
+		}
 	}
 	if f.activeIdx >= 0 && f.activeIdx < len(f.InputDefs) {
 		f.prepareInput(f.activeIdx)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Please read our contribution policy: https://github.com/terramate-io/terramate/blob/main/CONTRIBUTING.md
   Note: All code contributions are managed exclusively by the Terramate team.
2. If the PR is unfinished, mark it as draft: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request
3. Please update the PR title using the Conventional Commits convention: https://www.conventionalcommits.org/en/v1.0.0/
    Example: feat: add support for XYZ.
-->

## What this PR does / why we need it:

This PR marks seeded in a sub-form as user modified. This works just like when editing a top-level form to preserve user edits in attributes.

## Does this PR introduce a user-facing change?
<!--
If no, just write "no" in the block below.
If yes, please explain the change and update documentation and the CHANGELOG.md file accordingly.
-->
```
yes, see changelog
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to UI form seeding behavior with a clear user-facing bugfix and no auth or data-path impact.
> 
> **Overview**
> Fixes **`terramate ui`** dropping attribute values when you edit **nested object** inputs that have several fields.
> 
> **`InputsForm.SeedValues`** (used when opening a nested sub-form in edit mode) now marks each non-nil seeded value in **`userModified`**, same as explicitly confirmed inputs. Without that, only **`UserValues()`**-eligible fields were kept on confirm, and dependency/default logic could treat sibling attributes as unset.
> 
> Changelog updated under **Unreleased → Fixed**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5220104e5a9da3ad991a46ae541100486014cba7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->