### PR TITLE
fix: list(bundle) display summarization

### DIFF
--- a/commands/ui/bundleref_test.go
+++ b/commands/ui/bundleref_test.go
@@ -369,21 +369,53 @@ func TestBundleRefListWidgetEmptySelectionCommitsEmptyTuple(t *testing.T) {
 	}
 }
 
-// The completed-inputs panel has to name the referenced bundles; a list of
-// resolved bundle objects would otherwise render as an opaque item count.
-func TestFormatDisplayValueNamesBundleRefsInCollection(t *testing.T) {
+// A collection of references collapses the same way every other list type does,
+// so a handful of long aliases cannot crowd out the rest of the panel. The
+// single-element case still names the bundle rather than showing the object it
+// resolved to.
+func TestFormatDisplayValueCollapsesBundleRefCollections(t *testing.T) {
 	t.Parallel()
 
 	typ, err := typeschema.Parse(`list(bundle("test.class/v1"))`, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	val := cty.TupleVal([]cty.Value{
-		resolvedBundle("platform"),
-		cty.StringVal("payments"), // Not yet resolved, still a key.
-	})
 
-	if got := FormatDisplayValue(val, typ); got != "platform, payments" {
-		t.Fatalf("unexpected display: %q", got)
+	for _, tc := range []struct {
+		name string
+		val  cty.Value
+		want string
+	}{
+		{
+			name: "empty",
+			val:  cty.EmptyTupleVal,
+			want: "<empty>",
+		},
+		{
+			name: "one resolved reference is named",
+			val:  cty.TupleVal([]cty.Value{resolvedBundle("platform")}),
+			want: "platform",
+		},
+		{
+			name: "one unresolved key is named",
+			val:  cty.TupleVal([]cty.Value{cty.StringVal("platform")}),
+			want: "platform",
+		},
+		{
+			name: "several collapse to a count",
+			val: cty.TupleVal([]cty.Value{
+				resolvedBundle("platform"),
+				cty.StringVal("payments"), // Not yet resolved, still a key.
+			}),
+			want: "<2 items>",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := FormatDisplayValue(tc.val, typ); got != tc.want {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+		})
 	}
 }

--- a/commands/ui/widget.go
+++ b/commands/ui/widget.go
@@ -5,7 +5,6 @@ package ui
 
 import (
 	"fmt"
-	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/zclconf/go-cty/cty"
@@ -335,18 +334,6 @@ func formatCollectionDisplay(val cty.Value, elemType typeschema.Type) string {
 	n := val.LengthInt()
 	if n == 0 {
 		return "<empty>"
-	}
-	if _, isBundleType := elemType.(*typeschema.BundleType); isBundleType {
-		aliases := make([]string, 0, n)
-		for it := val.ElementIterator(); it.Next(); {
-			_, elem := it.Element()
-			alias, ok := bundleRefAlias(elem)
-			if !ok {
-				alias = "<unresolved>"
-			}
-			aliases = append(aliases, alias)
-		}
-		return strings.Join(aliases, ", ")
 	}
 	if n == 1 {
 		it := val.ElementIterator()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Please read our contribution policy: https://github.com/terramate-io/terramate/blob/main/CONTRIBUTING.md
   Note: All code contributions are managed exclusively by the Terramate team.
2. If the PR is unfinished, mark it as draft: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request
3. Please update the PR title using the Conventional Commits convention: https://www.conventionalcommits.org/en/v1.0.0/
    Example: feat: add support for XYZ.
-->

## What this PR does / why we need it:

This PR aligns the way list of bundle entries are collapsed (i.e. <2 items>) with other list entries.

## Does this PR introduce a user-facing change?
<!--
If no, just write "no" in the block below.
If yes, please explain the change and update documentation and the CHANGELOG.md file accordingly.
-->
```
no
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only change in the TUI completed-inputs summary; no data, evaluation, or persistence logic is touched.
> 
> **Overview**
> **Bundle reference lists** in the completed-inputs panel no longer expand every alias into a comma-separated line. They now use the same summarization as other `list(...)` values: **one** entry still shows the bundle name (resolved object or key), while **two or more** show `<N items>` so long alias lists do not dominate the panel.
> 
> Implementation removes the `list(bundle(...))` special case in `formatCollectionDisplay` and drops the unused `strings` import. Tests were renamed and broadened to cover empty, single, and multi-item bundle ref collections.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9731eee22e7ef5025efb890309984e54039a808c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->