### PR TITLE
fix: multiselect confirm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 
 - Fix `terramate ui` crash when using specific input types that are not supported by a form.
 - Fix inputs without a `prompt` block being dropped from the config when a bundle instance is reconfigured or promoted in `terramate ui`.
+- Fix multiselect list changes being applied to the input form before confirmation in `terramate ui`.
 
 ## 0.17.2
 

--- a/commands/ui/inputs_form.go
+++ b/commands/ui/inputs_form.go
@@ -530,6 +530,11 @@ func (f *InputsForm) PendingSubForm() *SubFormRequest {
 // ExtraHelpHints returns contextual help hints for the current state.
 // The caller appends these to the help line.
 func (f *InputsForm) ExtraHelpHints() string {
+	if f.IsEditingInput() && f.activeWidget != nil {
+		if h, ok := f.activeWidget.(HelpHinter); ok {
+			return h.HelpHints()
+		}
+	}
 	if f.focus == InputFocusCompleted && !f.reconfiguring && !f.promoting && f.hasOptionalInputs() {
 		return "◂▸: filter"
 	}

--- a/commands/ui/widget.go
+++ b/commands/ui/widget.go
@@ -50,6 +50,13 @@ type InputWidget interface {
 	AcceptSubFormResult(result SubFormResult) bool
 }
 
+// HelpHinter is an optional interface for widgets that contribute contextual
+// key hints to the bottom help line while they are the active input.
+// Hints use the same " • " separator as the rest of the help line.
+type HelpHinter interface {
+	HelpHints() string
+}
+
 // SubFormResult carries the output of a completed sub-form back to its
 // parent widget.
 type SubFormResult struct {

--- a/commands/ui/widget_select.go
+++ b/commands/ui/widget_select.go
@@ -255,11 +255,16 @@ func (w *MultiSelectWidget) FormatDisplay() string {
 	if val == cty.NilVal || val.IsNull() {
 		return "<none>"
 	}
-	if len(w.options) > 0 {
+	if len(w.options) > 0 && val.CanIterateElements() {
 		var labels []string
-		for i, opt := range w.options {
-			if w.selected[i] {
-				labels = append(labels, opt.Label)
+		for _, opt := range w.options {
+			it := val.ElementIterator()
+			for it.Next() {
+				_, elem := it.Element()
+				if optValEquals(opt.Value, elem) {
+					labels = append(labels, opt.Label)
+					break
+				}
 			}
 		}
 		if len(labels) == 0 {
@@ -268,6 +273,12 @@ func (w *MultiSelectWidget) FormatDisplay() string {
 		return strings.Join(labels, ", ")
 	}
 	return ctyToDisplayString(val)
+}
+
+// HelpHints returns the key hints shown in the bottom help line while the
+// multi-select is the active input.
+func (w *MultiSelectWidget) HelpHints() string {
+	return "enter: confirm • space: toggle"
 }
 
 // ForwardMsg is a no-op; multi-select widgets have no underlying input component.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Please read our contribution policy: https://github.com/terramate-io/terramate/blob/main/CONTRIBUTING.md
   Note: All code contributions are managed exclusively by the Terramate team.
2. If the PR is unfinished, mark it as draft: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request
3. Please update the PR title using the Conventional Commits convention: https://www.conventionalcommits.org/en/v1.0.0/
    Example: feat: add support for XYZ.
-->

## What this PR does / why we need it:

This PR fixes that changes in the multiselect widget for `terramate ui` are now staged in the edit form and explicitly confirmed, just like it works for other widgets. Pre-fix, toggling an entry would immediately affect the bottom form.

## Does this PR introduce a user-facing change?
<!--
If no, just write "no" in the block below.
If yes, please explain the change and update documentation and the CHANGELOG.md file accordingly.
-->
```
yes
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized TUI input-widget behavior and display; no auth, persistence, or generation paths affected.
> 
> **Overview**
> **Multiselect inputs in `terramate ui` no longer update the completed inputs panel until you confirm.** Space still toggles checkboxes in the editor only; **Enter** commits the tuple to the form, matching single-select and other widgets.
> 
> The completed-panel summary for multiselect now derives labels from the **committed** `cty` value instead of the in-progress `selected` map, and only iterates when the value is a collection. A **`HelpHinter`** hook lets the active widget add bottom-line keys; multiselect shows **`enter: confirm • space: toggle`**. The unreleased changelog documents the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6855f519754d8b824381123635cbfa63c4bc8a1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->