### PR TITLE
fix: keep existing unprompted values during reconfigure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 - Backward compatibility in versions `0.0.z` is **not guaranteed** when `z` is increased.
 - Backward compatibility in versions `0.y.z` is **not guaranteed** when `y` is increased.
 
+## Unreleased
+
+### Fixed
+
+- Fix inputs without a `prompt` block being dropped from the config when a bundle instance is reconfigured or promoted in `terramate ui`.
+
 ## 0.17.2
 
 ### Fixed

--- a/commands/ui/change.go
+++ b/commands/ui/change.go
@@ -435,12 +435,9 @@ func checkBundleRefsResolved(inputDefs []*config.InputDefinition, values map[str
 func (c *Change) Save(envs []*config.Environment) error {
 	var existing *yaml.BundleInstance
 
-	_, err := os.Stat(c.HostPath)
-	overwrite := err == nil
-
-	// If the change doesn't have an env, the bundle doesn't have envs, so no need for merging.
-	if overwrite && c.Env != nil {
-		var err error
+	// The existing config is needed for merging environments and to carry over
+	// inputs that are not part of the change, i.e. the ones without a prompt.
+	if _, err := os.Stat(c.HostPath); err == nil {
 		existing, err = loadBundleYAMLConfig(c.HostPath)
 		if err != nil {
 			return err
@@ -456,10 +453,16 @@ func (c *Change) Save(envs []*config.Environment) error {
 
 func (c *Change) generateBundleYAML(existing *yaml.BundleInstance, envs []*config.Environment) (string, error) {
 	inputs := yaml.Map[any]{}
+	// The change is only authoritative for the inputs it knows about. Inputs
+	// without a prompt never make it into a change, so they must be carried over
+	// from the existing config instead.
+	owned := make(map[string]bool, len(c.InputDefs))
 	for _, def := range c.InputDefs {
 		if isPseudoKey(def.Name) {
 			continue
 		}
+		owned[def.Name] = true
+
 		v, found := c.UserValues[def.Name]
 		if !found || v == cty.NilVal {
 			continue
@@ -482,6 +485,8 @@ func (c *Change) generateBundleYAML(existing *yaml.BundleInstance, envs []*confi
 			Value: yaml.Attr(yv),
 		})
 	}
+
+	inputs = mergeInputs(inputs, c.existingInputs(existing), owned)
 
 	var envID string
 	if c.Env != nil {
@@ -563,6 +568,66 @@ func loadBundleYAMLConfig(p string) (*yaml.BundleInstance, error) {
 
 func hasYAMLConfigExt(fn string) bool {
 	return strings.HasSuffix(fn, ".tm.yml") || strings.HasSuffix(fn, ".tm.yaml")
+}
+
+// existingInputs returns the inputs of the config block the change is derived
+// from, which is the environment a bundle is promoted from, the environment
+// being written, or the spec of a bundle without environments.
+func (c *Change) existingInputs(existing *yaml.BundleInstance) yaml.Map[any] {
+	if existing == nil {
+		return nil
+	}
+	if c.Env == nil {
+		return existing.Inputs.V
+	}
+
+	envID := c.Env.ID
+	if c.FromEnv != nil {
+		envID = c.FromEnv.ID
+	}
+	for _, item := range existing.Environments.V {
+		if item.Key.V == envID && item.Value.V != nil {
+			return item.Value.V.Inputs.V
+		}
+	}
+	return nil
+}
+
+// mergeInputs merges the generated inputs into the inputs of the existing
+// config. Entries the change is not authoritative for are carried over
+// unchanged, which keeps their original order and comments. Owned entries are
+// replaced by the generated value, or dropped if the change has no value for
+// them anymore.
+func mergeInputs(generated, existing yaml.Map[any], owned map[string]bool) yaml.Map[any] {
+	if len(existing) == 0 {
+		return generated
+	}
+
+	generatedByKey := make(map[string]yaml.MapItem[any], len(generated))
+	for _, item := range generated {
+		generatedByKey[item.Key.V] = item
+	}
+
+	merged := make(yaml.Map[any], 0, len(generated)+len(existing))
+	carried := make(map[string]bool, len(existing))
+	for _, item := range existing {
+		carried[item.Key.V] = true
+		if !owned[item.Key.V] {
+			merged = append(merged, item)
+			continue
+		}
+		if gen, found := generatedByKey[item.Key.V]; found {
+			merged = append(merged, gen)
+		}
+	}
+
+	// Inputs that are not in the existing config yet are appended.
+	for _, item := range generated {
+		if !carried[item.Key.V] {
+			merged = append(merged, item)
+		}
+	}
+	return merged
 }
 
 func mergeBundleYAMLEnv(existing yaml.BundleInstance, envID string, env *yaml.BundleEnvironment, envs []*config.Environment) yaml.BundleInstance {

--- a/commands/ui/change_test.go
+++ b/commands/ui/change_test.go
@@ -1,0 +1,254 @@
+// Copyright 2026 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/terramate-io/terramate/config"
+	"github.com/terramate-io/terramate/typeschema"
+	"github.com/terramate-io/terramate/yaml"
+)
+
+// Only inputs with a prompt are part of a change. All other inputs of a bundle
+// must be carried over from the existing config.
+var promptedDefs = []*config.InputDefinition{
+	promptedInput("name", "Name of the instance", "Name"),
+	promptedInput("description", "Short description", "Description"),
+}
+
+func TestGenerateBundleYAMLKeepsInputsWithoutPrompt(t *testing.T) {
+	existing := decodeBundleInstance(t, `apiVersion: terramate.io/cli/v1
+kind: BundleInstance
+metadata:
+  name: example
+  uuid: 6f2c1f6a-5c1a-4a2e-9f1b-2a7c0d3e4b55
+spec:
+  source: /bundles/example/v1
+  inputs:
+    # tmdoc: Name of the instance
+    name: example
+    # tmdoc: Gitignore template applied on creation
+    gitignore_template: Terraform
+    # tmdoc: Archive the instance, making it read-only
+    archived: true
+`)
+
+	change := reconfigChange(nil, map[string]cty.Value{
+		"name":        cty.StringVal("example"),
+		"description": cty.StringVal("Set during the reconfigure"),
+	})
+
+	// The inputs without a prompt keep their position and comments, while the
+	// newly set description is appended.
+	assertBundleYAML(t, change, existing, nil, `apiVersion: terramate.io/cli/v1
+kind: BundleInstance
+metadata:
+  name: example
+  uuid: 6f2c1f6a-5c1a-4a2e-9f1b-2a7c0d3e4b55
+spec:
+  source: /bundles/example/v1
+  inputs:
+    # tmdoc: Name of the instance
+    name: example
+    # tmdoc: Gitignore template applied on creation
+    gitignore_template: Terraform
+    # tmdoc: Archive the instance, making it read-only
+    archived: true
+    # tmdoc: Short description
+    description: Set during the reconfigure
+`)
+}
+
+func TestGenerateBundleYAMLDropsResetInput(t *testing.T) {
+	existing := decodeBundleInstance(t, `apiVersion: terramate.io/cli/v1
+kind: BundleInstance
+metadata:
+  name: example
+  uuid: 6f2c1f6a-5c1a-4a2e-9f1b-2a7c0d3e4b55
+spec:
+  source: /bundles/example/v1
+  inputs:
+    # tmdoc: Name of the instance
+    name: example
+    # tmdoc: Short description
+    description: Instance created before the reconfigure
+    # tmdoc: Archive the instance, making it read-only
+    archived: true
+`)
+
+	// The description was reset in the form, so the change has no value for it.
+	change := reconfigChange(nil, map[string]cty.Value{
+		"name": cty.StringVal("example"),
+	})
+
+	assertBundleYAML(t, change, existing, nil, `apiVersion: terramate.io/cli/v1
+kind: BundleInstance
+metadata:
+  name: example
+  uuid: 6f2c1f6a-5c1a-4a2e-9f1b-2a7c0d3e4b55
+spec:
+  source: /bundles/example/v1
+  inputs:
+    # tmdoc: Name of the instance
+    name: example
+    # tmdoc: Archive the instance, making it read-only
+    archived: true
+`)
+}
+
+func TestGenerateBundleYAMLKeepsInputsWithoutPromptOfEnv(t *testing.T) {
+	dev := &config.Environment{ID: "dev", Name: "Development"}
+	prod := &config.Environment{ID: "prod", Name: "Production"}
+
+	existing := decodeBundleInstance(t, `apiVersion: terramate.io/cli/v1
+kind: BundleInstance
+metadata:
+  name: example
+  uuid: 6f2c1f6a-5c1a-4a2e-9f1b-2a7c0d3e4b55
+environments:
+  dev:
+    source: /bundles/example/v1
+    inputs:
+      # tmdoc: Name of the instance
+      name: example-dev
+      # tmdoc: Gitignore template applied on creation
+      gitignore_template: Terraform
+  prod:
+    source: /bundles/example/v1
+    inputs:
+      # tmdoc: Name of the instance
+      name: example-prod
+      # tmdoc: Archive the instance, making it read-only
+      archived: true
+`)
+
+	// Reconfiguring prod must not touch dev, and must keep the inputs without a
+	// prompt of prod itself.
+	change := reconfigChange(prod, map[string]cty.Value{
+		"name": cty.StringVal("example-production"),
+	})
+
+	// The empty spec is what the encoder emits for a config that only has
+	// environments, independent of the merge.
+	assertBundleYAML(t, change, existing, []*config.Environment{dev, prod}, `apiVersion: terramate.io/cli/v1
+kind: BundleInstance
+metadata:
+  name: example
+  uuid: 6f2c1f6a-5c1a-4a2e-9f1b-2a7c0d3e4b55
+spec: {}
+environments:
+  dev:
+    source: /bundles/example/v1
+    inputs:
+      # tmdoc: Name of the instance
+      name: example-dev
+      # tmdoc: Gitignore template applied on creation
+      gitignore_template: Terraform
+  prod:
+    source: /bundles/example/v1
+    inputs:
+      # tmdoc: Name of the instance
+      name: example-production
+      # tmdoc: Archive the instance, making it read-only
+      archived: true
+`)
+}
+
+func TestGenerateBundleYAMLPromoteKeepsInputsWithoutPrompt(t *testing.T) {
+	dev := &config.Environment{ID: "dev", Name: "Development"}
+	prod := &config.Environment{ID: "prod", Name: "Production"}
+
+	existing := decodeBundleInstance(t, `apiVersion: terramate.io/cli/v1
+kind: BundleInstance
+metadata:
+  name: example
+  uuid: 6f2c1f6a-5c1a-4a2e-9f1b-2a7c0d3e4b55
+environments:
+  dev:
+    source: /bundles/example/v1
+    inputs:
+      # tmdoc: Name of the instance
+      name: example-dev
+      # tmdoc: Gitignore template applied on creation
+      gitignore_template: Terraform
+`)
+
+	// Promoting dev to prod: the inputs without a prompt must come along, since
+	// the target environment does not have them yet.
+	change := reconfigChange(prod, map[string]cty.Value{
+		"name": cty.StringVal("example-prod"),
+	})
+	change.Kind = ChangePromote
+	change.FromEnv = dev
+
+	assertBundleYAML(t, change, existing, []*config.Environment{dev, prod}, `apiVersion: terramate.io/cli/v1
+kind: BundleInstance
+metadata:
+  name: example
+  uuid: 6f2c1f6a-5c1a-4a2e-9f1b-2a7c0d3e4b55
+spec: {}
+environments:
+  dev:
+    source: /bundles/example/v1
+    inputs:
+      # tmdoc: Name of the instance
+      name: example-dev
+      # tmdoc: Gitignore template applied on creation
+      gitignore_template: Terraform
+  prod:
+    source: /bundles/example/v1
+    inputs:
+      # tmdoc: Name of the instance
+      name: example-prod
+      # tmdoc: Gitignore template applied on creation
+      gitignore_template: Terraform
+`)
+}
+
+func promptedInput(name, description, prompt string) *config.InputDefinition {
+	return &config.InputDefinition{
+		Name:        name,
+		Description: description,
+		Type:        &typeschema.PrimitiveType{Name: "string"},
+		Prompt:      config.PromptConfig{Text: prompt},
+	}
+}
+
+func reconfigChange(env *config.Environment, userValues map[string]cty.Value) Change {
+	return Change{
+		Kind:       ChangeReconfig,
+		Name:       "example",
+		UUID:       "6f2c1f6a-5c1a-4a2e-9f1b-2a7c0d3e4b55",
+		Source:     "/bundles/example/v1",
+		Env:        env,
+		InputDefs:  promptedDefs,
+		UserValues: userValues,
+	}
+}
+
+func assertBundleYAML(t *testing.T, c Change, existing *yaml.BundleInstance, envs []*config.Environment, want string) {
+	t.Helper()
+
+	got, err := c.generateBundleYAML(existing, envs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf("unexpected config\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	}
+}
+
+func decodeBundleInstance(t *testing.T, content string) *yaml.BundleInstance {
+	t.Helper()
+
+	var bundle yaml.BundleInstance
+	if err := yaml.Decode(strings.NewReader(content), &bundle); err != nil {
+		t.Fatal(err)
+	}
+	return &bundle
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Please read our contribution policy: https://github.com/terramate-io/terramate/blob/main/CONTRIBUTING.md
   Note: All code contributions are managed exclusively by the Terramate team.
2. If the PR is unfinished, mark it as draft: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request
3. Please update the PR title using the Conventional Commits convention: https://www.conventionalcommits.org/en/v1.0.0/
    Example: feat: add support for XYZ.
-->

## What this PR does / why we need it:
Before this fix, unprompted values (i.e. values not shown in terramate ui) were not preserved in the YAML file during a `terramate ui` reconfigure.

## Does this PR introduce a user-facing change?
<!--
If no, just write "no" in the block below.
If yes, please explain the change and update documentation and the CHANGELOG.md file accordingly.
-->
```
yes, see changelog
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted fix to bundle YAML persistence in the UI save path, with regression tests and no auth or infrastructure impact.
> 
> **Overview**
> Reconfigure and promote in **`terramate ui`** no longer strip bundle instance inputs that are not shown in the form (inputs without a `prompt` block).
> 
> **`Change.Save` / `generateBundleYAML`** now loads the on-disk bundle YAML whenever the instance file exists and merges YAML output with existing inputs: only prompted fields from the change replace or remove values; unprompted keys are carried over with their order and comments. Promotes copy unprompted inputs from the source environment block into the target.
> 
> Adds unit tests for spec-only, multi-environment reconfigure, promote, and clearing a prompted field; documents the fix under **Unreleased** in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 385197b0feb2f05e40ccde1d957800bef3dd3f24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->