### PR TITLE
feat: ui input widget for type = list(bundle(...))

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 
 ## Unreleased
 
+### Added
+
+- Add support for collections of bundle references, e.g. `type = list(bundle(<class>))`.
+  In `terramate ui` such an input is a multi-select over the bundles of that class.
+
 ### Fixed
 
 - Fix `terramate ui` crash when using specific input types that are not supported by a form.

--- a/commands/ui/bundleref_test.go
+++ b/commands/ui/bundleref_test.go
@@ -1,0 +1,389 @@
+// Copyright 2026 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/function"
+
+	"github.com/terramate-io/terramate/config"
+	"github.com/terramate-io/terramate/hcl/eval"
+	"github.com/terramate-io/terramate/typeschema"
+)
+
+// resolvedBundle mimics the object tm_bundle returns. Bundles of the same class
+// have different cty types because their inputs differ.
+func resolvedBundle(alias string) cty.Value {
+	return cty.ObjectVal(map[string]cty.Value{
+		"alias": cty.StringVal(alias),
+		"class": cty.StringVal("test.class/v1"),
+		"uuid":  cty.NullVal(cty.String),
+		"input": cty.ObjectVal(map[string]cty.Value{alias: cty.True}),
+	})
+}
+
+func bundleRefListInput(name string) *config.InputDefinition {
+	return &config.InputDefinition{
+		Name:        name,
+		Description: "Referenced bundles",
+		Type:        &typeschema.ListType{ValueType: &typeschema.BundleType{ClassID: "test.class/v1"}},
+		Prompt:      config.PromptConfig{Text: "Referenced bundles"},
+	}
+}
+
+func TestGenerateBundleYAMLWritesBundleRefListAsKeys(t *testing.T) {
+	change := Change{
+		Kind:      ChangeCreate,
+		Name:      "example",
+		UUID:      "6f2c1f6a-5c1a-4a2e-9f1b-2a7c0d3e4b55",
+		Source:    "/bundles/example/v1",
+		InputDefs: []*config.InputDefinition{bundleRefListInput("teams")},
+		UserValues: map[string]cty.Value{
+			// Resolved objects, as they are held internally after evaluation.
+			"teams": cty.TupleVal([]cty.Value{
+				resolvedBundle("platform"),
+				resolvedBundle("payments"),
+			}),
+		},
+	}
+
+	assertBundleYAML(t, change, nil, nil, `apiVersion: terramate.io/cli/v1
+kind: BundleInstance
+metadata:
+  name: example
+  uuid: 6f2c1f6a-5c1a-4a2e-9f1b-2a7c0d3e4b55
+spec:
+  source: /bundles/example/v1
+  inputs:
+    # tmdoc: Referenced bundles
+    teams:
+      - platform
+      - payments
+`)
+}
+
+func TestGenerateBundleYAMLWritesNestedBundleRefAsKey(t *testing.T) {
+	// A bundle reference inside an object attribute of a list item.
+	itemType := &typeschema.ObjectType{Attributes: []*typeschema.ObjectTypeAttribute{
+		{Name: "team", Type: &typeschema.BundleType{ClassID: "test.class/v1"}},
+		{Name: "role", Type: &typeschema.PrimitiveType{Name: "string"}},
+	}}
+
+	change := Change{
+		Kind:   ChangeCreate,
+		Name:   "example",
+		UUID:   "6f2c1f6a-5c1a-4a2e-9f1b-2a7c0d3e4b55",
+		Source: "/bundles/example/v1",
+		InputDefs: []*config.InputDefinition{{
+			Name:        "grants",
+			Description: "Team grants",
+			Type:        &typeschema.ListType{ValueType: itemType},
+			Prompt:      config.PromptConfig{Text: "Team grants"},
+		}},
+		UserValues: map[string]cty.Value{
+			"grants": cty.TupleVal([]cty.Value{
+				cty.ObjectVal(map[string]cty.Value{
+					"team": resolvedBundle("platform"),
+					"role": cty.StringVal("admin"),
+				}),
+			}),
+		},
+	}
+
+	assertBundleYAML(t, change, nil, nil, `apiVersion: terramate.io/cli/v1
+kind: BundleInstance
+metadata:
+  name: example
+  uuid: 6f2c1f6a-5c1a-4a2e-9f1b-2a7c0d3e4b55
+spec:
+  source: /bundles/example/v1
+  inputs:
+    # tmdoc: Team grants
+    grants:
+      - role: admin
+        team: platform
+`)
+}
+
+func TestNormalizeBundleRefValuesReducesCollectionsToKeys(t *testing.T) {
+	defs := []*config.InputDefinition{
+		bundleRefListInput("teams"),
+		{
+			Name: "owner",
+			Type: &typeschema.BundleType{ClassID: "test.class/v1"},
+		},
+		{
+			Name: "labels",
+			Type: &typeschema.ListType{ValueType: &typeschema.PrimitiveType{Name: "string"}},
+		},
+	}
+
+	values := map[string]cty.Value{
+		"teams": cty.TupleVal([]cty.Value{
+			resolvedBundle("platform"),
+			resolvedBundle("payments"),
+		}),
+		"owner":  resolvedBundle("platform"),
+		"labels": cty.TupleVal([]cty.Value{cty.StringVal("a")}),
+	}
+
+	normalizeBundleRefValues(typeschema.EvalContext{}, defs, values)
+
+	want := cty.TupleVal([]cty.Value{cty.StringVal("platform"), cty.StringVal("payments")})
+	if !values["teams"].RawEquals(want) {
+		t.Fatalf("teams: got %#v, want %#v", values["teams"], want)
+	}
+	if !values["owner"].RawEquals(cty.StringVal("platform")) {
+		t.Fatalf("owner: got %#v", values["owner"])
+	}
+	if !values["labels"].RawEquals(cty.TupleVal([]cty.Value{cty.StringVal("a")})) {
+		t.Fatalf("labels was rewritten: %#v", values["labels"])
+	}
+}
+
+func TestCheckBundleRefsResolvedNamesUnresolvedElement(t *testing.T) {
+	defs := []*config.InputDefinition{bundleRefListInput("teams")}
+
+	t.Run("all resolved", func(t *testing.T) {
+		values := map[string]cty.Value{
+			"teams": cty.TupleVal([]cty.Value{resolvedBundle("platform")}),
+		}
+		if err := checkBundleRefsResolved(typeschema.EvalContext{}, defs, values); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("one element missing", func(t *testing.T) {
+		values := map[string]cty.Value{
+			"teams": cty.TupleVal([]cty.Value{
+				resolvedBundle("platform"),
+				cty.NullVal(cty.DynamicPseudoType),
+			}),
+		}
+		err := checkBundleRefsResolved(typeschema.EvalContext{}, defs, values)
+		if err == nil {
+			t.Fatal("expected an error for the unresolved element")
+		}
+		if !strings.Contains(err.Error(), `"teams[1]"`) {
+			t.Fatalf("error does not name the element: %s", err)
+		}
+	})
+
+	t.Run("several elements missing", func(t *testing.T) {
+		values := map[string]cty.Value{
+			"teams": cty.TupleVal([]cty.Value{
+				cty.NullVal(cty.DynamicPseudoType),
+				resolvedBundle("platform"),
+				cty.NullVal(cty.DynamicPseudoType),
+			}),
+		}
+		err := checkBundleRefsResolved(typeschema.EvalContext{}, defs, values)
+		if err == nil {
+			t.Fatal("expected an error for the unresolved elements")
+		}
+		if !strings.Contains(err.Error(), `"teams[0]", "teams[2]"`) {
+			t.Fatalf("error does not name both elements: %s", err)
+		}
+	})
+
+	t.Run("top level miss keeps naming the input", func(t *testing.T) {
+		singleDefs := []*config.InputDefinition{{
+			Name: "owner",
+			Type: &typeschema.BundleType{ClassID: "test.class/v1"},
+		}}
+		values := map[string]cty.Value{"owner": cty.NullVal(cty.DynamicPseudoType)}
+		err := checkBundleRefsResolved(typeschema.EvalContext{}, singleDefs, values)
+		if err == nil {
+			t.Fatal("expected an error")
+		}
+		if !strings.Contains(err.Error(), `"owner"`) {
+			t.Fatalf("unexpected error: %s", err)
+		}
+	})
+}
+
+func bundleRefListWidgetContext(t *testing.T, aliases ...string) *WidgetContext {
+	t.Helper()
+
+	reg := &config.Registry{}
+	for _, alias := range aliases {
+		reg.Bundles = append(reg.Bundles, &config.Bundle{
+			DefinitionMetadata: config.Metadata{Class: "test.class/v1"},
+			Alias:              alias,
+			Name:               alias,
+			Inputs:             map[string]cty.Value{},
+			Exports:            map[string]cty.Value{},
+		})
+	}
+
+	return &WidgetContext{
+		SharedWidgetContext: &SharedWidgetContext{
+			Schemactx: typeschema.EvalContext{
+				Evalctx: eval.NewContext(map[string]function.Function{}),
+				Schemas: typeschema.NewSchemaNamespaces(),
+			},
+			Registry: reg,
+		},
+		Def:   bundleRefListInput("teams"),
+		Value: cty.NilVal,
+	}
+}
+
+func TestBundleRefListWidgetSeedsSelectionFromResolvedValue(t *testing.T) {
+	wctx := bundleRefListWidgetContext(t, "platform", "payments")
+	// Reconfigure seeds the form with keys, but be tolerant of resolved objects.
+	wctx.Value = cty.TupleVal([]cty.Value{resolvedBundle("payments")})
+
+	w := NewBundleRefListWidget(wctx, "test.class/v1")
+	w.Prepare()
+
+	if got := w.FormatDisplay(); got != "payments" {
+		t.Fatalf("unexpected display: %q", got)
+	}
+	if !w.isSelected("payments") || w.isSelected("platform") {
+		t.Fatalf("unexpected selection: %v", w.selected)
+	}
+}
+
+func TestBundleRefListWidgetTogglesAndCommitsInSelectionOrder(t *testing.T) {
+	wctx := bundleRefListWidgetContext(t, "platform", "payments")
+
+	w := NewBundleRefListWidget(wctx, "test.class/v1")
+	w.Prepare()
+
+	// Select the second bundle first, then the first one.
+	w.cursor = 1
+	w.toggle(w.rows()[w.cursor].alias)
+	w.cursor = 0
+	w.toggle(w.rows()[w.cursor].alias)
+	w.commit()
+
+	want := cty.TupleVal([]cty.Value{cty.StringVal("payments"), cty.StringVal("platform")})
+	if !wctx.Value.RawEquals(want) {
+		t.Fatalf("got %#v, want %#v", wctx.Value, want)
+	}
+
+	// Toggling an alias off removes it and keeps the rest.
+	w.toggle("payments")
+	w.commit()
+	want = cty.TupleVal([]cty.Value{cty.StringVal("platform")})
+	if !wctx.Value.RawEquals(want) {
+		t.Fatalf("got %#v, want %#v", wctx.Value, want)
+	}
+}
+
+func TestBundleRefListWidgetKeepsEditingAfterInlineCreate(t *testing.T) {
+	// The registry does not know the new bundle yet, so the widget has to list
+	// the selected alias on its own.
+	wctx := bundleRefListWidgetContext(t, "platform")
+
+	w := NewBundleRefListWidget(wctx, "test.class/v1")
+	w.Prepare()
+	w.toggle("platform")
+
+	done := w.AcceptCreatedBundleRef("brand-new")
+	if done {
+		t.Fatal("a collection of references must stay active for further additions")
+	}
+
+	want := cty.TupleVal([]cty.Value{cty.StringVal("platform"), cty.StringVal("brand-new")})
+	if !wctx.Value.RawEquals(want) {
+		t.Fatalf("got %#v, want %#v", wctx.Value, want)
+	}
+	rows := w.rows()
+	if len(rows) != 2 || rows[1].alias != "brand-new" {
+		t.Fatalf("unknown alias is not listed: %+v", rows)
+	}
+	if w.cursor != len(rows) {
+		t.Fatalf("cursor should rest on \"Add new\", got %d", w.cursor)
+	}
+}
+
+// The cursor runs over the bundles and ends on the "Add new" row. Enter confirms
+// from a bundle row, the way the ordinary multi-select does; only "Add new" does
+// something else, which is why the help hint follows the cursor.
+func TestBundleRefListWidgetKeys(t *testing.T) {
+	wctx := bundleRefListWidgetContext(t, "platform", "payments")
+
+	w := NewBundleRefListWidget(wctx, "test.class/v1")
+	w.Prepare()
+
+	if got := w.HelpHints(); got != "enter: confirm • space: toggle" {
+		t.Fatalf("unexpected hint on a bundle row: %q", got)
+	}
+
+	// Space toggles the row under the cursor without finishing the input.
+	if signal, _ := w.Update(tea.KeyMsg{Type: tea.KeySpace}); signal != WidgetContinue {
+		t.Fatalf("space should not confirm, got %v", signal)
+	}
+	if !w.isSelected("platform") {
+		t.Fatal("space should toggle the row under the cursor")
+	}
+
+	// Enter on a bundle row confirms the whole selection.
+	if signal, _ := w.Update(tea.KeyMsg{Type: tea.KeyEnter}); signal != WidgetConfirmed {
+		t.Fatalf("expected enter on a bundle row to confirm, got %v", signal)
+	}
+	want := cty.TupleVal([]cty.Value{cty.StringVal("platform")})
+	if !wctx.Value.RawEquals(want) {
+		t.Fatalf("got %#v, want %#v", wctx.Value, want)
+	}
+
+	// Down past the last bundle reaches "Add new", where enter creates instead
+	// of confirming and the hints drop away.
+	for range 2 {
+		w.Update(tea.KeyMsg{Type: tea.KeyDown})
+	}
+	if got := w.HelpHints(); got != "" {
+		t.Fatalf("the \"Add new\" row should show no hints, got %q", got)
+	}
+	if signal, _ := w.Update(tea.KeyMsg{Type: tea.KeyEnter}); signal != WidgetNeedSubForm {
+		t.Fatalf("expected the \"Add new\" row to request a sub-form, got %v", signal)
+	}
+
+	// Down stops on the create row rather than running off the end.
+	before := w.cursor
+	w.Update(tea.KeyMsg{Type: tea.KeyDown})
+	if w.cursor != before {
+		t.Fatalf("cursor ran past the \"Add new\" row: %d -> %d", before, w.cursor)
+	}
+}
+
+func TestBundleRefListWidgetEmptySelectionCommitsEmptyTuple(t *testing.T) {
+	wctx := bundleRefListWidgetContext(t, "platform")
+
+	w := NewBundleRefListWidget(wctx, "test.class/v1")
+	w.Prepare()
+	w.commit()
+
+	if !wctx.Value.RawEquals(cty.EmptyTupleVal) {
+		t.Fatalf("got %#v", wctx.Value)
+	}
+	if got := w.FormatDisplay(); got != "<none>" {
+		t.Fatalf("unexpected display: %q", got)
+	}
+}
+
+// The completed-inputs panel has to name the referenced bundles; a list of
+// resolved bundle objects would otherwise render as an opaque item count.
+func TestFormatDisplayValueNamesBundleRefsInCollection(t *testing.T) {
+	t.Parallel()
+
+	typ, err := typeschema.Parse(`list(bundle("test.class/v1"))`, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	val := cty.TupleVal([]cty.Value{
+		resolvedBundle("platform"),
+		cty.StringVal("payments"), // Not yet resolved, still a key.
+	})
+
+	if got := FormatDisplayValue(val, typ); got != "platform, payments" {
+		t.Fatalf("unexpected display: %q", got)
+	}
+}

--- a/commands/ui/change.go
+++ b/commands/ui/change.go
@@ -11,6 +11,7 @@ import (
 	"reflect"
 	"regexp"
 	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/google/uuid"
@@ -56,6 +57,11 @@ type Change struct {
 	Values         map[string]cty.Value      // All values (user + defaults) for validation
 	UserValues     map[string]cty.Value      // Only user-set values (written to YAML)
 
+	// Schemactx is the context the values were evaluated in. It is needed to
+	// walk input types when writing the values back out, e.g. to translate
+	// resolved bundle references back into keys.
+	Schemactx typeschema.EvalContext
+
 	Env     *config.Environment
 	FromEnv *config.Environment
 
@@ -91,7 +97,7 @@ func NewCreateChange(
 	if err != nil {
 		return Change{}, err
 	}
-	if err := checkBundleRefsResolved(inputDefs, allValues); err != nil {
+	if err := checkBundleRefsResolved(schemactx, inputDefs, allValues); err != nil {
 		return Change{}, err
 	}
 
@@ -171,6 +177,7 @@ func NewCreateChange(
 		InputDefs:      inputDefs,
 		Values:         allValues,
 		UserValues:     values,
+		Schemactx:      schemactx,
 	}, nil
 }
 
@@ -202,7 +209,7 @@ func NewReconfigChange(
 	if err != nil {
 		return Change{}, err
 	}
-	if err := checkBundleRefsResolved(inputDefs, allValues); err != nil {
+	if err := checkBundleRefsResolved(schemactx, inputDefs, allValues); err != nil {
 		return Change{}, err
 	}
 
@@ -247,6 +254,7 @@ func NewReconfigChange(
 		InputDefs:      inputDefs,
 		Values:         allValues,
 		UserValues:     values,
+		Schemactx:      schemactx,
 		OriginalBundle: bundle,
 		OriginalValues: inputsToValueMap(bundle.Inputs),
 		Warnings:       warnings,
@@ -282,7 +290,7 @@ func NewPromoteChange(
 	if err != nil {
 		return Change{}, err
 	}
-	if err := checkBundleRefsResolved(inputDefs, allValues); err != nil {
+	if err := checkBundleRefsResolved(schemactx, inputDefs, allValues); err != nil {
 		return Change{}, err
 	}
 
@@ -328,6 +336,7 @@ func NewPromoteChange(
 		InputDefs:      inputDefs,
 		Values:         allValues,
 		UserValues:     values,
+		Schemactx:      schemactx,
 		OriginalBundle: bundle,
 		OriginalValues: inputsToValueMap(bundle.Inputs),
 		Warnings:       warnings,
@@ -390,42 +399,79 @@ func reEvalAllInputs(
 	return result, nil
 }
 
+// bundleRefKey converts a resolved bundle object back to the key that is written
+// to a bundle instance file. Values that are not resolved bundles - plain keys,
+// [key, envID] tuples, nulls - are returned unchanged.
+func bundleRefKey(v cty.Value) cty.Value {
+	if v == cty.NilVal || !v.IsKnown() || v.IsNull() {
+		return v
+	}
+	if v.Type().IsObjectType() && v.Type().HasAttribute("alias") {
+		alias := v.GetAttr("alias")
+		if alias.IsKnown() && !alias.IsNull() && alias.Type() == cty.String {
+			return alias
+		}
+	}
+	return v
+}
+
 // normalizeBundleRefValues converts resolved bundle objects back to alias strings.
 // When reconfiguring or promoting, bundle-ref inputs are loaded as full objects
-// (with alias, uuid, etc.) from disk. The type system expects strings, so we
-// extract the alias before the values enter the form.
-func normalizeBundleRefValues(inputDefs []*config.InputDefinition, values map[string]cty.Value) map[string]cty.Value {
+// (with alias, uuid, etc.) from disk. The type system expects keys, so we extract
+// the alias before the values enter the form. References nested in collections or
+// object attributes are normalized too.
+func normalizeBundleRefValues(schemactx typeschema.EvalContext, inputDefs []*config.InputDefinition, values map[string]cty.Value) map[string]cty.Value {
 	for _, def := range inputDefs {
-		if _, isBundleType := def.Type.(*typeschema.BundleType); !isBundleType {
-			continue
-		}
 		v, ok := values[def.Name]
 		if !ok || v == cty.NilVal || v.IsNull() || !v.IsKnown() {
 			continue
 		}
-		if v.Type().IsObjectType() && v.Type().HasAttribute("alias") {
-			alias := v.GetAttr("alias")
-			if alias.IsKnown() && alias.Type() == cty.String {
-				values[def.Name] = alias
-			}
+		normalized, err := typeschema.MapBundleRefs(def.Type, v, schemactx,
+			func(_ *typeschema.BundleType, ref cty.Value, _ typeschema.BundleRefPath) (cty.Value, error) {
+				return bundleRefKey(ref), nil
+			})
+		if err != nil {
+			continue
 		}
+		values[def.Name] = normalized
 	}
 	return values
 }
 
-// checkBundleRefsResolved verifies that all bundle-ref inputs resolved to non-null
-// values. Returns a user-friendly error if any referenced bundle is missing.
-func checkBundleRefsResolved(inputDefs []*config.InputDefinition, values map[string]cty.Value) error {
+// checkBundleRefsResolved verifies that all bundle references resolved to
+// non-null values. Returns a user-friendly error if any referenced bundle is
+// missing, naming the element for references nested in collections or objects.
+func checkBundleRefsResolved(schemactx typeschema.EvalContext, inputDefs []*config.InputDefinition, values map[string]cty.Value) error {
 	for _, def := range inputDefs {
-		if _, isBundleType := def.Type.(*typeschema.BundleType); !isBundleType {
-			continue
-		}
 		v, ok := values[def.Name]
 		if !ok || v == cty.NilVal {
 			continue
 		}
-		if v.IsNull() {
-			return errors.E("Input %q references a bundle that does not exist in this environment. Promote dependencies first.", def.Name)
+
+		var unresolved []string
+		_, err := typeschema.MapBundleRefs(def.Type, v, schemactx,
+			func(_ *typeschema.BundleType, ref cty.Value, path typeschema.BundleRefPath) (cty.Value, error) {
+				if ref != cty.NilVal && ref.IsKnown() && ref.IsNull() {
+					unresolved = append(unresolved, def.Name+path.String())
+				}
+				return ref, nil
+			})
+		if err != nil {
+			return err
+		}
+		switch len(unresolved) {
+		case 0:
+		case 1:
+			return errors.E("Input %q references a bundle that does not exist in this environment. Promote dependencies first.",
+				unresolved[0])
+		default:
+			slices.Sort(unresolved)
+			quoted := make([]string, len(unresolved))
+			for i, name := range unresolved {
+				quoted[i] = strconv.Quote(name)
+			}
+			return errors.E("Inputs %s reference bundles that do not exist in this environment. Promote dependencies first.",
+				strings.Join(quoted, ", "))
 		}
 	}
 	return nil
@@ -468,12 +514,14 @@ func (c *Change) generateBundleYAML(existing *yaml.BundleInstance, envs []*confi
 			continue
 		}
 
-		// Bundle-ref values are stored as resolved objects internally
-		// but must be written as alias strings in the YAML config.
-		if _, isBundleType := def.Type.(*typeschema.BundleType); isBundleType {
-			if v.IsKnown() && !v.IsNull() && v.Type().IsObjectType() && v.Type().HasAttribute("alias") {
-				v = v.GetAttr("alias")
-			}
+		// Bundle references are stored as resolved objects internally but must
+		// be written as alias strings in the YAML config, at any depth.
+		v, err := typeschema.MapBundleRefs(def.Type, v, c.Schemactx,
+			func(_ *typeschema.BundleType, ref cty.Value, _ typeschema.BundleRefPath) (cty.Value, error) {
+				return bundleRefKey(ref), nil
+			})
+		if err != nil {
+			return "", err
 		}
 
 		yv, err := yaml.ConvertFromCty(v)

--- a/commands/ui/inputs_form.go
+++ b/commands/ui/inputs_form.go
@@ -683,21 +683,27 @@ func (f *InputsForm) ForwardMsg(msg tea.Msg) tea.Cmd {
 	return nil
 }
 
-// setBundleRefValue sets the current bundle-ref input to the given ID and advances.
+// setBundleRefValue hands the alias of a bundle that was just created inline to
+// the active widget. A single reference is complete once it is set, so the form
+// advances; a collection of references stays active for further additions.
 func (f *InputsForm) setBundleRefValue(bundleID string) {
 	if f.activeIdx >= len(f.InputDefs) {
 		return
 	}
 	def := f.InputDefs[f.activeIdx]
-	v := cty.StringVal(bundleID)
-	f.setValueByName(def.Name, v)
-	f.userModified[def.Name] = true
-	if bw, ok := f.activeWidget.(*BundleRefWidget); ok {
-		bw.Reload()
+
+	done := true
+	if acceptor, ok := f.activeWidget.(bundleRefAcceptor); ok {
+		done = acceptor.AcceptCreatedBundleRef(bundleID)
+	} else {
+		f.setValueByName(def.Name, cty.StringVal(bundleID))
 	}
+	f.userModified[def.Name] = true
 	f.state = InputsFormActive
 	f.seedDefaults()
-	f.advanceToNextPending()
+	if done {
+		f.advanceToNextPending()
+	}
 }
 
 // syncAllValuesToEvalctx seeds the eval context with all current values at once.
@@ -1080,6 +1086,9 @@ func (f InputsForm) updateInput(msg tea.KeyMsg) (InputsForm, tea.Cmd) {
 	case WidgetNeedSubForm:
 		if bw, ok := f.activeWidget.(*BundleRefWidget); ok {
 			f.pendingRefClass = bw.PendingRefClass
+			f.state = InputsFormCreateRef
+		} else if blw, ok := f.activeWidget.(*BundleRefListWidget); ok {
+			f.pendingRefClass = blw.PendingRefClass
 			f.state = InputsFormCreateRef
 		} else if ow, ok := f.activeWidget.(*ObjectWidget); ok && ow.SubFormRequest != nil {
 			f.pendingSubForm = ow.SubFormRequest

--- a/commands/ui/model.go
+++ b/commands/ui/model.go
@@ -70,6 +70,11 @@ type CreateFrame struct {
 	selectedBundleSource   string
 	inputsForm             InputsForm
 	parentBundleName       string // name of the bundle being configured (for UI context)
+
+	// objectEditStack holds the sub-forms that were open when the creation
+	// started. The nested bundle gets its own form and must not be mistaken for
+	// a sub-form of the suspended one, so the stack travels with the frame.
+	objectEditStack []ObjectEditFrame
 }
 
 // flatBundleEntry maps a row in the flat bundle list back to its collection/bundle origin.

--- a/commands/ui/view_create.go
+++ b/commands/ui/view_create.go
@@ -276,8 +276,10 @@ func (m *Model) pushCreateFrame() {
 		selectedBundleSource:   m.selectedBundleSource,
 		inputsForm:             m.inputsForm,
 		parentBundleName:       bundleName,
+		objectEditStack:        m.objectEditStack,
 	}
 	m.createStack = append(m.createStack, frame)
+	m.objectEditStack = nil
 }
 
 // restoreCreateFrame pops the last frame and restores the wizard state.
@@ -296,6 +298,7 @@ func (m *Model) restoreCreateFrame(newBundleAlias string) {
 	m.selectedBundleSource = frame.selectedBundleSource
 	m.inputsForm = frame.inputsForm
 	m.inputsForm.state = InputsFormActive
+	m.objectEditStack = frame.objectEditStack
 	m.nestedRefClass = ""
 
 	if newBundleAlias != "" {

--- a/commands/ui/view_promote.go
+++ b/commands/ui/view_promote.go
@@ -84,7 +84,7 @@ func (m *Model) loadPromoteBundle(b *config.Bundle, targetEnv *config.Environmen
 	}
 
 	values := inputsToValueMap(b.Inputs)
-	normalizeBundleRefValues(inputDefs, values)
+	normalizeBundleRefValues(schemactx, inputDefs, values)
 
 	m.promoteBundle = b
 	m.selectedBundleDefEntry = bde

--- a/commands/ui/view_reconfig.go
+++ b/commands/ui/view_reconfig.go
@@ -86,7 +86,7 @@ func (m *Model) loadReconfigBundle(b *config.Bundle) error {
 	}
 
 	values := inputsToValueMap(b.Inputs)
-	normalizeBundleRefValues(inputDefs, values)
+	normalizeBundleRefValues(schemactx, inputDefs, values)
 
 	m.reconfigBundle = b
 	m.selectedBundleDefEntry = bde

--- a/commands/ui/widget.go
+++ b/commands/ui/widget.go
@@ -5,6 +5,7 @@ package ui
 
 import (
 	"fmt"
+	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/zclconf/go-cty/cty"
@@ -191,6 +192,8 @@ func NewListWidget(wctx *WidgetContext, valTyp typeschema.Type) InputWidget {
 		case "string", "number":
 			return NewInlineListWidget(wctx, t)
 		}
+	case *typeschema.BundleType:
+		return NewBundleRefListWidget(wctx, t.ClassID)
 	}
 	return NewSubFormListWidget(wctx, valTyp)
 }
@@ -252,6 +255,12 @@ func FormatDisplayValue(val cty.Value, typ typeschema.Type) string {
 
 	switch t := typ.(type) {
 	case *typeschema.PrimitiveType:
+		return ctyToDisplayString(val)
+
+	case *typeschema.BundleType:
+		if alias, ok := bundleRefAlias(val); ok {
+			return alias
+		}
 		return ctyToDisplayString(val)
 
 	case *typeschema.ListType:
@@ -326,6 +335,18 @@ func formatCollectionDisplay(val cty.Value, elemType typeschema.Type) string {
 	n := val.LengthInt()
 	if n == 0 {
 		return "<empty>"
+	}
+	if _, isBundleType := elemType.(*typeschema.BundleType); isBundleType {
+		aliases := make([]string, 0, n)
+		for it := val.ElementIterator(); it.Next(); {
+			_, elem := it.Element()
+			alias, ok := bundleRefAlias(elem)
+			if !ok {
+				alias = "<unresolved>"
+			}
+			aliases = append(aliases, alias)
+		}
+		return strings.Join(aliases, ", ")
 	}
 	if n == 1 {
 		it := val.ElementIterator()

--- a/commands/ui/widget_select.go
+++ b/commands/ui/widget_select.go
@@ -5,10 +5,13 @@ package ui
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/zclconf/go-cty/cty"
+
+	"github.com/terramate-io/terramate/typeschema"
 )
 
 // SelectWidget provides a cursor-based single-select option list.
@@ -323,7 +326,7 @@ func (w *BundleRefWidget) Prepare() {
 // Update handles keyboard input and returns the resulting signal.
 func (w *BundleRefWidget) Update(msg tea.KeyMsg) (WidgetSignal, tea.Cmd) {
 	matching := MatchingBundleOptions(w.wctx.Registry, w.classID, w.wctx.Env)
-	n := len(matching) + 1 // +1 for "Add new" option
+	n := len(matching) + 1 // +1 for the "Add new" row
 
 	switch msg.Type {
 	case tea.KeyShiftTab, tea.KeyEsc:
@@ -364,9 +367,9 @@ func (w *BundleRefWidget) Render() []string {
 		}
 	}
 	if w.cursor == len(matching) {
-		lines = append(lines, activeOptionStyle.Render("› + Add new"))
+		lines = append(lines, activeOptionStyle.Render("+ Add new"))
 	} else {
-		lines = append(lines, dimOptionStyle.Render("  + Add new"))
+		lines = append(lines, dimOptionStyle.Render("  Add new"))
 	}
 	return lines
 }
@@ -423,6 +426,258 @@ func (w *BundleRefWidget) ForwardMsg(tea.Msg) tea.Cmd {
 
 // AcceptSubFormResult is a no-op; bundle-ref widgets do not use sub-forms.
 func (w *BundleRefWidget) AcceptSubFormResult(SubFormResult) bool { return true }
+
+// bundleRefAcceptor is implemented by widgets that can take over the alias of a
+// bundle the user created inline through the "Add new" row.
+type bundleRefAcceptor interface {
+	AcceptCreatedBundleRef(alias string) (done bool)
+}
+
+// BundleRefListWidget lets the user pick any number of bundles of one class.
+type BundleRefListWidget struct {
+	wctx     *WidgetContext
+	classID  string
+	selected []string // Aliases, in selection order.
+	cursor   int      // 0..n-1 = bundles, n = "Add new"
+
+	PendingRefClass string
+}
+
+// NewBundleRefListWidget creates a widget for selecting multiple bundle references.
+func NewBundleRefListWidget(wctx *WidgetContext, classID string) *BundleRefListWidget {
+	return &BundleRefListWidget{
+		wctx:    wctx,
+		classID: classID,
+	}
+}
+
+// WidgetContext returns the widget's context.
+func (w *BundleRefListWidget) WidgetContext() *WidgetContext {
+	return w.wctx
+}
+
+// Prepare initializes the widget for a new editing session.
+func (w *BundleRefListWidget) Prepare() {
+	w.PendingRefClass = ""
+	val := w.wctx.Value
+	if val == cty.NilVal {
+		val, _ = w.wctx.Def.EvalDefault(w.wctx.Schemactx)
+	}
+	w.setSelection(val)
+	w.cursor = 0
+}
+
+// bundleRefRow is one selectable bundle in the widget. Rows come from the registry, plus
+// any selected alias the registry does not know about - a bundle created during
+// this session that a stale registry has not picked up yet.
+type bundleRefRow struct {
+	alias string
+	label string
+}
+
+func (w *BundleRefListWidget) rows() []bundleRefRow {
+	var rows []bundleRefRow
+	known := map[string]bool{}
+	for _, opt := range MatchingBundleOptions(w.wctx.Registry, w.classID, w.wctx.Env) {
+		label := opt.Name
+		if label == "" {
+			label = opt.Alias
+		}
+		if opt.EnvID != "" {
+			label += " [" + opt.EnvID + "]"
+		}
+		rows = append(rows, bundleRefRow{alias: opt.Alias, label: label})
+		known[opt.Alias] = true
+	}
+	for _, alias := range w.selected {
+		if !known[alias] {
+			rows = append(rows, bundleRefRow{alias: alias, label: alias})
+			known[alias] = true
+		}
+	}
+	return rows
+}
+
+// Update handles keyboard input and returns the resulting signal.
+func (w *BundleRefListWidget) Update(msg tea.KeyMsg) (WidgetSignal, tea.Cmd) {
+	rows := w.rows()
+	n := len(rows)
+
+	switch msg.Type {
+	case tea.KeyShiftTab, tea.KeyEsc:
+		return WidgetBack, nil
+	case tea.KeyUp:
+		if w.cursor > 0 {
+			w.cursor--
+		}
+	case tea.KeyDown:
+		if w.cursor < n {
+			w.cursor++
+		}
+	case tea.KeySpace:
+		if w.cursor < n {
+			w.toggle(rows[w.cursor].alias)
+		}
+	case tea.KeyEnter:
+		if w.cursor == n {
+			w.PendingRefClass = w.classID
+			return WidgetNeedSubForm, nil
+		}
+		w.commit()
+		return WidgetConfirmed, nil
+	}
+	return WidgetContinue, nil
+}
+
+// Render returns the rendered display lines for the widget.
+func (w *BundleRefListWidget) Render() []string {
+	rows := w.rows()
+	n := len(rows)
+
+	var lines []string
+	for i, row := range rows {
+		prefix := checkboxOff.Render("[ ]")
+		if w.isSelected(row.alias) {
+			prefix = checkboxOn.Render("[✓]")
+		}
+		if i == w.cursor {
+			lines = append(lines, activeOptionStyle.Render(fmt.Sprintf("› %s %s", prefix, row.label)))
+		} else {
+			lines = append(lines, optionStyle.Render(fmt.Sprintf("  %s %s", prefix, row.label)))
+		}
+	}
+
+	// The add row carries its own marker: the "+" sits in the cursor column
+	// instead of the "›" the bundle rows use.
+	if w.cursor == n {
+		lines = append(lines, activeOptionStyle.Render("+ Add new"))
+	} else {
+		lines = append(lines, dimOptionStyle.Render("  Add new"))
+	}
+	return lines
+}
+
+// HelpHints returns the key hints shown in the bottom help line while the
+// bundle multi-select is the active input. The "Add new" row speaks for itself,
+// so it drops the hints rather than repeating what its label already says - and
+// the selection hints would be wrong there anyway.
+func (w *BundleRefListWidget) HelpHints() string {
+	if w.cursor == len(w.rows()) {
+		return ""
+	}
+	return "enter: confirm • space: toggle"
+}
+
+// Reload syncs the widget's internal state from the WidgetContext value.
+func (w *BundleRefListWidget) Reload() {
+	w.setSelection(w.wctx.Value)
+}
+
+// FormatDisplay returns a comma-separated summary of the selected bundles.
+func (w *BundleRefListWidget) FormatDisplay() string {
+	val := w.wctx.Value
+	if val == cty.NilVal || val.IsNull() || !val.IsKnown() || !val.CanIterateElements() {
+		return "<none>"
+	}
+	if val.LengthInt() == 0 {
+		return "<none>"
+	}
+	return FormatDisplayValue(val, &typeschema.ListType{
+		ValueType: &typeschema.BundleType{ClassID: w.classID},
+	})
+}
+
+// ForwardMsg is a no-op; bundle-ref lists have no underlying input component.
+func (w *BundleRefListWidget) ForwardMsg(tea.Msg) tea.Cmd {
+	return nil
+}
+
+// AcceptSubFormResult is a no-op; bundle-ref lists do not use sub-forms.
+func (w *BundleRefListWidget) AcceptSubFormResult(SubFormResult) bool { return true }
+
+// AcceptCreatedBundleRef adds the newly created bundle to the selection. The
+// input stays active so that more references can be added.
+func (w *BundleRefListWidget) AcceptCreatedBundleRef(alias string) bool {
+	w.PendingRefClass = ""
+	if !w.isSelected(alias) {
+		w.selected = append(w.selected, alias)
+	}
+	w.commit()
+	// Park the cursor on "Add new" again, which is where the user left off.
+	w.cursor = len(w.rows())
+	return false
+}
+
+func (w *BundleRefListWidget) isSelected(alias string) bool {
+	return slices.Contains(w.selected, alias)
+}
+
+func (w *BundleRefListWidget) toggle(alias string) {
+	if i := slices.Index(w.selected, alias); i >= 0 {
+		w.selected = slices.Delete(w.selected, i, i+1)
+		return
+	}
+	w.selected = append(w.selected, alias)
+}
+
+// setSelection reads the selection from an input value. Values loaded from disk
+// hold resolved bundle objects, so each element is reduced to its alias.
+func (w *BundleRefListWidget) setSelection(val cty.Value) {
+	w.selected = nil
+	if val == cty.NilVal || val.IsNull() || !val.IsKnown() || !val.CanIterateElements() {
+		return
+	}
+	for it := val.ElementIterator(); it.Next(); {
+		_, elem := it.Element()
+		if alias, ok := bundleRefAlias(elem); ok && !w.isSelected(alias) {
+			w.selected = append(w.selected, alias)
+		}
+	}
+}
+
+func (w *BundleRefListWidget) commit() {
+	val := cty.EmptyTupleVal
+	if len(w.selected) > 0 {
+		elems := make([]cty.Value, len(w.selected))
+		for i, alias := range w.selected {
+			elems[i] = cty.StringVal(alias)
+		}
+		val = cty.TupleVal(elems)
+	}
+	w.wctx.UpdateValue(val)
+}
+
+// bundleRefAlias extracts the alias from a bundle reference value, which is
+// either a key string or a resolved bundle object.
+func bundleRefAlias(val cty.Value) (string, bool) {
+	if val == cty.NilVal || val.IsNull() || !val.IsKnown() {
+		return "", false
+	}
+	switch {
+	case val.Type() == cty.String:
+		return val.AsString(), true
+	case val.Type().IsObjectType() && val.Type().HasAttribute("alias"):
+		alias := val.GetAttr("alias")
+		if alias.IsKnown() && !alias.IsNull() && alias.Type() == cty.String {
+			return alias.AsString(), true
+		}
+	case val.Type().IsTupleType() && val.LengthInt() == 2:
+		// The [key, envID] form.
+		if key := val.AsValueSlice()[0]; key.IsKnown() && key.Type() == cty.String {
+			return key.AsString(), true
+		}
+	}
+	return "", false
+}
+
+// AcceptCreatedBundleRef makes the newly created bundle the value of the input,
+// which completes it.
+func (w *BundleRefWidget) AcceptCreatedBundleRef(alias string) bool {
+	w.PendingRefClass = ""
+	w.value = cty.StringVal(alias)
+	w.wctx.UpdateValue(w.value)
+	return true
+}
 
 // ---------------------------------------------------------------------------
 // Shared helpers

--- a/config/schema.go
+++ b/config/schema.go
@@ -91,6 +91,9 @@ func EvalDefineSchema(evalctx *eval.Context, schemaHCL *hcl.DefineSchema) (*type
 	if err != nil {
 		return nil, err
 	}
+	if err := typeschema.ValidateBundleRefPositions(ret.Type); err != nil {
+		return nil, errors.E(err, schemaHCL.DefRange, "schema '%s'", schemaHCL.Name)
+	}
 
 	return ret, nil
 }
@@ -109,6 +112,9 @@ func EvalObjectAttributes(evalctx *eval.Context, attrsHCL []*hcl.DefineObjectAtt
 		attrTyp, err := typeschema.Parse(typeStr, nil)
 		if err != nil {
 			return nil, errors.E(err, "failed to parse typestr %s", typeStr)
+		}
+		if err := typeschema.ValidateBundleRefPositions(attrTyp); err != nil {
+			return nil, errors.E(err, attrHCL.DefRange, "attribute '%s'", attrHCL.Name)
 		}
 
 		desc := ""
@@ -202,6 +208,9 @@ func EvalInputSchema(evalctx *eval.Context, inputHCL *hcl.DefineInput) (*typesch
 	if err != nil {
 		return nil, errors.E(err, "failed to parse typestr %s", typeStr)
 	}
+	if err := typeschema.ValidateBundleRefPositions(schema.Type); err != nil {
+		return nil, errors.E(err, inputHCL.DefRange, "input '%s'", inputHCL.Name)
+	}
 
 	return schema, nil
 }
@@ -220,15 +229,31 @@ func applyInputSchema(name string, v cty.Value, sc typeschema.EvalContext) (cty.
 	if err != nil {
 		return v, err
 	}
-	if bt, ok := schema.Type.(*typeschema.BundleType); ok {
-		return resolveBundleType(bt, name, v, sc.Evalctx)
-	}
-	return v, nil
+	return resolveBundleRefs(schema.Type, v, sc, name)
 }
 
-// resolveBundleType resolves a bundle-typed input value by calling tm_bundle.
-func resolveBundleType(bt *typeschema.BundleType, name string, v cty.Value, evalctx *eval.Context) (cty.Value, error) {
-	if v.IsNull() {
+// resolveBundleRefs resolves every bundle-typed position in val by calling
+// tm_bundle. Bundle references are not necessarily the whole input value: they
+// can be nested inside collections (`list(bundle(...))`), object attributes or
+// schema references, so the value is walked alongside its type.
+func resolveBundleRefs(typ typeschema.Type, val cty.Value, sc typeschema.EvalContext, inputName string) (cty.Value, error) {
+	return typeschema.MapBundleRefs(typ, val, sc,
+		func(bt *typeschema.BundleType, ref cty.Value, path typeschema.BundleRefPath) (cty.Value, error) {
+			return resolveBundleRef(bt, ref, sc.Evalctx, inputName, path)
+		})
+}
+
+// resolveBundleRef resolves a single bundle reference by calling tm_bundle.
+// Accepted reference values:
+//   - null: passed through as-is
+//   - string: a bundle key (alias or UUID)
+//   - tuple/list [key, envID]: a bundle key with an explicit environment ID
+//   - object/map: an already resolved bundle, passed through as-is
+//
+// An unresolvable reference yields a null value, which callers detect and report
+// with a domain specific message.
+func resolveBundleRef(bt *typeschema.BundleType, v cty.Value, evalctx *eval.Context, inputName string, path typeschema.BundleRefPath) (cty.Value, error) {
+	if !v.IsKnown() || v.IsNull() {
 		return v, nil
 	}
 
@@ -240,13 +265,18 @@ func resolveBundleType(bt *typeschema.BundleType, name string, v cty.Value, eval
 
 	case v.Type().IsTupleType() || v.Type().IsListType():
 		elems := v.AsValueSlice()
+		if len(elems) != 2 {
+			return v, errors.E("bundle input %q expects a [key, envID] tuple of length 2, got %d",
+				inputName+path.String(), len(elems))
+		}
 		args = []cty.Value{cty.StringVal(bt.ClassID), elems[0], elems[1]}
 
 	case v.Type().IsObjectType() || v.Type().IsMapType():
 		return v, nil
 
 	default:
-		return v, errors.E("unexpected value type %s for bundle input %q", v.Type().FriendlyName(), name)
+		return v, errors.E("unexpected value type %s for bundle input %q",
+			v.Type().FriendlyName(), inputName+path.String())
 	}
 
 	hclctx := evalctx.Unwrap()
@@ -257,7 +287,7 @@ func resolveBundleType(bt *typeschema.BundleType, name string, v cty.Value, eval
 
 	result, err := fn.Call(args)
 	if err != nil {
-		return v, err
+		return v, errors.E(err, "resolving bundle input %q", inputName+path.String())
 	}
 	return result, nil
 }

--- a/config/schema_bundleref_test.go
+++ b/config/schema_bundleref_test.go
@@ -1,0 +1,245 @@
+// Copyright 2026 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+package config
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/madlambda/spells/assert"
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/function"
+
+	hhcl "github.com/terramate-io/hcl/v2"
+	"github.com/terramate-io/hcl/v2/hclsyntax"
+	"github.com/terramate-io/terramate/hcl"
+	"github.com/terramate-io/terramate/hcl/ast"
+	"github.com/terramate-io/terramate/hcl/eval"
+	"github.com/terramate-io/terramate/stdlib"
+	"github.com/terramate-io/terramate/typeschema"
+)
+
+const testClass = "test.io/team"
+
+// bundleRefTestCtx builds an eval context with a tm_bundle backed by a registry
+// holding the given aliases.
+func bundleRefTestCtx(t *testing.T, aliases ...string) typeschema.EvalContext {
+	t.Helper()
+
+	reg := &Registry{}
+	for _, alias := range aliases {
+		reg.Bundles = append(reg.Bundles, &Bundle{
+			DefinitionMetadata: Metadata{Class: testClass},
+			Alias:              alias,
+			Name:               alias,
+			// Distinct input sets, so resolved bundles have distinct cty types.
+			Inputs:  map[string]cty.Value{alias: cty.True},
+			Exports: map[string]cty.Value{},
+		})
+	}
+
+	evalctx := eval.NewContext(map[string]function.Function{})
+	evalctx.SetFunction(stdlib.Name("bundle"), BundleFunc(context.Background(), reg, nil, false))
+	return typeschema.EvalContext{Evalctx: evalctx, Schemas: typeschema.NewSchemaNamespaces()}
+}
+
+func TestResolveBundleRefsInCollections(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name    string
+		typeStr string
+		val     cty.Value
+		// Aliases expected at each resolved position, in iteration order.
+		wantAliases []string
+	}{
+		{
+			name:        "single reference",
+			typeStr:     `bundle("test.io/team")`,
+			val:         cty.StringVal("platform"),
+			wantAliases: []string{"platform"},
+		},
+		{
+			name:        "list of references",
+			typeStr:     `list(bundle("test.io/team"))`,
+			val:         cty.TupleVal([]cty.Value{cty.StringVal("platform"), cty.StringVal("payments")}),
+			wantAliases: []string{"platform", "payments"},
+		},
+		{
+			name:        "set of references",
+			typeStr:     `set(bundle("test.io/team"))`,
+			val:         cty.TupleVal([]cty.Value{cty.StringVal("payments")}),
+			wantAliases: []string{"payments"},
+		},
+		{
+			name:    "list of [key, envID] tuples",
+			typeStr: `list(bundle("test.io/team"))`,
+			val: cty.TupleVal([]cty.Value{
+				cty.TupleVal([]cty.Value{cty.StringVal("platform"), cty.StringVal("")}),
+			}),
+			wantAliases: []string{"platform"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			sc := bundleRefTestCtx(t, "platform", "payments")
+			typ, err := typeschema.Parse(tc.typeStr, nil)
+			assert.NoError(t, err)
+
+			applied, err := typ.Apply(tc.val, sc, true)
+			assert.NoError(t, err)
+
+			got, err := resolveBundleRefs(typ, applied, sc, "teams")
+			assert.NoError(t, err)
+
+			var aliases []string
+			collect := func(v cty.Value) {
+				assert.IsTrue(t, v.Type().IsObjectType(), "not resolved: %s", v.Type().FriendlyName())
+				aliases = append(aliases, v.GetAttr("alias").AsString())
+			}
+			if got.Type().IsTupleType() {
+				for _, elem := range got.AsValueSlice() {
+					collect(elem)
+				}
+			} else {
+				collect(got)
+			}
+
+			assert.EqualInts(t, len(tc.wantAliases), len(aliases))
+			for i, want := range tc.wantAliases {
+				assert.EqualStrings(t, want, aliases[i])
+			}
+		})
+	}
+}
+
+func TestResolveBundleRefsYieldsNullForMissingElement(t *testing.T) {
+	t.Parallel()
+
+	sc := bundleRefTestCtx(t, "platform")
+	typ, err := typeschema.Parse(`list(bundle("test.io/team"))`, nil)
+	assert.NoError(t, err)
+
+	val := cty.TupleVal([]cty.Value{cty.StringVal("platform"), cty.StringVal("gone")})
+	applied, err := typ.Apply(val, sc, true)
+	assert.NoError(t, err)
+
+	got, err := resolveBundleRefs(typ, applied, sc, "teams")
+	assert.NoError(t, err)
+
+	elems := got.AsValueSlice()
+	assert.EqualInts(t, 2, len(elems))
+	assert.EqualStrings(t, "platform", elems[0].GetAttr("alias").AsString())
+	assert.IsTrue(t, elems[1].IsNull(), "missing bundle must resolve to null, got %#v", elems[1])
+}
+
+func TestResolveBundleRefsLeavesUnrelatedTypesAlone(t *testing.T) {
+	t.Parallel()
+
+	sc := bundleRefTestCtx(t)
+	typ, err := typeschema.Parse(`list(string)`, nil)
+	assert.NoError(t, err)
+
+	val := cty.TupleVal([]cty.Value{cty.StringVal("platform")})
+	got, err := resolveBundleRefs(typ, val, sc, "labels")
+	assert.NoError(t, err)
+	assert.IsTrue(t, got.RawEquals(val), "value was modified: %#v", got)
+}
+
+func TestResolveBundleRefsPassesResolvedObjectsThrough(t *testing.T) {
+	t.Parallel()
+
+	// Values loaded from a bundle instance on disk are already resolved.
+	sc := bundleRefTestCtx(t, "platform")
+	typ, err := typeschema.Parse(`list(bundle("test.io/team"))`, nil)
+	assert.NoError(t, err)
+
+	resolved := MakeObjectFromBundle(&Bundle{
+		DefinitionMetadata: Metadata{Class: testClass},
+		Alias:              "platform",
+		Inputs:             map[string]cty.Value{},
+		Exports:            map[string]cty.Value{},
+	})
+	val := cty.TupleVal([]cty.Value{resolved})
+
+	got, err := resolveBundleRefs(typ, val, sc, "teams")
+	assert.NoError(t, err)
+	assert.IsTrue(t, got.RawEquals(val), "resolved value was rewritten: %#v", got)
+}
+
+// typeAttr builds the `type = <expr>` attribute of an input or attribute
+// definition from its source text.
+func typeAttr(t *testing.T, typeStr string) *ast.Attribute {
+	t.Helper()
+
+	const filename = "/test.tm" // Absolute and under the rootdir, as ranges require.
+
+	expr, diags := hclsyntax.ParseExpression([]byte(typeStr), filename, hhcl.InitialPos)
+	if diags.HasErrors() {
+		t.Fatalf("parsing %q: %v", typeStr, diags)
+	}
+	attr := ast.NewAttribute("/", &hhcl.Attribute{
+		Name:  "type",
+		Expr:  expr,
+		Range: hhcl.Range{Filename: filename, Start: hhcl.InitialPos, End: hhcl.InitialPos},
+	})
+	return &attr
+}
+
+// The unsupported shapes have to be rejected where the definition is read, so
+// the author sees the error instead of a form they cannot use.
+func TestEvalInputSchemaRejectsUnsupportedBundleRefPositions(t *testing.T) {
+	t.Parallel()
+
+	evalctx := eval.NewContext(map[string]function.Function{})
+
+	t.Run("input type", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := EvalInputSchema(evalctx, &hcl.DefineInput{
+			Name: "teams",
+			Type: typeAttr(t, `map(bundle("test.io/team"))`),
+		})
+		if err == nil {
+			t.Fatal("expected map(bundle(...)) to be rejected")
+		}
+		if !strings.Contains(err.Error(), "teams") {
+			t.Fatalf("error does not name the input: %v", err)
+		}
+	})
+
+	t.Run("attribute type", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := EvalObjectAttributes(evalctx, []*hcl.DefineObjectAttribute{{
+			Name: "team",
+			Type: typeAttr(t, `list(list(bundle("test.io/team")))`),
+		}})
+		if err == nil {
+			t.Fatal("expected list(list(bundle(...))) to be rejected")
+		}
+		if !strings.Contains(err.Error(), "team") {
+			t.Fatalf("error does not name the attribute: %v", err)
+		}
+	})
+
+	t.Run("supported shapes pass", func(t *testing.T) {
+		t.Parallel()
+
+		for _, typeStr := range []string{
+			`bundle("test.io/team")`,
+			`list(bundle("test.io/team"))`,
+			`set(bundle("test.io/team"))`,
+		} {
+			if _, err := EvalInputSchema(evalctx, &hcl.DefineInput{
+				Name: "teams",
+				Type: typeAttr(t, typeStr),
+			}); err != nil {
+				t.Fatalf("%s: unexpected error: %v", typeStr, err)
+			}
+		}
+	})
+}

--- a/typeschema/bundleref.go
+++ b/typeschema/bundleref.go
@@ -1,0 +1,365 @@
+// Copyright 2026 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+package typeschema
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/terramate-io/terramate/errors"
+)
+
+// BundleRefPath locates a bundle reference inside a structured input value.
+// The zero value refers to the value itself.
+type BundleRefPath []string
+
+// Index returns the path of the i-th element of the collection at p.
+func (p BundleRefPath) Index(i int) BundleRefPath {
+	return p.child("[" + strconv.Itoa(i) + "]")
+}
+
+// Key returns the path of the map entry k at p.
+func (p BundleRefPath) Key(k string) BundleRefPath {
+	return p.child("[" + strconv.Quote(k) + "]")
+}
+
+// AnyKey returns the path of any entry of the map at p, for messages that talk
+// about the map's value type rather than one entry.
+func (p BundleRefPath) AnyKey() BundleRefPath {
+	return p.child("[*]")
+}
+
+// Attr returns the path of the object attribute name at p.
+func (p BundleRefPath) Attr(name string) BundleRefPath {
+	return p.child("." + name)
+}
+
+func (p BundleRefPath) child(step string) BundleRefPath {
+	// Copy so that sibling paths never share the backing array.
+	out := make(BundleRefPath, len(p), len(p)+1)
+	copy(out, p)
+	return append(out, step)
+}
+
+// IsRoot reports whether p points at the value itself.
+func (p BundleRefPath) IsRoot() bool { return len(p) == 0 }
+
+// String renders the path as a suffix that can be appended to an input name,
+// e.g. `[0].team`. It is empty for the root.
+func (p BundleRefPath) String() string { return strings.Join(p, "") }
+
+// BundleRefFunc is called by [MapBundleRefs] for every bundle-typed position in
+// a value. It returns the replacement value for that position.
+type BundleRefFunc func(bt *BundleType, val cty.Value, path BundleRefPath) (cty.Value, error)
+
+// MapBundleRefs walks val alongside typ and calls fn at every position typed
+// `bundle(<class>)`, returning val with fn's results substituted in.
+//
+// Bundle references can be nested inside collections (`list(bundle(...))`),
+// object attributes and schema references, so everything that translates
+// between the two representations of a reference — the key that is written to
+// disk and the resolved bundle object — has to walk the type tree instead of
+// only looking at the top level.
+//
+// Collections are rebuilt as tuples and maps as objects, mirroring
+// [Type.Apply], because resolved bundles of the same class still have different
+// cty types: their input and export attributes differ per bundle.
+//
+// Subtrees that hold no bundle reference are returned untouched, and so are
+// values whose shape does not match typ. [Type.Apply] is responsible for
+// validation; this is a value transformation only.
+func MapBundleRefs(typ Type, val cty.Value, schemactx EvalContext, fn BundleRefFunc) (cty.Value, error) {
+	v, _, err := mapBundleRefs(typ, val, schemactx, nil, fn)
+	return v, err
+}
+
+// mapBundleRefs reports whether it replaced anything, so that untouched
+// subtrees keep their original value instead of being rebuilt.
+func mapBundleRefs(typ Type, val cty.Value, schemactx EvalContext, path BundleRefPath, fn BundleRefFunc) (cty.Value, bool, error) {
+	if val == cty.NilVal {
+		return val, false, nil
+	}
+
+	switch t := typ.(type) {
+	case *BundleType:
+		out, err := fn(t, val, path)
+		if err != nil {
+			return val, false, err
+		}
+		return out, true, nil
+
+	case *ListType:
+		return mapBundleRefsInSeq(t.ValueType, val, schemactx, path, fn)
+
+	case *SetType:
+		return mapBundleRefsInSeq(t.ValueType, val, schemactx, path, fn)
+
+	case *TupleType:
+		return mapBundleRefsInTuple(t, val, schemactx, path, fn)
+
+	case *MapType:
+		return mapBundleRefsInMap(t.ValueType, val, schemactx, path, fn)
+
+	case *ObjectType:
+		return mapBundleRefsInAttrs(t.Attributes, val, schemactx, path, fn)
+
+	case *MergedObjectType:
+		return mapBundleRefsInAttrs(mergedAttributes(t, schemactx), val, schemactx, path, fn)
+
+	case *ReferenceType:
+		schema, err := schemactx.Schemas.Lookup(t.Name)
+		if err != nil {
+			// Apply already validated the reference. Without the schema there
+			// is nothing to map, which is not an error for a transformation.
+			return val, false, nil
+		}
+		return mapBundleRefs(schema.Type, val, schemactx, path, fn)
+
+	case *NonStrictType:
+		return mapBundleRefs(t.Inner, val, schemactx, path, fn)
+
+	case *VariantType:
+		return mapBundleRefsInVariant(t, val, schemactx, path, fn)
+	}
+
+	return val, false, nil
+}
+
+func mapBundleRefsInSeq(elemType Type, val cty.Value, schemactx EvalContext, path BundleRefPath, fn BundleRefFunc) (cty.Value, bool, error) {
+	if !isMappableCollection(val) || !isSequenceLike(val) {
+		return val, false, nil
+	}
+	elems := val.AsValueSlice()
+	if len(elems) == 0 {
+		return val, false, nil
+	}
+
+	out := make([]cty.Value, len(elems))
+	changed := false
+	for i, elem := range elems {
+		mapped, elemChanged, err := mapBundleRefs(elemType, elem, schemactx, path.Index(i), fn)
+		if err != nil {
+			return val, false, err
+		}
+		out[i] = mapped
+		changed = changed || elemChanged
+	}
+	if !changed {
+		return val, false, nil
+	}
+	return cty.TupleVal(out), true, nil
+}
+
+func mapBundleRefsInTuple(t *TupleType, val cty.Value, schemactx EvalContext, path BundleRefPath, fn BundleRefFunc) (cty.Value, bool, error) {
+	if !isMappableCollection(val) || !isSequenceLike(val) {
+		return val, false, nil
+	}
+	elems := val.AsValueSlice()
+	if len(elems) != len(t.Elems) {
+		return val, false, nil
+	}
+
+	out := make([]cty.Value, len(elems))
+	changed := false
+	for i, elem := range elems {
+		mapped, elemChanged, err := mapBundleRefs(t.Elems[i], elem, schemactx, path.Index(i), fn)
+		if err != nil {
+			return val, false, err
+		}
+		out[i] = mapped
+		changed = changed || elemChanged
+	}
+	if !changed {
+		return val, false, nil
+	}
+	return cty.TupleVal(out), true, nil
+}
+
+func mapBundleRefsInMap(valType Type, val cty.Value, schemactx EvalContext, path BundleRefPath, fn BundleRefFunc) (cty.Value, bool, error) {
+	if !isMappableCollection(val) || !isObjectLike(val) {
+		return val, false, nil
+	}
+	entries := val.AsValueMap()
+	if len(entries) == 0 {
+		return val, false, nil
+	}
+
+	changed := false
+	for k, elem := range entries {
+		mapped, elemChanged, err := mapBundleRefs(valType, elem, schemactx, path.Key(k), fn)
+		if err != nil {
+			return val, false, err
+		}
+		if elemChanged {
+			entries[k] = mapped
+			changed = true
+		}
+	}
+	if !changed {
+		return val, false, nil
+	}
+	return cty.ObjectVal(entries), true, nil
+}
+
+func mapBundleRefsInAttrs(attrs []*ObjectTypeAttribute, val cty.Value, schemactx EvalContext, path BundleRefPath, fn BundleRefFunc) (cty.Value, bool, error) {
+	if len(attrs) == 0 || !isMappableCollection(val) || !isObjectLike(val) {
+		return val, false, nil
+	}
+
+	// Start from the value's own attributes so that entries the type does not
+	// cover - non-strict objects - survive the rebuild.
+	out := val.AsValueMap()
+	changed := false
+	for _, attr := range attrs {
+		elem, exists := out[attr.Name]
+		if !exists {
+			continue
+		}
+		mapped, attrChanged, err := mapBundleRefs(attr.Type, elem, schemactx, path.Attr(attr.Name), fn)
+		if err != nil {
+			return val, false, err
+		}
+		if attrChanged {
+			out[attr.Name] = mapped
+			changed = true
+		}
+	}
+	if !changed {
+		return val, false, nil
+	}
+	return cty.ObjectVal(out), true, nil
+}
+
+// mapBundleRefsInVariant maps the first option that accepts val, mirroring how
+// [VariantType.Apply] picks the matching option.
+func mapBundleRefsInVariant(t *VariantType, val cty.Value, schemactx EvalContext, path BundleRefPath, fn BundleRefFunc) (cty.Value, bool, error) {
+	for _, opt := range t.Options {
+		if _, err := opt.Apply(val, schemactx, true); err != nil {
+			continue
+		}
+		return mapBundleRefs(opt, val, schemactx, path, fn)
+	}
+	return val, false, nil
+}
+
+// mergedAttributes collects the attributes of a merged object type. Duplicates
+// and non-object operands are already rejected by [MergedObjectType.Apply].
+func mergedAttributes(t *MergedObjectType, schemactx EvalContext) []*ObjectTypeAttribute {
+	var attrs []*ObjectTypeAttribute
+	for _, obj := range t.Objects {
+		switch x := obj.(type) {
+		case *ObjectType:
+			attrs = append(attrs, x.Attributes...)
+		case *ReferenceType:
+			schema, err := schemactx.Schemas.Lookup(x.Name)
+			if err != nil {
+				continue
+			}
+			if objType, ok := schema.Type.(*ObjectType); ok {
+				attrs = append(attrs, objType.Attributes...)
+			}
+		}
+	}
+	return attrs
+}
+
+func isMappableCollection(val cty.Value) bool {
+	return val.IsKnown() && !val.IsNull() && val.CanIterateElements()
+}
+
+func isObjectLike(val cty.Value) bool {
+	t := val.Type()
+	return t.IsObjectType() || t.IsMapType()
+}
+
+func isSequenceLike(val cty.Value) bool {
+	t := val.Type()
+	return t.IsListType() || t.IsTupleType() || t.IsSetType()
+}
+
+// ValidateBundleRefPositions reports an error if a bundle reference appears in a
+// position the CLI cannot edit. Supported are a reference on its own and a list
+// or set of references:
+//
+//	bundle(<class>)
+//	list(bundle(<class>))
+//	set(bundle(<class>))
+//
+// Deeper nesting - map values, tuple elements, lists of lists, any_of options -
+// would resolve correctly but has no editor that makes sense, so it is rejected
+// at definition time rather than surfacing as a confusing form. Object
+// attributes are types in their own right, so an attribute may hold any of the
+// supported shapes; `list(object)` with a bundle-typed attribute is fine.
+//
+// Schema references are not followed: a referenced schema is validated where it
+// is defined.
+func ValidateBundleRefPositions(typ Type) error {
+	path, found := findUnsupportedBundleRef(typ, nil, true, true)
+	if !found {
+		return nil
+	}
+	const rule = "a bundle reference must be the whole type, or the elements of a list or set"
+	if path.IsRoot() {
+		return errors.E("type %q is not supported: %s", typ.String(), rule)
+	}
+	return errors.E("type %q is not supported: the bundle reference at %s is not allowed, %s",
+		typ.String(), path.String(), rule)
+}
+
+// findUnsupportedBundleRef returns the path of the first bundle reference in an
+// unsupported position. allowed reports whether a reference may sit at this
+// exact position; atRoot reports whether this position is the root of a type,
+// which is the only place a list or set may still carry references.
+func findUnsupportedBundleRef(typ Type, path BundleRefPath, allowed, atRoot bool) (BundleRefPath, bool) {
+	switch t := typ.(type) {
+	case *BundleType:
+		if !allowed {
+			return path, true
+		}
+
+	case *ListType:
+		return findUnsupportedBundleRef(t.ValueType, path.Index(0), allowed && atRoot, false)
+
+	case *SetType:
+		return findUnsupportedBundleRef(t.ValueType, path.Index(0), allowed && atRoot, false)
+
+	case *MapType:
+		return findUnsupportedBundleRef(t.ValueType, path.AnyKey(), false, false)
+
+	case *TupleType:
+		for i, elem := range t.Elems {
+			if p, found := findUnsupportedBundleRef(elem, path.Index(i), false, false); found {
+				return p, true
+			}
+		}
+
+	case *VariantType:
+		for _, opt := range t.Options {
+			if p, found := findUnsupportedBundleRef(opt, path, false, false); found {
+				return p, true
+			}
+		}
+
+	case *NonStrictType:
+		return findUnsupportedBundleRef(t.Inner, path, allowed, atRoot)
+
+	case *ObjectType:
+		for _, attr := range t.Attributes {
+			if p, found := findUnsupportedBundleRef(attr.Type, path.Attr(attr.Name), true, true); found {
+				return p, true
+			}
+		}
+
+	case *MergedObjectType:
+		for _, obj := range t.Objects {
+			if p, found := findUnsupportedBundleRef(obj, path, allowed, atRoot); found {
+				return p, true
+			}
+		}
+	}
+
+	return nil, false
+}

--- a/typeschema/bundleref_test.go
+++ b/typeschema/bundleref_test.go
@@ -1,0 +1,404 @@
+// Copyright 2026 Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
+package typeschema
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/madlambda/spells/assert"
+	"github.com/terramate-io/terramate/errors"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// resolved fakes what tm_bundle returns for a key: bundles of the same class
+// still have different cty types, which is why collections must be rebuilt as
+// tuples and objects.
+func resolved(key string) cty.Value {
+	attrs := map[string]cty.Value{
+		"alias": cty.StringVal(key),
+		"class": cty.StringVal("test.class/v1"),
+	}
+	// Vary the object type per key, like real bundles do via their inputs.
+	attrs["input"] = cty.ObjectVal(map[string]cty.Value{key: cty.True})
+	return cty.ObjectVal(attrs)
+}
+
+// resolveAll is a BundleRefFunc that resolves every string key and records the
+// paths it was called at.
+func resolveAll(paths *[]string) BundleRefFunc {
+	return func(_ *BundleType, val cty.Value, path BundleRefPath) (cty.Value, error) {
+		*paths = append(*paths, path.String())
+		if val.IsNull() || val.Type() != cty.String {
+			return val, nil
+		}
+		return resolved(val.AsString()), nil
+	}
+}
+
+// The walker deliberately has no opinion on which shapes an input may use -
+// that is [ValidateBundleRefPositions]' job - so it is exercised on shapes a
+// definition would be rejected for, to keep it correct if the restriction is
+// ever lifted.
+func TestMapBundleRefsPaths(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name      string
+		typeStr   string
+		val       cty.Value
+		wantPaths []string
+	}{
+		{
+			name:      "top level bundle",
+			typeStr:   `bundle("test.class/v1")`,
+			val:       cty.StringVal("a"),
+			wantPaths: []string{""},
+		},
+		{
+			name:      "list of bundles",
+			typeStr:   `list(bundle("test.class/v1"))`,
+			val:       cty.TupleVal([]cty.Value{cty.StringVal("a"), cty.StringVal("b")}),
+			wantPaths: []string{"[0]", "[1]"},
+		},
+		{
+			name:      "set of bundles",
+			typeStr:   `set(bundle("test.class/v1"))`,
+			val:       cty.TupleVal([]cty.Value{cty.StringVal("a")}),
+			wantPaths: []string{"[0]"},
+		},
+		{
+			name:    "map of bundles",
+			typeStr: `map(bundle("test.class/v1"))`,
+			val: cty.ObjectVal(map[string]cty.Value{
+				"primary": cty.StringVal("a"),
+			}),
+			wantPaths: []string{`["primary"]`},
+		},
+		{
+			name:      "tuple of bundle and string",
+			typeStr:   `tuple(bundle("test.class/v1"), string)`,
+			val:       cty.TupleVal([]cty.Value{cty.StringVal("a"), cty.StringVal("not-a-ref")}),
+			wantPaths: []string{"[0]"},
+		},
+		{
+			name:      "nested list of lists",
+			typeStr:   `list(list(bundle("test.class/v1")))`,
+			val:       cty.TupleVal([]cty.Value{cty.TupleVal([]cty.Value{cty.StringVal("a")})}),
+			wantPaths: []string{"[0][0]"},
+		},
+		{
+			name:      "cty list value instead of tuple",
+			typeStr:   `list(bundle("test.class/v1"))`,
+			val:       cty.ListVal([]cty.Value{cty.StringVal("a")}),
+			wantPaths: []string{"[0]"},
+		},
+		{
+			name:      "empty list is not walked",
+			typeStr:   `list(bundle("test.class/v1"))`,
+			val:       cty.EmptyTupleVal,
+			wantPaths: nil,
+		},
+		{
+			name:      "null value is not walked",
+			typeStr:   `list(bundle("test.class/v1"))`,
+			val:       cty.NullVal(cty.List(cty.String)),
+			wantPaths: nil,
+		},
+		{
+			name:      "no bundle type in tree",
+			typeStr:   `list(string)`,
+			val:       cty.TupleVal([]cty.Value{cty.StringVal("a")}),
+			wantPaths: nil,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			typ, err := Parse(tc.typeStr, nil)
+			assert.NoError(t, err)
+
+			var paths []string
+			_, err = MapBundleRefs(typ, tc.val, EvalContext{}, resolveAll(&paths))
+			assert.NoError(t, err)
+			assert.EqualStrings(t, sprintStrings(tc.wantPaths), sprintStrings(paths))
+		})
+	}
+}
+
+func TestMapBundleRefsRebuildsCollectionsAsTuples(t *testing.T) {
+	t.Parallel()
+
+	typ, err := Parse(`list(bundle("test.class/v1"))`, nil)
+	assert.NoError(t, err)
+
+	// Both elements resolve to objects with *different* cty types, so the result
+	// can only be a tuple. cty.ListVal would panic here.
+	val := cty.TupleVal([]cty.Value{cty.StringVal("a"), cty.StringVal("b")})
+
+	var paths []string
+	got, err := MapBundleRefs(typ, val, EvalContext{}, resolveAll(&paths))
+	assert.NoError(t, err)
+
+	assert.IsTrue(t, got.Type().IsTupleType(), "expected tuple, got %s", got.Type().FriendlyName())
+	assert.EqualInts(t, 2, got.LengthInt())
+
+	elems := got.AsValueSlice()
+	assert.EqualStrings(t, "a", elems[0].GetAttr("alias").AsString())
+	assert.EqualStrings(t, "b", elems[1].GetAttr("alias").AsString())
+}
+
+func TestMapBundleRefsKeepsUnrelatedValues(t *testing.T) {
+	t.Parallel()
+
+	// A type tree without any bundle position must hand back the identical value.
+	typ, err := Parse(`map(list(string))`, nil)
+	assert.NoError(t, err)
+
+	val := cty.ObjectVal(map[string]cty.Value{
+		"a": cty.TupleVal([]cty.Value{cty.StringVal("x")}),
+	})
+
+	got, err := MapBundleRefs(typ, val, EvalContext{}, func(_ *BundleType, v cty.Value, _ BundleRefPath) (cty.Value, error) {
+		t.Fatal("callback must not be invoked")
+		return v, nil
+	})
+	assert.NoError(t, err)
+	assert.IsTrue(t, got.RawEquals(val), "value was rebuilt unnecessarily")
+}
+
+func TestMapBundleRefsInObjectAttributes(t *testing.T) {
+	t.Parallel()
+
+	typ, err := Parse("object", []*ObjectTypeAttribute{
+		{Name: "team", Type: &BundleType{ClassID: "test.class/v1"}},
+		{Name: "peers", Type: &ListType{ValueType: &BundleType{ClassID: "test.class/v1"}}},
+		{Name: "name", Type: &PrimitiveType{Name: "string"}},
+	})
+	assert.NoError(t, err)
+
+	val := cty.ObjectVal(map[string]cty.Value{
+		"team":  cty.StringVal("a"),
+		"peers": cty.TupleVal([]cty.Value{cty.StringVal("b")}),
+		"name":  cty.StringVal("keep-me"),
+		// Not covered by the type: must survive the rebuild.
+		"extra": cty.StringVal("untouched"),
+	})
+
+	var paths []string
+	got, err := MapBundleRefs(typ, val, EvalContext{}, resolveAll(&paths))
+	assert.NoError(t, err)
+
+	assert.EqualStrings(t, sprintStrings([]string{".team", ".peers[0]"}), sprintStrings(paths))
+	assert.EqualStrings(t, "a", got.GetAttr("team").GetAttr("alias").AsString())
+	assert.EqualStrings(t, "b", got.GetAttr("peers").AsValueSlice()[0].GetAttr("alias").AsString())
+	assert.EqualStrings(t, "keep-me", got.GetAttr("name").AsString())
+	assert.EqualStrings(t, "untouched", got.GetAttr("extra").AsString())
+}
+
+func TestMapBundleRefsThroughSchemaReference(t *testing.T) {
+	t.Parallel()
+
+	schemas := NewSchemaNamespaces()
+	schemas.Set("my", []*Schema{{
+		Name: "Team",
+		Type: &ObjectType{Attributes: []*ObjectTypeAttribute{
+			{Name: "ref", Type: &BundleType{ClassID: "test.class/v1"}},
+		}},
+	}})
+	schemactx := EvalContext{Schemas: schemas}
+
+	typ, err := Parse("list(my.Team)", nil)
+	assert.NoError(t, err)
+
+	val := cty.TupleVal([]cty.Value{
+		cty.ObjectVal(map[string]cty.Value{"ref": cty.StringVal("a")}),
+	})
+
+	var paths []string
+	got, err := MapBundleRefs(typ, val, schemactx, resolveAll(&paths))
+	assert.NoError(t, err)
+
+	assert.EqualStrings(t, sprintStrings([]string{"[0].ref"}), sprintStrings(paths))
+	assert.EqualStrings(t, "a", got.AsValueSlice()[0].GetAttr("ref").GetAttr("alias").AsString())
+}
+
+func TestMapBundleRefsPropagatesError(t *testing.T) {
+	t.Parallel()
+
+	typ, err := Parse(`list(bundle("test.class/v1"))`, nil)
+	assert.NoError(t, err)
+
+	val := cty.TupleVal([]cty.Value{cty.StringVal("a"), cty.StringVal("b")})
+
+	calls := 0
+	_, err = MapBundleRefs(typ, val, EvalContext{}, func(_ *BundleType, v cty.Value, path BundleRefPath) (cty.Value, error) {
+		calls++
+		if path.String() == "[1]" {
+			return v, errors.E("boom")
+		}
+		return v, nil
+	})
+	assert.Error(t, err)
+	assert.EqualInts(t, 2, calls)
+}
+
+func sprintStrings(s []string) string {
+	return fmt.Sprintf("%q", s)
+}
+
+// A bundle reference resolves at any depth, but only two shapes have an editor
+// that makes sense, so the rest is rejected at definition time.
+func TestValidateBundleRefPositions(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		typeStr string
+		wantErr bool
+	}{
+		{typeStr: `bundle("test.class/v1")`},
+		{typeStr: `list(bundle("test.class/v1"))`},
+		{typeStr: `set(bundle("test.class/v1"))`},
+		{typeStr: `list(string)`},
+		{typeStr: `map(object)`},
+
+		{typeStr: `map(bundle("test.class/v1"))`, wantErr: true},
+		{typeStr: `list(list(bundle("test.class/v1")))`, wantErr: true},
+		{typeStr: `set(set(bundle("test.class/v1")))`, wantErr: true},
+		{typeStr: `list(map(bundle("test.class/v1")))`, wantErr: true},
+		{typeStr: `tuple(bundle("test.class/v1"), string)`, wantErr: true},
+		{typeStr: `any_of(string, bundle("test.class/v1"))`, wantErr: true},
+	} {
+		t.Run(tc.typeStr, func(t *testing.T) {
+			t.Parallel()
+
+			typ, err := Parse(tc.typeStr, nil)
+			if err != nil {
+				t.Fatalf("parsing %q: %v", tc.typeStr, err)
+			}
+			err = ValidateBundleRefPositions(typ)
+			if tc.wantErr && err == nil {
+				t.Fatalf("%s: expected an error", tc.typeStr)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("%s: unexpected error: %v", tc.typeStr, err)
+			}
+		})
+	}
+}
+
+// An attribute carries a type of its own, so the supported shapes are supported
+// there too - including inside a list of objects, which the form edits with one
+// sub-form per item and the usual picker inside it.
+func TestValidateBundleRefPositionsInObjectAttributes(t *testing.T) {
+	t.Parallel()
+
+	attrType := func(t *testing.T, typeStr string) Type {
+		t.Helper()
+		typ, err := Parse(typeStr, nil)
+		if err != nil {
+			t.Fatalf("parsing %q: %v", typeStr, err)
+		}
+		return typ
+	}
+
+	for _, tc := range []struct {
+		typeStr string
+		wantErr bool
+	}{
+		{typeStr: `bundle("test.class/v1")`},
+		{typeStr: `list(bundle("test.class/v1"))`},
+		{typeStr: `map(bundle("test.class/v1"))`, wantErr: true},
+	} {
+		t.Run(tc.typeStr, func(t *testing.T) {
+			t.Parallel()
+
+			obj := &ObjectType{Attributes: []*ObjectTypeAttribute{
+				{Name: "team", Type: attrType(t, tc.typeStr)},
+			}}
+			for name, typ := range map[string]Type{
+				"attribute":       obj,
+				"list(attribute)": &ListType{ValueType: obj},
+			} {
+				err := ValidateBundleRefPositions(typ)
+				if tc.wantErr && err == nil {
+					t.Fatalf("%s in %s: expected an error", tc.typeStr, name)
+				}
+				if !tc.wantErr && err != nil {
+					t.Fatalf("%s in %s: unexpected error: %v", tc.typeStr, name, err)
+				}
+			}
+		})
+	}
+}
+
+// A value whose shape does not match its type is the caller's problem, not the
+// walker's - [Type.Apply] reports it. The walker has to hand such a value back
+// untouched, which the sequence cases have to guard for explicitly: objects and
+// maps iterate too, and AsValueSlice drops their keys instead of failing.
+func TestMapBundleRefsLeavesMismatchedShapesUntouched(t *testing.T) {
+	t.Parallel()
+
+	bt := &BundleType{ClassID: "test.class/v1"}
+
+	for _, tc := range []struct {
+		name string
+		typ  Type
+		val  cty.Value
+	}{
+		{
+			name: "list type over an object value",
+			typ:  &ListType{ValueType: bt},
+			val: cty.ObjectVal(map[string]cty.Value{
+				"primary": cty.StringVal("a"),
+				"backup":  cty.StringVal("b"),
+			}),
+		},
+		{
+			name: "set type over a map value",
+			typ:  &SetType{ValueType: bt},
+			val:  cty.MapVal(map[string]cty.Value{"primary": cty.StringVal("a")}),
+		},
+		{
+			name: "tuple type over an object value",
+			typ:  &TupleType{Elems: []Type{bt, &PrimitiveType{Name: "string"}}},
+			val: cty.ObjectVal(map[string]cty.Value{
+				"primary": cty.StringVal("a"),
+				"label":   cty.StringVal("b"),
+			}),
+		},
+		{
+			name: "map type over a tuple value",
+			typ:  &MapType{ValueType: bt},
+			val:  cty.TupleVal([]cty.Value{cty.StringVal("a")}),
+		},
+		{
+			name: "object type over a tuple value",
+			typ: &ObjectType{Attributes: []*ObjectTypeAttribute{
+				{Name: "primary", Type: bt},
+			}},
+			val: cty.TupleVal([]cty.Value{cty.StringVal("a")}),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			called := false
+			out, err := MapBundleRefs(tc.typ, tc.val, EvalContext{Schemas: NewSchemaNamespaces()},
+				func(_ *BundleType, _ cty.Value, _ BundleRefPath) (cty.Value, error) {
+					called = true
+					return cty.StringVal("resolved"), nil
+				})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if called {
+				t.Error("a mismatched shape must not be walked as if it matched")
+			}
+			if !out.RawEquals(tc.val) {
+				t.Errorf("value was rewritten:\n got %#v\nwant %#v", out, tc.val)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Please read our contribution policy: https://github.com/terramate-io/terramate/blob/main/CONTRIBUTING.md
   Note: All code contributions are managed exclusively by the Terramate team.
2. If the PR is unfinished, mark it as draft: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request
3. Please update the PR title using the Conventional Commits convention: https://www.conventionalcommits.org/en/v1.0.0/
    Example: feat: add support for XYZ.
-->

## What this PR does / why we need it:

This PR adds an input widget for `list(bundle(<class>))` (and set(..)). The form is a multi-select list with the option to open a nested creation form just like for regular `bundle(<class>)`.

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Keep it empty if not applicable.
-->
Fixes #2369

## Does this PR introduce a user-facing change?
<!--
If no, just write "no" in the block below.
If yes, please explain the change and update documentation and the CHANGELOG.md file accordingly.
-->
```
yes
```


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes bundle input resolution, validation, and YAML persistence across config and UI; behavior is well covered by tests but affects reconfigure/promote flows that reference other bundles.
> 
> **Overview**
> Adds **`list(bundle(<class>))`** and **`set(bundle(...))`** as supported input types, with **`terramate ui`** rendering them as a multi-select over bundles of that class (toggle with space, confirm with enter, inline **Add new** like single refs).
> 
> Introduces **`typeschema.MapBundleRefs`** and **`ValidateBundleRefPositions`** so bundle keys and resolved `tm_bundle` objects are converted consistently at any nesting depth (lists, object attributes in list items). Unsupported shapes such as **`map(bundle(...))`** or nested lists of bundles fail at definition time. Config input application walks the full type tree when resolving references; the UI normalizes loaded values, checks missing refs with paths like **`teams[1]`**, and writes YAML as alias keys only.
> 
> **`BundleRefListWidget`** keeps the form open after inline bundle creation so users can add more references; nested-create suspend/resume now preserves **`objectEditStack`** on **`CreateFrame`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d028a47e27c5ee09d0a5e8fb9f161305e0e37518. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->