### PR TITLE
fix: do not crash when input has no ui widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 
 ### Fixed
 
+- Fix `terramate ui` crash when using specific input types that are not supported by a form.
 - Fix inputs without a `prompt` block being dropped from the config when a bundle instance is reconfigured or promoted in `terramate ui`.
 
 ## 0.17.2

--- a/commands/ui/inputs_form.go
+++ b/commands/ui/inputs_form.go
@@ -327,10 +327,9 @@ func (f *InputsForm) confirmCurrent() {
 // If all visible inputs are filled, the form moves to the done/buttons state.
 func (f *InputsForm) advanceToNextPending() {
 	for _, idx := range f.allVisibleIndices() {
-		def := f.InputDefs[idx]
 		// Skip inputs with a filled value (either user-set or successfully default-seeded).
 		// Inputs with HasDefault() but no filled value (e.g. default eval failed) are still prompted.
-		if !f.isInputFilled(idx) && !f.hasPendingDependencies(def) {
+		if !f.isInputFilled(idx) && f.canActivate(idx) {
 			f.activeIdx = idx
 			f.prepareInput(idx)
 			return
@@ -353,8 +352,7 @@ func (f *InputsForm) goBack() bool {
 	f.confirmingDiscard = false
 	idx := f.activeIdx - 1
 	for idx >= 0 {
-		def := f.InputDefs[idx]
-		if !f.evalCondition(def) || f.hasPendingDependencies(def) {
+		if !f.canActivate(idx) {
 			idx--
 			continue
 		}
@@ -363,6 +361,33 @@ func (f *InputsForm) goBack() bool {
 		return true
 	}
 	return false
+}
+
+// canActivate reports whether the input at idx can become the active input.
+// A read-only input never can - it has no editor to show - and neither can one
+// whose prompt condition is false or whose dependencies are unresolved. Every
+// search for a new active input goes through this, forwards and backwards.
+func (f *InputsForm) canActivate(idx int) bool {
+	if idx < 0 || idx >= len(f.InputDefs) {
+		return false
+	}
+	def := f.InputDefs[idx]
+	return f.evalCondition(def) && !f.isReadOnly(idx) && !f.hasPendingDependencies(def)
+}
+
+// isReadOnly reports whether the input at idx is shown but cannot be edited:
+// either it is immutable in a diff view, or its type has no editor. Read-only
+// inputs are never made active and cannot be selected in the completed panel.
+func (f *InputsForm) isReadOnly(idx int) bool {
+	if idx < 0 || idx >= len(f.InputDefs) {
+		return false
+	}
+	def := f.InputDefs[idx]
+	if def.Immutable && (f.reconfiguring || f.promoting) {
+		return true
+	}
+	_, noEditor := f.widgets[def.Name].(*readOnlyWidget)
+	return noEditor
 }
 
 // allInputsDone returns true when all inputs have been filled in.
@@ -436,14 +461,13 @@ func (f *InputsForm) maxButtonIdx() int {
 	return 1
 }
 
-// firstSelectableCursor returns the first cursor index that is not immutable or disabled.
-// Returns -1 if no selectable item exists (all inputs are immutable/disabled).
+// firstSelectableCursor returns the first cursor index that is not read-only or disabled.
+// Returns -1 if no selectable item exists (all inputs are read-only/disabled).
 func (f *InputsForm) firstSelectableCursor() int {
-	diffMode := f.reconfiguring || f.promoting
 	visible := f.allVisibleIndices()
 	for i, idx := range visible {
 		def := f.InputDefs[idx]
-		if (def.Immutable && diffMode) || f.hasPendingDependencies(def) {
+		if f.isReadOnly(idx) || f.hasPendingDependencies(def) {
 			continue
 		}
 		if f.isFilteredByRequiredOnly(idx) {
@@ -921,7 +945,7 @@ func (f InputsForm) updateCompleted(msg tea.KeyMsg) (InputsForm, tea.Cmd) {
 		}
 		realIdx := combined[idx]
 		def := f.InputDefs[realIdx]
-		if (def.Immutable && diffMode) || f.hasPendingDependencies(def) {
+		if f.isReadOnly(realIdx) || f.hasPendingDependencies(def) {
 			return true
 		}
 		return f.isFilteredByRequiredOnly(realIdx)
@@ -1011,8 +1035,7 @@ func (f InputsForm) updateCompleted(msg tea.KeyMsg) (InputsForm, tea.Cmd) {
 		}
 		realIdx := combined[f.completedCursor]
 		def := f.InputDefs[realIdx]
-		isImmutable := def.Immutable && diffMode
-		if isImmutable || f.hasPendingDependencies(def) {
+		if f.isReadOnly(realIdx) || f.hasPendingDependencies(def) {
 			return f, nil
 		}
 		f.ReenterAt(realIdx)
@@ -1117,7 +1140,7 @@ func (f InputsForm) updateButtons(msg tea.KeyMsg) (InputsForm, tea.Cmd) {
 		for i := len(combined) - 1; i >= 0; i-- {
 			idx := combined[i]
 			def := f.InputDefs[idx]
-			if (def.Immutable && (f.reconfiguring || f.promoting)) || f.hasPendingDependencies(def) {
+			if f.isReadOnly(idx) || f.hasPendingDependencies(def) {
 				continue
 			}
 			if f.isFilteredByRequiredOnly(idx) {
@@ -1597,7 +1620,7 @@ func (f InputsForm) renderCompletedPanelContent() string {
 		isActive := realIdx == f.activeIdx
 		isDisabled := f.hasPendingDependencies(def)
 		diffMode := f.reconfiguring || f.promoting
-		isImmutable := def.Immutable && diffMode
+		isReadOnly := f.isReadOnly(realIdx)
 		userSet := f.isUserModified(realIdx)
 
 		label := def.Prompt.Text
@@ -1607,10 +1630,10 @@ func (f InputsForm) renderCompletedPanelContent() string {
 
 		// Required: no value at all, non-disabled, non-immutable, no default.
 		requiredIcon := lipgloss.NewStyle().Foreground(colorText).Bold(true).Render("*")
-		isRequired := !isFilled && !isDisabled && !isImmutable && !def.HasDefault() && !diffMode
+		isRequired := !isFilled && !isDisabled && !isReadOnly && !def.HasDefault() && !diffMode
 
-		if isImmutable {
-			// Immutable: not selectable, always show tag
+		if isReadOnly {
+			// Read-only: not selectable, always show tag
 			prefix = "  "
 			statusIcon = " "
 			nameCol = completedLabelStyle.Render(label) + labelPad
@@ -1665,7 +1688,7 @@ func (f InputsForm) renderCompletedPanelContent() string {
 		var valueStr string
 		var valueWidth int
 		dimEquals := false
-		if isImmutable && isFilled {
+		if isReadOnly && isFilled {
 			v := f.formatCompletedValue(realIdx)
 			valueStr = immutableValueStyle.Render(v)
 			valueWidth = len(v)
@@ -1706,8 +1729,12 @@ func (f InputsForm) renderCompletedPanelContent() string {
 
 		// Build the tag (immutable, enter to edit, etc.) and align to a common column.
 		var tag string
-		if isImmutable {
-			tag = hintStyle.Render("immutable")
+		if isReadOnly {
+			if def.Immutable {
+				tag = hintStyle.Render("immutable")
+			} else {
+				tag = hintStyle.Render("read-only")
+			}
 		} else if isCursorSelected && !isDisabled {
 			hint := "enter to edit"
 			if userSet {

--- a/commands/ui/widget.go
+++ b/commands/ui/widget.go
@@ -140,9 +140,33 @@ func NewWidget(wctx *WidgetContext, typ typeschema.Type) InputWidget {
 	case *typeschema.NonStrictType:
 		return NewWidget(wctx, t.Inner)
 	}
-	// Will crash.
-	return nil
+	// No editor for this type - any, tuple, any_of, schema references, merged
+	// objects. The input is still listed with its value, just not editable.
+	return newReadOnlyWidget(wctx, typ)
 }
+
+// readOnlyWidget holds the value of an input the form has no editor for.
+//
+// It exists so such an input is still listed with its value, reusing the
+// read-only presentation of immutable inputs. The form never makes it active -
+// see InputsForm.isReadOnly - so it needs no editing behaviour of its own.
+type readOnlyWidget struct {
+	wctx *WidgetContext
+	typ  typeschema.Type
+}
+
+func newReadOnlyWidget(wctx *WidgetContext, typ typeschema.Type) *readOnlyWidget {
+	return &readOnlyWidget{wctx: wctx, typ: typ}
+}
+
+func (w *readOnlyWidget) WidgetContext() *WidgetContext { return w.wctx }
+func (w *readOnlyWidget) FormatDisplay() string         { return FormatDisplayValue(w.wctx.Value, w.typ) }
+func (w *readOnlyWidget) Prepare()                      {}
+func (w *readOnlyWidget) Render() []string              { return nil }
+func (w *readOnlyWidget) ForwardMsg(tea.Msg) tea.Cmd    { return nil }
+
+func (w *readOnlyWidget) Update(tea.KeyMsg) (WidgetSignal, tea.Cmd) { return WidgetBack, nil }
+func (w *readOnlyWidget) AcceptSubFormResult(SubFormResult) bool    { return true }
 
 // isStructuredObject returns true if typ is an ObjectType with at least one
 // defined attribute. An ObjectType with no attributes is treated as a free-form


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Please read our contribution policy: https://github.com/terramate-io/terramate/blob/main/CONTRIBUTING.md
   Note: All code contributions are managed exclusively by the Terramate team.
2. If the PR is unfinished, mark it as draft: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request
3. Please update the PR title using the Conventional Commits convention: https://www.conventionalcommits.org/en/v1.0.0/
    Example: feat: add support for XYZ.
-->

## What this PR does / why we need it:

This PR adds a fallback widget for input types that are unsupported to be edited in `terramate ui`, for example `type = any`. In this case, the current value is still attempted to be rendered if possible, but it cannot be edited.

## Does this PR introduce a user-facing change?
<!--
If no, just write "no" in the block below.
If yes, please explain the change and update documentation and the CHANGELOG.md file accordingly.
-->
```
yes, see changelog
```


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized TUI form/widget behavior; no auth, persistence, or API changes beyond preventing a crash and tightening focus rules.
> 
> **Overview**
> Fixes **`terramate ui`** panics when a form includes inputs whose schema type has no dedicated editor (e.g. `any`, tuple, `any_of`).
> 
> **`NewWidget`** now returns a **`readOnlyWidget`** instead of `nil`, so values can still be shown via **`FormatDisplayValue`** but are not editable. **`InputsForm`** gains **`canActivate`** and **`isReadOnly`** (immutable in reconfigure/promote, or read-only widget) so forward/back navigation, the completed panel, and cursor selection skip those fields—read-only non-immutable inputs show a **"read-only"** hint tag instead of **"immutable"**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fdd52f8c7a76ac11d3d0d1a1fdb4ffeb0cfb955. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->